### PR TITLE
chore: add default to userId in PowerSyncCredentials

### DIFF
--- a/Demo/PowerSyncExample/PowerSync/SupabaseConnector.swift
+++ b/Demo/PowerSyncExample/PowerSync/SupabaseConnector.swift
@@ -70,15 +70,14 @@ class SupabaseConnector: PowerSyncBackendConnector {
 
     override func fetchCredentials() async throws -> PowerSyncCredentials? {
         session = try await client.auth.session
-        
+
         if (self.session == nil) {
             throw AuthError.sessionMissing
         }
-        
+
         let token = session!.accessToken
-        
-        // userId is for debugging purposes only
-        return PowerSyncCredentials(endpoint: self.powerSyncEndpoint, token: token, userId: currentUserID)
+
+        return PowerSyncCredentials(endpoint: self.powerSyncEndpoint, token: token)
     }
 
     override func uploadData(database: PowerSyncDatabaseProtocol) async throws {

--- a/Sources/PowerSync/PowerSyncCredentials.swift
+++ b/Sources/PowerSync/PowerSyncCredentials.swift
@@ -14,7 +14,7 @@ public struct PowerSyncCredentials: Codable {
     /// User ID.
     public let userId: String?
 
-    public init(endpoint: String, token: String, userId: String?) {
+    public init(endpoint: String, token: String, userId: String? = nil) {
         self.endpoint = endpoint
         self.token = token
         self.userId = userId


### PR DESCRIPTION
## Description
Add a default value of `nil` for `userId` in `PowerSyncCredentials` so users do not always need to include a `nil` value in their `fetchCredentials` function. I removed the `userId` from the example app as this is not useful for people trying to use the demo and could end up being a red herring.

## Testing
Ran the demo app