### PR TITLE
feat: add SqlCursor function improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0-Beta.4
 * Allow cursor to use column name to get value by including the following functions that accept a column name parameter:
 `getBoolean`,`getBooleanOptional`,`getString`,`getStringOptional`, `getLong`,`getLongOptional`, `getDouble`,`getDoubleOptional`
+* BREAKING CHANGE: This should not affect anyone but made `KotlinPowerSyncCredentials`, `KotlinPowerSyncDatabase` and `KotlinPowerSyncBackendConnector` as these should never have been public.
 
 
 ## 1.0.0-Beta.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 1.0.0-Beta.4
 * Allow cursor to use column name to get value by including the following functions that accept a column name parameter:
 `getBoolean`,`getBooleanOptional`,`getString`,`getStringOptional`, `getLong`,`getLongOptional`, `getDouble`,`getDoubleOptional`
-* BREAKING CHANGE: This should not affect anyone but made `KotlinPowerSyncCredentials`, `KotlinPowerSyncDatabase` and `KotlinPowerSyncBackendConnector` as these should never have been public.
+* BREAKING CHANGE: This should not affect anyone but made `KotlinPowerSyncCredentials`, `KotlinPowerSyncDatabase` and `KotlinPowerSyncBackendConnector` private as these should never have been public.
 
 
 ## 1.0.0-Beta.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.0-Beta.4
+* Allow cursor to use column name to get value by including the following functions that accept a column name parameter:
+`getBoolean`,`getBooleanOptional`,`getString`,`getStringOptional`, `getLong`,`getLongOptional`, `getDouble`,`getDoubleOptional`
+
+
 ## 1.0.0-Beta.3
 
 * BREAKING CHANGE: Update underlying powersync-kotlin package to BETA18.0 which requires transactions to become synchronous as opposed to asynchronous.

