### PR TITLE
Support bucket priorities

### DIFF
--- a/Demo/PowerSyncExample/Components/ListView.swift
+++ b/Demo/PowerSyncExample/Components/ListView.swift
@@ -9,8 +9,18 @@ struct ListView: View {
     @State private var error: Error?
     @State private var newList: NewListContent?
     @State private var editing: Bool = false
+    @State private var didSync: Bool = false
 
     var body: some View {
+        if !didSync {
+            Text("Busy with sync!").task {
+                do {
+                    try await system.db.waitForFirstSync(priority: 1)
+                    didSync = true;
+                } catch {}
+            }
+        }
+        
         List {
             if let error {
                 ErrorText(error)

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-kotlin.git",
       "state" : {
-        "revision" : "203db74889df8a20e3c6ac38aede6b0186d2e3b5",
-        "version" : "1.0.0-BETA23.0"
+        "revision" : "0541a4744088ea24084c47c158ab116db35f9345",
+        "version" : "1.0.0-BETA26.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-sqlite-core-swift.git",
       "state" : {
-        "revision" : "5de629f7ddc649a1e89c64fde6113fe113fe14de",
-        "version" : "0.3.9"
+        "revision" : "fb313c473b17457d79bf3847905f5a288901d493",
+        "version" : "0.3.11"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "1.0.0-BETA23.0"),
-        .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", "0.3.9"..<"0.4.0")
+        .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", "0.3.11"..<"0.4.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
             targets: ["PowerSync"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "1.0.0-BETA23.0"),
+        .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "1.0.0-BETA26.0"),
         .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", "0.3.11"..<"0.4.0")
     ],
     targets: [

--- a/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
+++ b/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
@@ -25,6 +25,10 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
     func waitForFirstSync() async throws {
         try await kotlinDatabase.waitForFirstSync()
     }
+    
+    func waitForFirstSync(priority: Int32) async throws {
+        try await kotlinDatabase.waitForFirstSync(priority: priority)
+    }
 
     func connect(
         connector: PowerSyncBackendConnector,

--- a/Sources/PowerSync/PowerSyncDatabaseProtocol.swift
+++ b/Sources/PowerSync/PowerSyncDatabaseProtocol.swift
@@ -13,6 +13,9 @@ public protocol PowerSyncDatabaseProtocol: Queries {
     
     /// Wait for the first sync to occur
     func waitForFirstSync() async throws
+   
+    /// Wait for the first (possibly partial) sync to occur that contains all buckets in the given priority.
+    func waitForFirstSync(priority: Int32) async throws
     
     /// Connect to the PowerSync service, and keep the databases in sync.
     ///


### PR DESCRIPTION
Support bucket priorities through the Kotlin SDK. The only Swift change is that we're exposing the new `waitForFirstSync(priority)` API.