### PR TITLE
chore: make execute, watch and transaction functions throwable in swift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.0-Beta.6
+
+* Allow `execute` to be handled
+* BREAKING CHANGE: `watch` queries are now throwable and therefore will need to be accompanied by a `try` e.g.
+
+```swift
+try database.watch()
+```
+
 ## 1.0.0-Beta.5
 
 * Implement improvements to errors originating in Kotlin so that they can be handled in Swift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,21 @@
 
 ## 1.0.0-Beta.6
 
-* Allow `execute` to be handled
 * BREAKING CHANGE: `watch` queries are now throwable and therefore will need to be accompanied by a `try` e.g.
 
 ```swift
 try database.watch()
 ```
+
+* BREAKING CHANGE: `transaction` functions are now throwable and therefore will need to be accompanied by a `try` e.g.
+
+```swift
+try await database.writeTransaction { transaction in
+  try transaction.execute(...)
+}
+```
+* Allow `execute` errors to be handled
+* `userId` is now set to `nil` by default and therefore it is no longer required to be set to `nil` when instantiating `PowerSyncCredentials` and can therefore be left out.
 
 ## 1.0.0-Beta.5
 

--- a/Demo/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-kotlin.git",
       "state" : {
-        "revision" : "61d195816585f30260181dcbd157bf1660c9ac4e",
-        "version" : "1.0.0-BETA22.0"
+        "revision" : "203db74889df8a20e3c6ac38aede6b0186d2e3b5",
+        "version" : "1.0.0-BETA23.0"
       }
     },
     {

--- a/Demo/PowerSyncExample/Components/TodoListView.swift
+++ b/Demo/PowerSyncExample/Components/TodoListView.swift
@@ -28,7 +28,7 @@ struct TodoListView: View {
             ForEach(todos) { todo in
                 TodoListRow(todo: todo) {
                     Task {
-                        await toggleCompletion(of: todo)
+                        try await toggleCompletion(of: todo)
                     }
                 }
             }

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-kotlin.git",
       "state" : {
-        "revision" : "61d195816585f30260181dcbd157bf1660c9ac4e",
-        "version" : "1.0.0-BETA22.0"
+        "revision" : "203db74889df8a20e3c6ac38aede6b0186d2e3b5",
+        "version" : "1.0.0-BETA23.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
             targets: ["PowerSync"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "1.0.0-BETA22.0"),
+        .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "1.0.0-BETA23.0"),
         .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", "0.3.9"..<"0.4.0")
     ],
     targets: [

--- a/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
+++ b/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
@@ -195,45 +195,30 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
     }
 
     public func writeTransaction<R>(callback: @escaping (any PowerSyncTransaction) throws -> R) async throws -> R {
-        var err: Error? = nil
-        let result = try await kotlinDatabase.writeTransaction { transaction in
-            do {
-                let res = try callback(transaction)
-                return res as R
-            } catch {
-                err = error
-                return TransactionResponse.rollback
-            }
-        }
-        
-        if(err != nil) {
-            throw err!
-        }
-        
-        return result as! R
+        return try await kotlinDatabase.writeTransaction(callback: TransactionCallback(callback: callback)) as! R
     }
 
     public func readTransaction<R>(callback: @escaping (any PowerSyncTransaction) throws -> R) async throws -> R {
-        var err: Error? = nil
-        let result = try await kotlinDatabase.readTransaction { transaction in
-            do {
-                let res = try callback(transaction)
-                return res as R
-            } catch {
-                err = error
-                return TransactionResponse.rollback
-            }
-        }
-        
-        if(err != nil) {
-            throw err!
-        }
-        
-        return result as! R
+        return try await kotlinDatabase.readTransaction(callback: TransactionCallback(callback: callback)) as! R
+    }
+}
+
+class TransactionCallback<R>: PowerSyncKotlin.ThrowableTransactionCallback {
+    let callback: (PowerSyncTransaction) throws -> R
+
+    init(callback: @escaping (PowerSyncTransaction) throws -> R) {
+        self.callback = callback
     }
 
-    public func readTransaction<R>(callback: @escaping (any PowerSyncTransaction) -> R) async throws -> R {
-        return try await kotlinDatabase.readTransaction(callback: callback) as! R
+    func execute(transaction: PowerSyncKotlin.PowerSyncTransaction) throws -> Any{
+        do {
+            return try callback(transaction)
+        } catch let error {
+            return PowerSyncKotlin.PowerSyncException(
+                message: error.localizedDescription,
+                cause: PowerSyncKotlin.KotlinThrowable(message: error.localizedDescription)
+            )
+        }
     }
 }
 

--- a/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
+++ b/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
@@ -79,7 +79,7 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
             mapper: mapper
         ) as! RowType
     }
-    
+
     func get<RowType>(
         sql: String,
         parameters: [Any]?,
@@ -93,7 +93,7 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
             }
         ) as! RowType
     }
-    
+
     func getAll<RowType>(
         sql: String,
         parameters: [Any]?,
@@ -105,7 +105,7 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
             mapper: mapper
         ) as! [RowType]
     }