--- a/Demo/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-kotlin.git",
       "state" : {
-        "revision" : "074001ad7d02b2b70c77168cdf4958c08dd6121b",
-        "version" : "1.0.0-BETA18.0"
+        "revision" : "7cd47ffc9dbec8fae4f9e067945ef2279015a90d",
+        "version" : "1.0.0-BETA20.0"
       }
     },
     {

--- a/Demo/PowerSyncExample/PowerSync/SystemManager.swift
+++ b/Demo/PowerSyncExample/PowerSync/SystemManager.swift
@@ -39,10 +39,10 @@ class SystemManager {
             parameters: [],
             mapper: { cursor in
                 ListContent(
-                    id: cursor.getString(index: 0)!,
-                    name: cursor.getString(index: 1)!,
-                    createdAt: cursor.getString(index: 2)!,
-                    ownerId: cursor.getString(index: 3)!
+                    id: try cursor.getString(name: "id"),
+                    name: try cursor.getString(name: "name"),
+                    createdAt: try cursor.getString(name: "created_at"),
+                    ownerId: try cursor.getString(name: "owner_id")
                 )
             }
         ) {
@@ -77,15 +77,15 @@ class SystemManager {
             parameters: [listId],
             mapper: { cursor in
                 return Todo(
-                    id: cursor.getString(index: 0)!,
-                    listId: cursor.getString(index: 1)!,
-                    photoId: cursor.getString(index: 2),
-                    description: cursor.getString(index: 3)!,
-                    isComplete: cursor.getBoolean(index: 4)! as! Bool,
-                    createdAt: cursor.getString(index: 5),
-                    completedAt: cursor.getString(index: 6),
-                    createdBy: cursor.getString(index: 7),
-                    completedBy: cursor.getString(index: 8)
+                    id: try cursor.getString(name: "id"),
+                    listId: try cursor.getString(name: "list_id"),
+                    photoId: try cursor.getStringOptional(name: "photo_id"),
+                    description: try cursor.getString(name: "description"),
+                    isComplete: try cursor.getBoolean(name: "completed"),
+                    createdAt: try cursor.getString(name: "created_at"),
+                    completedAt: try cursor.getStringOptional(name: "completed_at"),
+                    createdBy: try cursor.getStringOptional(name: "created_by"),
+                    completedBy: try cursor.getStringOptional(name: "completed_by")
                 )
             }
         ) {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-kotlin.git",
       "state" : {
-        "revision" : "074001ad7d02b2b70c77168cdf4958c08dd6121b",
-        "version" : "1.0.0-BETA18.0"
+        "revision" : "7cd47ffc9dbec8fae4f9e067945ef2279015a90d",
+        "version" : "1.0.0-BETA20.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
             targets: ["PowerSync"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "1.0.0-BETA18.0"),
+        .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "1.0.0-BETA20.0"),
         .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", "0.3.9"..<"0.4.0")
     ],
     targets: [

--- a/Sources/PowerSync/Kotlin/KotlinTypes.swift
+++ b/Sources/PowerSync/Kotlin/KotlinTypes.swift
@@ -1,12 +1,11 @@
 import PowerSyncKotlin
 
-public typealias KotlinPowerSyncBackendConnector = PowerSyncKotlin.PowerSyncBackendConnector
+typealias KotlinPowerSyncBackendConnector = PowerSyncKotlin.PowerSyncBackendConnector
 public typealias CrudEntry = PowerSyncKotlin.CrudEntry
 public typealias CrudBatch = PowerSyncKotlin.CrudBatch
 public typealias SyncStatus = PowerSyncKotlin.SyncStatus
-public typealias SqlCursor = PowerSyncKotlin.RuntimeSqlCursor
+public typealias SqlCursor = PowerSyncKotlin.SqlCursor
 public typealias JsonParam = PowerSyncKotlin.JsonParam
 public typealias CrudTransaction = PowerSyncKotlin.CrudTransaction
-public typealias KotlinPowerSyncCredentials = PowerSyncKotlin.PowerSyncCredentials
-public typealias KotlinPowerSyncDatabase = PowerSyncKotlin.PowerSyncDatabase
-
+typealias KotlinPowerSyncCredentials = PowerSyncKotlin.PowerSyncCredentials
+typealias KotlinPowerSyncDatabase = PowerSyncKotlin.PowerSyncDatabase

--- a/Sources/PowerSync/Kotlin/SqlCursor.swift
+++ b/Sources/PowerSync/Kotlin/SqlCursor.swift
@@ -1,0 +1,68 @@
+import Foundation
+import PowerSyncKotlin
+
+extension SqlCursor {
+    private func getColumnIndex(name: String) throws -> Int32 {
+        guard let columnIndex = columnNames[name]?.int32Value else {
+            throw SqlCursorError.columnNotFound(name)
+        }
+        return columnIndex
+    }
+    
+    private func getValue<T>(name: String, getter: (Int32) -> T?) throws -> T {
+        let columnIndex = try getColumnIndex(name: name)
+        guard let value = getter(columnIndex) else {
+            throw SqlCursorError.nullValueFound(name)
+        }
+        return value
+    }
+    
+    private func getOptionalValue<T>(name: String, getter: (String) -> T?) throws -> T? {
+        _ = try getColumnIndex(name: name)
+        return getter(name)
+    }
+    
+    public func getBoolean(name: String) throws -> Bool {
+        try getValue(name: name) { getBoolean(index: $0)?.boolValue }
+    }
+    
+    public func getDouble(name: String) throws -> Double {
+        try getValue(name: name) { getDouble(index: $0)?.doubleValue }
+    }
+    
+    public func getLong(name: String) throws -> Int {
+        try getValue(name: name) { getLong(index: $0)?.intValue }
+    }
+    
+    public func getString(name: String) throws -> String {
+        try getValue(name: name) { getString(index: $0) }
+    }
+    
+    public func getBooleanOptional(name: String) throws -> Bool? {
+        try getOptionalValue(name: name) { getBooleanOptional(name: $0)?.boolValue }
+    }
+    
+    public func getDoubleOptional(name: String) throws -> Double? {
+        try getOptionalValue(name: name) { getDoubleOptional(name: $0)?.doubleValue }
+    }
+    
+    public func getLongOptional(name: String) throws -> Int? {
+        try getOptionalValue(name: name) { getLongOptional(name: $0)?.intValue }
+    }
+    
+    public func getStringOptional(name: String) throws -> String? {
+        try getOptionalValue(name: name) { PowerSyncKotlin.SqlCursorKt.getStringOptional(self, name: $0) }
+    }
+}
+
+enum SqlCursorError: Error {
+    case nullValue(message: String)
+    
+    static func columnNotFound(_ name: String) -> SqlCursorError {
+        .nullValue(message: "Column '\(name)' not found")
+    }
+    
+    static func nullValueFound(_ name: String) -> SqlCursorError {
+        .nullValue(message: "Null value found for column \(name)")
+    }
+}

--- a/Sources/PowerSync/QueriesProtocol.swift
+++ b/Sources/PowerSync/QueriesProtocol.swift
@@ -16,11 +16,27 @@ public protocol Queries {
         mapper: @escaping (SqlCursor) -> RowType
     ) async throws -> RowType
 
+    /// Execute a read-only (SELECT) query and return a single result.
+    /// If there is no result, throws an IllegalArgumentException.
+    /// See `getOptional` for queries where the result might be empty.
+    func get<RowType>(
+        sql: String,
+        parameters: [Any]?,
+        mapper: @escaping (SqlCursor) throws -> RowType
+    ) async throws -> RowType
+
     /// Execute a read-only (SELECT) query and return the results.
     func getAll<RowType>(
         sql: String,
         parameters: [Any]?,
         mapper: @escaping (SqlCursor) -> RowType
+    ) async throws -> [RowType]
+
+    /// Execute a read-only (SELECT) query and return the results.
+    func getAll<RowType>(
+        sql: String,
+        parameters: [Any]?,
+        mapper: @escaping (SqlCursor) throws -> RowType
     ) async throws -> [RowType]
 
     /// Execute a read-only (SELECT) query and return a single optional result.
@@ -30,12 +46,27 @@ public protocol Queries {
         mapper: @escaping (SqlCursor) -> RowType
     ) async throws -> RowType?
 
+    /// Execute a read-only (SELECT) query and return a single optional result.
+    func getOptional<RowType>(
+        sql: String,
+        parameters: [Any]?,
+        mapper: @escaping (SqlCursor) throws -> RowType
+    ) async throws -> RowType?
+
     /// Execute a read-only (SELECT) query every time the source tables are modified
     /// and return the results as an array in a Publisher.
     func watch<RowType>(
         sql: String,
         parameters: [Any]?,
         mapper: @escaping (SqlCursor) -> RowType
+    ) -> AsyncStream<[RowType]>
+
+    /// Execute a read-only (SELECT) query every time the source tables are modified
+    /// and return the results as an array in a Publisher.
+    func watch<RowType>(
+        sql: String,
+        parameters: [Any]?,
+        mapper: @escaping (SqlCursor) throws -> RowType
     ) -> AsyncStream<[RowType]>
 
     /// Execute a write transaction with the given callback

--- a/Tests/PowerSyncTests/Kotlin/KotlinPowerSyncDatabaseImplTests.swift
+++ b/Tests/PowerSyncTests/Kotlin/KotlinPowerSyncDatabaseImplTests.swift
@@ -38,9 +38,9 @@ final class KotlinPowerSyncDatabaseImplTests: XCTestCase {
             parameters: ["1"]
         ) { cursor in
             (
-                cursor.getString(index: 0)!,
-                cursor.getString(index: 1)!,
-                cursor.getString(index: 2)!
+                try cursor.getString(name: "id"),
+                try cursor.getString(name: "name"),
+                try cursor.getString(name: "email")
             )
         }
 
@@ -84,7 +84,10 @@ final class KotlinPowerSyncDatabaseImplTests: XCTestCase {
             sql: "SELECT id, name FROM users ORDER BY id",
             parameters: nil
         ) { cursor in
-            (cursor.getString(index: 0)!, cursor.getString(index: 1)!)
+            (
+                try cursor.getString(name: "id"),
+                try cursor.getString(name: "name")
+            )
         }
 
         XCTAssertEqual(users.count, 2)

--- a/Tests/PowerSyncTests/Kotlin/SqlCursorTests.swift
+++ b/Tests/PowerSyncTests/Kotlin/SqlCursorTests.swift
@@ -1,0 +1,96 @@
+import XCTest
+@testable import PowerSync
+
+struct User {
+    let id: String
+    let count: Int
+    let isActive: Bool
+    let weight: Double
+}
+
+struct UserOptional {
+    let id: String
+    let count: Int?
+    let isActive: Bool?
+    let weight: Double?
+    let description: String?
+}
+
+final class SqlCursorTests: XCTestCase {
+    private var database: KotlinPowerSyncDatabaseImpl!
+    private var schema: Schema!
+    
+    override func setUp() async throws {
+        try await super.setUp()
+        schema = Schema(tables: [
+            Table(name: "users", columns: [
+                .text("count"),
+                .integer("is_active"),
+                .real("weight"),
+                .text("description")
+            ])
+        ])
+        
+        database = KotlinPowerSyncDatabaseImpl(
+            schema: schema,
+            dbFilename: ":memory:"
+        )
+        try await database.disconnectAndClear()
+    }
+    
+    override func tearDown() async throws {
+        try await database.disconnectAndClear()
+        database = nil
+        try await super.tearDown()
+    }
+    
+    func testValidValues() async throws {
+        _ = try await database.execute(
+            sql: "INSERT INTO users (id, count, is_active, weight) VALUES (?, ?, ?, ?)",
+            parameters: ["1", 110, 0, 1.1111]
+        )
+        
+        let user: User = try await database.get(
+            sql: "SELECT id, count, is_active, weight FROM users WHERE id = ?",
+            parameters: ["1"]
+        ) { cursor in
+            User(
+                id: try cursor.getString(name: "id"),
+                count: try cursor.getLong(name: "count"),
+                isActive: try cursor.getBoolean(name: "is_active"),
+                weight: try cursor.getDouble(name: "weight")
+            )
+        }
+        
+        XCTAssertEqual(user.id, "1")
+        XCTAssertEqual(user.count, 110)
+        XCTAssertEqual(user.isActive, false)
+        XCTAssertEqual(user.weight, 1.1111)
+    }
+    
+    func testOptionalValues() async throws {
+        _ = try await database.execute(
+            sql: "INSERT INTO users (id, count, is_active, weight, description) VALUES (?, ?, ?, ?, ?)",
+            parameters: ["1", nil, nil, nil, nil, nil]
+        )
+        
+        let user: UserOptional = try await database.get(
+            sql: "SELECT id, count, is_active, weight, description FROM users WHERE id = ?",
+            parameters: ["1"]
+        ) { cursor in
+            UserOptional(
+                id: try cursor.getString(name: "id"),
+                count: try cursor.getLongOptional(name: "count"),
+                isActive: try cursor.getBooleanOptional(name: "is_active"),
+                weight: try cursor.getDoubleOptional(name: "weight"),
+                description: try cursor.getStringOptional(name: "description")
+            )
+        }
+        
+        XCTAssertEqual(user.id, "1")
+        XCTAssertNil(user.count)
+        XCTAssertNil(user.isActive)
+        XCTAssertNil(user.weight)
+        XCTAssertNil(user.description)
+    }
+}


### PR DESCRIPTION
## Description
* Allow cursor to use column name to get value by including the following functions that accept a column name parameter:
`getBoolean`,`getBooleanOptional`,`getString`,`getStringOptional`, `getLong`,`getLongOptional`, `getDouble`,`getDoubleOptional`
* Adapted demos
* Updated `powersync-kotlin` package to latest version

Note: The SqlCursor interface to user has not changed

## Testing
Added unit tests for `SqlCursor` changes and ran the demo