### PR TITLE
Cursor Exceptions and Type Casts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.0-Beta.7
+
+* Fixed an issue where throwing exceptions in the query `mapper` could cause a runtime crash.
+* Internally improved type casting.
+
 ## 1.0.0-Beta.6
 
 * BREAKING CHANGE: `watch` queries are now throwable and therefore will need to be accompanied by a `try` e.g.

--- a/Sources/PowerSync/Kotlin/SafeCastError.swift
+++ b/Sources/PowerSync/Kotlin/SafeCastError.swift
@@ -1,0 +1,19 @@
+enum SafeCastError: Error, CustomStringConvertible {
+    case typeMismatch(expected: Any.Type, actual: Any?)
+
+    var description: String {
+        switch self {
+        case let .typeMismatch(expected, actual):
+            let actualType = actual.map { String(describing: type(of: $0)) } ?? "nil"
+            return "Type mismatch: Expected \(expected), but got \(actualType)."
+        }
+    }
+}
+
+internal func safeCast<T>(_ value: Any?, to type: T.Type) throws -> T {
+    if let castedValue = value as? T {
+        return castedValue
+    } else {
+        throw SafeCastError.typeMismatch(expected: type, actual: value)
+    }
+}

--- a/Sources/PowerSync/Kotlin/TransactionCallback.swift
+++ b/Sources/PowerSync/Kotlin/TransactionCallback.swift
@@ -1,0 +1,35 @@
+import PowerSyncKotlin
+
+class TransactionCallback<R>: PowerSyncKotlin.ThrowableTransactionCallback {
+    let callback: (PowerSyncTransaction) throws -> R
+
+    init(callback: @escaping (PowerSyncTransaction) throws -> R) {
+        self.callback = callback
+    }
+
+    // The Kotlin SDK does not gracefully handle exceptions thrown from Swift callbacks.
+    // If a Swift callback throws an exception, it results in a `BAD ACCESS` crash.
+    //
+    // To prevent this, we catch the exception and return it as a `PowerSyncException`,
+    // allowing Kotlin to propagate the error correctly.
+    //
+    // This approach is a workaround. Ideally, we should introduce an internal mechanism
+    // in the Kotlin SDK to handle errors from Swift more robustly.
+    //
+    // Currently, we wrap the public `PowerSyncDatabase` class in Kotlin, which limits our
+    // ability to handle exceptions cleanly. Instead, we should expose an internal implementation
+    // from a "core" package in Kotlin that provides better control over exception handling
+    // and other functionality—without modifying the public `PowerSyncDatabase` API to include
+    // Swift-specific logic.
+    func execute(transaction: PowerSyncKotlin.PowerSyncTransaction) throws -> Any {
+        do {
+            return try callback(transaction)
+        } catch {
+            return PowerSyncKotlin.PowerSyncException(
+                message: error.localizedDescription,
+                cause: PowerSyncKotlin.KotlinThrowable(message: error.localizedDescription)
+            )
+        }
+    }
+}
+

--- a/Sources/PowerSync/Kotlin/wrapQueryCursor.swift
+++ b/Sources/PowerSync/Kotlin/wrapQueryCursor.swift
@@ -1,0 +1,51 @@
+
+// The Kotlin SDK does not gracefully handle exceptions thrown from Swift callbacks.
+// If a Swift callback throws an exception, it results in a `BAD ACCESS` crash.
+//
+// This approach is a workaround. Ideally, we should introduce an internal mechanism
+// in the Kotlin SDK to handle errors from Swift more robustly.
+//
+// This hoists any exceptions thrown in a cursor mapper in order for the error to propagate correctly.
+//
+// Currently, we wrap the public `PowerSyncDatabase` class in Kotlin, which limits our
+// ability to handle exceptions cleanly. Instead, we should expose an internal implementation
+// from a "core" package in Kotlin that provides better control over exception handling
+// and other functionality—without modifying the public `PowerSyncDatabase` API to include
+// Swift-specific logic.
+internal func wrapQueryCursor<RowType, ReturnType>(
+    mapper: @escaping (SqlCursor) throws -> RowType,
+    //    The Kotlin APIs return the results as Any, we can explicitly cast internally
+    executor: @escaping (_ wrappedMapper: @escaping (SqlCursor) -> RowType?) async throws -> ReturnType
+) async throws -> ReturnType {
+    var mapperException: Error?
+
+    // Wrapped version of the mapper that catches exceptions and sets `mapperException`
+    // In the case of an exception this will return an empty result.
+    let wrappedMapper: (SqlCursor) -> RowType? = { cursor in
+        do {
+            return try mapper(cursor)
+        } catch {
+            // Store the error in order to propagate it
+            mapperException = error
+            // Return nothing here. Kotlin should handle this as an empty object/row
+            return nil
+        }
+    }
+
+    let executionResult = try await executor(wrappedMapper)
+    if mapperException != nil {
+        //        Allow propagating the error
+        throw mapperException!
+    }
+
+    return executionResult
+}
+
+internal func wrapQueryCursorTyped<RowType, ReturnType>(
+    mapper: @escaping (SqlCursor) throws -> RowType,
+    //    The Kotlin APIs return the results as Any, we can explicitly cast internally
+    executor: @escaping (_ wrappedMapper: @escaping (SqlCursor) -> RowType?) async throws -> Any?,
+    resultType: ReturnType.Type
+) async throws -> ReturnType {
+    return try safeCast(await wrapQueryCursor(mapper: mapper, executor: executor), to: resultType)
+}


### PR DESCRIPTION
# Overview

## Cursor Exceptions

We currently support a SQL query cursor callback, which can throw exceptions if there are issues processing the result columns.

For example:

```swift
let _ = try await database.get(
    sql: "SELECT id, name, email FROM users WHERE id = ?",
    parameters: ["1"]
) { cursor in
    try (
        cursor.getString(name: "fakecolumn")
    )
}
```
In the above query, if the `fakecolumn` does not exist, an exception would be thrown during the mapping phase.

The current implementation uses a forced unwrap (`try!`) during the cursor's invocation. This could lead to a runtime crash if an exception occurs during the mapping process. Errors thrown in the cursor should propagate to the relevant execution method (such as get in the above example).

Unfortunately, throwing exceptions in a Swift callback passed internally to the Kotlin SDK is quite tricky. While we've managed to achieve this for read and write transactions [here](https://github.com/powersync-ja/powersync-swift/pull/21), the current method could potentially break compatibility with the existing Kotlin SDK's mapper parameter.

At present, we wrap the Kotlin SDK PowerSyncDatabase client directly in the Swift SDK, forcing us to use the "public" Kotlin SDK methods in Swift. Ideally, in the future, we would split the Kotlin SDK into smaller components and use the internals directly (with some modifications) to better accommodate Swift-specific behavior.

This PR implements a workaround by intercepting the mapper provided to the Kotlin SDK. Exceptions are tracked and manually propagated. Although this isn't the ideal solution, it works with the current setup. A better approach could be possible once the proposal above is implemented.

## Type Casting

The Kotlin SDK query methods (`get`, `execute`, etc.) return `Any` after being processed by SKIEE. Currently, we explicitly cast the return type to the one provided by the mapper using `as!`. This forced `as!` cast can result in a runtime crash if there is an issue with the casting. While the cast should be safe in most cases, for consistency, we've now added safeguards to catch any potential casting errors and throw an exception that can be handled.

Formatting
I ran the modified files through `swiftformat` to clean up the code, which resulted in some formatting improvements.