-    
+
     func getAll<RowType>(
         sql: String,
         parameters: [Any]?,
@@ -131,7 +131,7 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
             mapper: mapper
         ) as! RowType?
     }
-    
+
     func getOptional<RowType>(
         sql: String,
         parameters: [Any]?,
@@ -150,42 +150,50 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
         sql: String,
         parameters: [Any]?,
         mapper: @escaping (SqlCursor) -> RowType
-    ) -> AsyncStream<[RowType]> {
-        AsyncStream { continuation in
+    ) throws -> AsyncThrowingStream<[RowType], Error> {
+        AsyncThrowingStream { continuation in
             Task {
-                for await values in try self.kotlinDatabase.watch(
-                    sql: sql,
-                    parameters: parameters,
-                    mapper: mapper
-                ) {
-                    continuation.yield(values as! [RowType])
-                }
-                continuation.finish()
-            }
-        }
-    }
-    
-    func watch<RowType>(
-        sql: String,
-        parameters: [Any]?,
-        mapper: @escaping (SqlCursor) throws -> RowType
-    ) -> AsyncStream<[RowType]> {
-        AsyncStream { continuation in
-            Task {
-                for await values in try self.kotlinDatabase.watch(
-                    sql: sql,
-                    parameters: parameters,
-                    mapper: { cursor in
-                        try! mapper(cursor)
+                do {
+                    for await values in try self.kotlinDatabase.watch(
+                        sql: sql,
+                        parameters: parameters,
+                        mapper: mapper
+                    ) {
+                        continuation.yield(values as! [RowType])
                     }
-                ) {
-                    continuation.yield(values as! [RowType])
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
                 }
-                continuation.finish()
             }
         }
     }
-    
+
+    func watch<RowType>(
+        sql: String,
+        parameters: [Any]?,
+        mapper: @escaping (SqlCursor) throws -> RowType
+    ) throws -> AsyncThrowingStream<[RowType], Error> {
+        AsyncThrowingStream { continuation in
+            Task {
+                do {
+                    for await values in try self.kotlinDatabase.watch(
+                        sql: sql,
+                        parameters: parameters,
+                        mapper: { cursor in
+                            try! mapper(cursor)
+                        }
+                    ) {
+                        continuation.yield(values as! [RowType])
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
     public func writeTransaction<R>(callback: @escaping (any PowerSyncTransaction) -> R) async throws -> R {
         return try await kotlinDatabase.writeTransaction(callback: callback) as! R
     }

--- a/Sources/PowerSync/QueriesProtocol.swift
+++ b/Sources/PowerSync/QueriesProtocol.swift
@@ -59,7 +59,7 @@ public protocol Queries {
         sql: String,
         parameters: [Any]?,
         mapper: @escaping (SqlCursor) -> RowType
-    ) -> AsyncStream<[RowType]>
+    ) throws -> AsyncThrowingStream<[RowType], Error>
 
     /// Execute a read-only (SELECT) query every time the source tables are modified
     /// and return the results as an array in a Publisher.
@@ -67,7 +67,7 @@ public protocol Queries {
         sql: String,
         parameters: [Any]?,
         mapper: @escaping (SqlCursor) throws -> RowType
-    ) -> AsyncStream<[RowType]>
+    ) throws -> AsyncThrowingStream<[RowType], Error>
 
     /// Execute a write transaction with the given callback
     func writeTransaction<R>(callback: @escaping (any PowerSyncTransaction) -> R) async throws -> R
@@ -105,7 +105,7 @@ extension Queries {
     public func watch<RowType>(
         _ sql: String,
         mapper: @escaping (SqlCursor) -> RowType
-    ) -> AsyncStream<[RowType]> {
-        return watch(sql: sql, parameters: [], mapper: mapper)
+    ) throws -> AsyncThrowingStream<[RowType], Error> {
+        return try watch(sql: sql, parameters: [], mapper: mapper)
     }
 }

--- a/Sources/PowerSync/QueriesProtocol.swift
+++ b/Sources/PowerSync/QueriesProtocol.swift
@@ -70,10 +70,10 @@ public protocol Queries {
     ) throws -> AsyncThrowingStream<[RowType], Error>
 
     /// Execute a write transaction with the given callback
-    func writeTransaction<R>(callback: @escaping (any PowerSyncTransaction) -> R) async throws -> R
+    func writeTransaction<R>(callback: @escaping (any PowerSyncTransaction) throws -> R) async throws -> R
 
     /// Execute a read transaction with the given callback
-    func readTransaction<R>(callback: @escaping (any PowerSyncTransaction) -> R) async throws -> R
+    func readTransaction<R>(callback: @escaping (any PowerSyncTransaction) throws -> R) async throws -> R
 }
 
 extension Queries {


### PR DESCRIPTION
## Description
Allow `execute`, `watch` and `transaction` functions to throw in Swift allowing users to handle them. This makes breaking changes to `watch` and `transaction` functions as they now require a `try` before implementation.

Includes changelog updates as well in preparation for the `Beta.6` release.

## Testing
Tests have been included to confirm errors are thrown and can be handled and show an error log of the issue. I also ran the demo app to confirm it works as expected.