### PR TITLE
Upstream Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.0.0-Beta.9
+
+* Update PowerSync SQLite core extension to 0.3.12.
+* Added queuing protection and warnings when connecting multiple PowerSync clients to the same database file.
+* Improved concurrent SQLite connection support. A single write connection and multiple read connections are used for concurrent read queries.
+* Internally improved the linking of SQLite.
+* Enabled Full Text Search support.
+* Added the ability to update the schema for existing PowerSync clients.
+* Fixed bug where local only, insert only and view name overrides were not applied for schema tables.
+
 ## 1.0.0-Beta.8
 
 * Improved watch query internals. Added the ability to throttle watched queries.

--- a/Demo/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-kotlin.git",
       "state" : {
-        "revision" : "cb1a7d186144290b5ad706f5c2c9b67ff707356e",
-        "version" : "1.0.0-BETA27.0"
+        "revision" : "443df078f4b9352de137000b993d564d4ab019b7",
+        "version" : "1.0.0-BETA28.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-sqlite-core-swift.git",
       "state" : {
-        "revision" : "fb313c473b17457d79bf3847905f5a288901d493",
-        "version" : "0.3.11"
+        "revision" : "5041116d295e61d3c54f27117c02fd81071a1ab3",
+        "version" : "0.3.12"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-kotlin.git",
       "state" : {
-        "revision" : "cb1a7d186144290b5ad706f5c2c9b67ff707356e",
-        "version" : "1.0.0-BETA27.0"
+        "revision" : "443df078f4b9352de137000b993d564d4ab019b7",
+        "version" : "1.0.0-BETA28.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-sqlite-core-swift.git",
       "state" : {
-        "revision" : "fb313c473b17457d79bf3847905f5a288901d493",
-        "version" : "0.3.11"
+        "revision" : "5041116d295e61d3c54f27117c02fd81071a1ab3",
+        "version" : "0.3.12"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,7 @@ let package = Package(
             targets: ["PowerSync"]),
     ],
     dependencies: [
-//        .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "1.0.0-BETA28.0"),
-        .package(path: "/Users/stevenontong/Documents/platform_code/powersync/powersync-kotlin"),
+        .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "1.0.0-BETA28.0"),
         .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", "0.3.12"..<"0.4.0")
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,9 @@ let package = Package(
             targets: ["PowerSync"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "1.0.0-BETA27.0"),
-        .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", "0.3.11"..<"0.4.0")
+//        .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "1.0.0-BETA28.0"),
+        .package(path: "/Users/stevenontong/Documents/platform_code/powersync/powersync-kotlin"),
+        .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", "0.3.12"..<"0.4.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
+++ b/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
@@ -26,6 +26,10 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
         try await kotlinDatabase.waitForFirstSync()
     }
 
+    func updateSchema(schema: any SchemaProtocol) async throws {
+        try await kotlinDatabase.updateSchema(schema: KotlinAdapter.Schema.toKotlin(schema))
+    }
+
     func waitForFirstSync(priority: Int32) async throws {
         try await kotlinDatabase.waitForFirstSync(priority: priority)
     }

--- a/Sources/PowerSync/PowerSyncDatabaseProtocol.swift
+++ b/Sources/PowerSync/PowerSyncDatabaseProtocol.swift
@@ -13,6 +13,13 @@ public protocol PowerSyncDatabaseProtocol: Queries {
     
     /// Wait for the first sync to occur
     func waitForFirstSync() async throws
+    
+
+    /// Replace the schema with a new version. This is for advanced use cases - typically the schema
+    /// should just be specified once in the constructor.
+    ///
+    /// Cannot be used while connected - this should only be called before connect.
+    func updateSchema(schema: SchemaProtocol) async throws
    
     /// Wait for the first (possibly partial) sync to occur that contains all buckets in the given priority.
     func waitForFirstSync(priority: Int32) async throws

--- a/Tests/PowerSyncTests/Kotlin/KotlinPowerSyncDatabaseImplTests.swift
+++ b/Tests/PowerSyncTests/Kotlin/KotlinPowerSyncDatabaseImplTests.swift
@@ -443,6 +443,11 @@ final class KotlinPowerSyncDatabaseImplTests: XCTestCase {
     }
 
     func testUpdatingSchema() async throws {
+        _ = try await database.execute(
+            sql: "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
+            parameters: ["1", "Test User", "test@example.com"]
+        )
+
         let newSchema = Schema(tables: [
             Table(
                 name: "users",
@@ -453,11 +458,6 @@ final class KotlinPowerSyncDatabaseImplTests: XCTestCase {
                 viewNameOverride: "people"
             ),
         ])
-
-        _ = try await database.execute(
-            sql: "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
-            parameters: ["1", "Test User", "test@example.com"]
-        )
 
         try await database.updateSchema(schema: newSchema)
 

--- a/Tests/PowerSyncTests/Kotlin/KotlinPowerSyncDatabaseImplTests.swift
+++ b/Tests/PowerSyncTests/Kotlin/KotlinPowerSyncDatabaseImplTests.swift
@@ -213,7 +213,6 @@ final class KotlinPowerSyncDatabaseImplTests: XCTestCase {
             }
         }
 
-
         let resultsStore = ResultsStore()
 
         let stream = try database.watch(
@@ -242,7 +241,6 @@ final class KotlinPowerSyncDatabaseImplTests: XCTestCase {
             sql: "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
             parameters: ["2", "User 2", "user2@example.com"]
         )
-        
 
         await fulfillment(of: [expectation], timeout: 5)
         watchTask.cancel()
@@ -432,5 +430,42 @@ final class KotlinPowerSyncDatabaseImplTests: XCTestCase {
             no such table: usersfail
             """)
         }
+    }
+
+    func testFTS() async throws {
+        let supported = try await database.get(
+            "SELECT sqlite_compileoption_used('ENABLE_FTS5');"
+        ) { cursor in
+            cursor.getLong(index: 0)
+        }
+
+        XCTAssertEqual(supported, 1)
+    }
+
+    func testUpdatingSchema() async throws {
+        let newSchema = Schema(tables: [
+            Table(
+                name: "users",
+                columns: [
+                    .text("name"),
+                    .text("email"),
+                ],
+                viewNameOverride: "people"
+            ),
+        ])
+
+        _ = try await database.execute(
+            sql: "INSERT INTO users (id, name, email) VALUES (?, ?, ?)",
+            parameters: ["1", "Test User", "test@example.com"]
+        )
+
+        try await database.updateSchema(schema: newSchema)
+
+        let peopleCount = try await database.get(
+            sql: "SELECT COUNT(*) FROM people",
+            parameters: []
+        ) { cursor in cursor.getLong(index: 0) }
+
+        XCTAssertEqual(peopleCount, 1)
     }
 }


### PR DESCRIPTION
# Overview

This updates the Kotlin package dependency to 1.0.0-BETA28.  Relevant changes include:

* Update PowerSync SQLite core extension to 0.3.12.
* Added queuing protection and warnings when connecting multiple PowerSync clients to the same database file.
* Improved concurrent SQLite connection support. A single write connection and multiple read connections are used for concurrent read queries.
* Internally improved the linking of SQLite.
* Enabled Full Text Search support.
* Added the ability to update the schema for existing PowerSync clients.
* Fixed bug where local only, insert only and view name overrides were not applied for schema tables.