### PR TITLE
Watched Query Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.0-Beta.8
 
 * Improved watch query internals. Added the ability to throttle watched queries.
+* Added support for sync bucket priorities.
 
 ## 1.0.0-Beta.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.0-Beta.8
+
+* Improved watch query internals. Added the ability to throttle watched queries.
+
 ## 1.0.0-Beta.7
 
 * Fixed an issue where throwing exceptions in the query `mapper` could cause a runtime crash.

--- a/Demo/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "25b8cd5d97789d7e497d6a5e0b04419a426018d83f0e80ab6817b213aa976748",
+  "originHash" : "33297127250b66812faa920958a24bae46bf9e9d1c38ea6b84ca413efaf16afd",
   "pins" : [
     {
       "identity" : "anycodable",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-kotlin.git",
       "state" : {
-        "revision" : "203db74889df8a20e3c6ac38aede6b0186d2e3b5",
-        "version" : "1.0.0-BETA23.0"
+        "revision" : "cb1a7d186144290b5ad706f5c2c9b67ff707356e",
+        "version" : "1.0.0-BETA27.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-sqlite-core-swift.git",
       "state" : {
-        "revision" : "5de629f7ddc649a1e89c64fde6113fe113fe14de",
-        "version" : "0.3.9"
+        "revision" : "fb313c473b17457d79bf3847905f5a288901d493",
+        "version" : "0.3.11"
       }
     },
     {

--- a/Demo/PowerSyncExample/PowerSync/SystemManager.swift
+++ b/Demo/PowerSyncExample/PowerSync/SystemManager.swift
@@ -56,20 +56,10 @@ class SystemManager {
     }
 
     func insertList(_ list: NewListContent) async throws {
-        let id = try await self.db.get(sql: "select uuid() as uuid", parameters: [], mapper: {cursor in try cursor.getString(name: "uuid")})
-        
         let result = try await self.db.execute(
-            sql: "INSERT INTO \(LISTS_TABLE) (id, created_at, name, owner_id) VALUES (?, datetime(), ?, ?)",
-            parameters: [id, list.name, connector.currentUserID]
+            sql: "INSERT INTO \(LISTS_TABLE) (id, created_at, name, owner_id) VALUES (uuid(), datetime(), ?, ?)",
+            parameters: [list.name, connector.currentUserID]
         )
-        
-        // insert 2000k todos
-        // try await self.db.writeTransaction(callback: { tx in
-        //     for (_) in 0..<10000 {
-        //         try tx.execute(sql: "INSERT INTO \(TODOS_TABLE) (id, list_id, description) VALUES (uuid(), ?, ?)", parameters: [id, "Todo \(Int.random(in: 0..<1000))"])
-        //     }
-            
-        // })
     }
 
     func deleteList(id: String) async throws {
@@ -97,8 +87,8 @@ class SystemManager {
                         listId: cursor.getString(name: "list_id"),
                         photoId: cursor.getStringOptional(name: "photo_id"),
                         description: cursor.getString(name: "description"),
-                        isComplete: cursor.getBooleanOptional(name: "completed") ?? false,
-                        createdAt: cursor.getStringOptional(name: "created_at"),
+                        isComplete: cursor.getBoolean(name: "completed"),
+                        createdAt: cursor.getString(name: "created_at"),
                         completedAt: cursor.getStringOptional(name: "completed_at"),
                         createdBy: cursor.getStringOptional(name: "created_by"),
                         completedBy: cursor.getStringOptional(name: "completed_by")

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-kotlin.git",
       "state" : {
-        "revision" : "0541a4744088ea24084c47c158ab116db35f9345",
-        "version" : "1.0.0-BETA26.0"
+        "revision" : "cb1a7d186144290b5ad706f5c2c9b67ff707356e",
+        "version" : "1.0.0-BETA27.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
             targets: ["PowerSync"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "1.0.0-BETA26.0"),
+        .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "1.0.0-BETA27.0"),
         .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", "0.3.11"..<"0.4.0")
     ],
     targets: [

--- a/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
+++ b/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
@@ -183,6 +183,14 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
                 Task {
                     do {
                         var mapperError: Error?
+                        // HACK!
+                        // SKIEE doesn't support custom exceptions in Flows
+                        // Exceptions which occur in the Flow itself cause runtime crashes.
+                        // The most probable crash would be the internal EXPLAIN statement.
+                        // This attempts to EXPLAIN the query before passing it to Kotlin
+                        // We could introduce an onChange API in Kotlin which we use to implement watches here.
+                        // This would prevent most issues with exceptions.
+                        _ = try await self.kotlinDatabase.get(sql: "EXPLAIN \(options.sql)", parameters: options.parameters, mapper: {_ in ""})
                         for try await values in try self.kotlinDatabase.watch(
                             sql: options.sql,
                             parameters: options.parameters,

--- a/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
+++ b/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
@@ -190,7 +190,11 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
                     // This attempts to EXPLAIN the query before passing it to Kotlin
                     // We could introduce an onChange API in Kotlin which we use to implement watches here.
                     // This would prevent most issues with exceptions.
-                    _ = try await self.kotlinDatabase.getAll(sql: "EXPLAIN \(options.sql)", parameters: options.parameters, mapper: { _ in "" })
+                    _ = try await self.kotlinDatabase.getAll(
+                        sql: "EXPLAIN \(options.sql)",
+                        parameters: options.parameters,
+                        mapper: { _ in "" }
+                    )
                     for try await values in try self.kotlinDatabase.watch(
                         sql: options.sql,
                         parameters: options.parameters,

--- a/Sources/PowerSync/QueriesProtocol.swift
+++ b/Sources/PowerSync/QueriesProtocol.swift
@@ -1,20 +1,20 @@
-import Foundation
 import Combine
+import Foundation
 import PowerSyncKotlin
 
-public let DEFAULT_WATCH_THROTTLE_MS = Int64(30);
+public let DEFAULT_WATCH_THROTTLE_MS = Int64(30)
 
 public struct WatchOptions<RowType> {
     public var sql: String
     public var parameters: [Any]
     public var throttleMs: Int64
     public var mapper: (SqlCursor) throws -> RowType
-    
+
     public init(sql: String, parameters: [Any]? = [], throttleMs: Int64? = DEFAULT_WATCH_THROTTLE_MS, mapper: @escaping (SqlCursor) throws -> RowType) {
         self.sql = sql
         self.parameters = parameters ?? [] // Default to empty array if nil
         self.throttleMs = throttleMs ?? DEFAULT_WATCH_THROTTLE_MS // Default to the constant if nil
-        self.mapper = mapper;
+        self.mapper = mapper
     }
 }
 
@@ -84,7 +84,7 @@ public protocol Queries {
         parameters: [Any]?,
         mapper: @escaping (SqlCursor) throws -> RowType
     ) throws -> AsyncThrowingStream<[RowType], Error>
-    
+
     func watch<RowType>(
         options: WatchOptions<RowType>
     ) throws -> AsyncThrowingStream<[RowType], Error>
@@ -96,59 +96,36 @@ public protocol Queries {
     func readTransaction<R>(callback: @escaping (any PowerSyncTransaction) throws -> R) async throws -> R
 }
 
-extension Queries {
-    public func execute(_ sql: String) async throws -> Int64 {
+public extension Queries {
+    func execute(_ sql: String) async throws -> Int64 {
         return try await execute(sql: sql, parameters: [])
     }
 
-    public func get<RowType>(
+    func get<RowType>(
         _ sql: String,
         mapper: @escaping (SqlCursor) -> RowType
     ) async throws -> RowType {
         return try await get(sql: sql, parameters: [], mapper: mapper)
     }
 
-    public func getAll<RowType>(
+    func getAll<RowType>(
         _ sql: String,
         mapper: @escaping (SqlCursor) -> RowType
     ) async throws -> [RowType] {
         return try await getAll(sql: sql, parameters: [], mapper: mapper)
     }
 
-    public func getOptional<RowType>(
+    func getOptional<RowType>(
         _ sql: String,
         mapper: @escaping (SqlCursor) -> RowType
     ) async throws -> RowType? {
         return try await getOptional(sql: sql, parameters: [], mapper: mapper)
     }
 
-    public func watch<RowType>(
+    func watch<RowType>(
         _ sql: String,
         mapper: @escaping (SqlCursor) -> RowType
     ) throws -> AsyncThrowingStream<[RowType], Error> {
         return try watch(sql: sql, parameters: [], mapper: mapper)
     }
-    
-
-    /// Execute a read-only (SELECT) query every time the source tables are modified
-    /// and return the results as an array in a Publisher.
-    func watch<RowType>(
-        sql: String,
-        parameters: [Any]?,
-        mapper: @escaping (SqlCursor) -> RowType
-    ) throws -> AsyncThrowingStream<[RowType], Error> {
-        return try watch(sql: sql, parameters: [], mapper: mapper)
-    }
-
-    /// Execute a read-only (SELECT) query every time the source tables are modified
-    /// and return the results as an array in a Publisher.
-    func watch<RowType>(
-        sql: String,
-        parameters: [Any]?,
-        mapper: @escaping (SqlCursor) throws -> RowType
-    ) throws -> AsyncThrowingStream<[RowType], Error> {
-        return try watch(sql: sql, parameters: [], mapper: mapper)
-    }
-    
-    
 }

--- a/Tests/PowerSyncTests/Kotlin/KotlinPowerSyncDatabaseImplTests.swift
+++ b/Tests/PowerSyncTests/Kotlin/KotlinPowerSyncDatabaseImplTests.swift
@@ -226,7 +226,6 @@ final class KotlinPowerSyncDatabaseImplTests: XCTestCase {
 
         let watchTask = Task {
             for try await names in stream {
-                print(names)
                 await resultsStore.append(names)
                 if await resultsStore.count() == 2 {
                     expectation.fulfill()

--- a/Tests/PowerSyncTests/Kotlin/KotlinPowerSyncDatabaseImplTests.swift
+++ b/Tests/PowerSyncTests/Kotlin/KotlinPowerSyncDatabaseImplTests.swift
@@ -198,13 +198,13 @@ final class KotlinPowerSyncDatabaseImplTests: XCTestCase {
 
         // Create an actor to handle concurrent mutations
         actor ResultsStore {
-            private var results: [[String]] = []
+            private var results: Set<String> = []
 
             func append(_ names: [String]) {
-                results.append(names)
+                results.formUnion(names)
             }
 
-            func getResults() -> [[String]] {
+            func getResults() -> Set<String> {
                 results
             }
 
@@ -213,17 +213,20 @@ final class KotlinPowerSyncDatabaseImplTests: XCTestCase {
             }
         }
 
+
         let resultsStore = ResultsStore()
 
         let stream = try database.watch(
-            sql: "SELECT name FROM users ORDER BY id",
-            parameters: nil
-        ) { cursor in
-            cursor.getString(index: 0)!
-        }
+            options: WatchOptions(
+                sql: "SELECT name FROM users ORDER BY id",
+                mapper: { cursor in
+                    cursor.getString(index: 0)!
+                }
+            ))
 
         let watchTask = Task {
             for try await names in stream {
+                print(names)
                 await resultsStore.append(names)
                 if await resultsStore.count() == 2 {
                     expectation.fulfill()
@@ -240,13 +243,18 @@ final class KotlinPowerSyncDatabaseImplTests: XCTestCase {
             sql: "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
             parameters: ["2", "User 2", "user2@example.com"]
         )
+        
 
         await fulfillment(of: [expectation], timeout: 5)
         watchTask.cancel()
 
         let finalResults = await resultsStore.getResults()
-        XCTAssertEqual(finalResults.count, 2)
-        XCTAssertEqual(finalResults[1], ["User 1", "User 2"])
+        // The count of invocations here can vary a lot depending on the order of execution
+        // In some cases the creation of the users can fire before the initial watched query
+        // has emitted a result.
+        // However the watched query should always emit the latest result set.
+        XCTAssertLessThanOrEqual(finalResults.count, 3)
+        XCTAssertEqual(finalResults, ["User 1", "User 2"])
     }
 
     func testWatchError() async throws {


### PR DESCRIPTION
# Overview

This applies the latest watched query updates from https://github.com/powersync-ja/powersync-kotlin/pull/136.

The current Query protocol is a bit verbose due to handling optional function parameters. Watched queries now support an optional `throttleMs` parameter. Adding this new param to the current structure would require a function definition for every possible permutation of optional arguments. A new struct based approach has been added for the `watch` method, this handles optional arguments better.