### PR TITLE
Configurable Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+# 1.0.0-Beta.10 (unreleased)
+
+* Added the ability to specify a custom logging implementation
+```swift
+  let db = PowerSyncDatabase(
+    schema: Schema(
+        tables: [
+            Table(
+                name: "users",
+                columns: [
+                    .text("name"),
+                    .text("email")
+                ]
+            )
+        ]
+    ),
+    logger: DefaultLogger(minSeverity: .debug)
+)
+```
+* added `.close()` method on `PowerSyncDatabaseProtocol`
+
 ## 1.0.0-Beta.9
 
 * Update PowerSync SQLite core extension to 0.3.12.

--- a/Sources/PowerSync/Kotlin/DatabaseLogger.swift
+++ b/Sources/PowerSync/Kotlin/DatabaseLogger.swift
@@ -1,0 +1,135 @@
+import PowerSyncKotlin
+
+/// Maps a Kermit `Severity` level to a local `LogSeverity`.
+///
+/// - Parameter severity: The Kermit log severity value from Kotlin.
+/// - Returns: The corresponding `LogSeverity` used in Swift.
+private func mapKermitSeverity(_ severity: PowerSyncKotlin.Kermit_coreSeverity) -> LogSeverity {
+    switch severity {
+        case PowerSyncKotlin.Kermit_coreSeverity.verbose:
+            return LogSeverity.debug
+        case PowerSyncKotlin.Kermit_coreSeverity.debug:
+            return LogSeverity.debug
+        case PowerSyncKotlin.Kermit_coreSeverity.info:
+            return LogSeverity.info
+        case PowerSyncKotlin.Kermit_coreSeverity.warn:
+            return LogSeverity.warning
+        case PowerSyncKotlin.Kermit_coreSeverity.error:
+            return LogSeverity.error
+        case PowerSyncKotlin.Kermit_coreSeverity.assert:
+            return LogSeverity.fault
+    }
+}
+
+/// Maps a local `LogSeverity` to a Kermit-compatible `Kermit_coreSeverity`.
+///
+/// - Parameter severity: The Swift-side `LogSeverity`.
+/// - Returns: The equivalent Kermit log severity.
+private func mapSeverity(_ severity: LogSeverity) -> PowerSyncKotlin.Kermit_coreSeverity {
+    switch severity {
+        case .debug:
+            return PowerSyncKotlin.Kermit_coreSeverity.debug
+        case .info:
+            return PowerSyncKotlin.Kermit_coreSeverity.info
+        case .warning:
+            return PowerSyncKotlin.Kermit_coreSeverity.warn
+        case .error:
+            return PowerSyncKotlin.Kermit_coreSeverity.error
+        case .fault:
+            return PowerSyncKotlin.Kermit_coreSeverity.assert
+    }
+}
+
+/// Adapts a Swift `LogWritterProtocol` to Kermit's `LogWriter` interface.
+///
+/// This allows Kotlin logging (via Kermit) to call into the Swift logging implementation.
+private class KermitLogWriterAdapter: Kermit_coreLogWriter {
+    /// The underlying Swift log writer to forward log messages to.
+    var adapter: LogWriterProtocol
+    
+    /// Initializes a new adapter.
+    ///
+    /// - Parameter adapter: A Swift log writer that will handle log output.
+    init(adapter: LogWriterProtocol) {
+        self.adapter = adapter
+        super.init()
+    }
+    
+    /// Called by Kermit to log a message.
+    ///
+    /// - Parameters:
+    ///   - severity: The severity level of the log.
+    ///   - message: The content of the log message.
+    ///   - tag: An optional string categorizing the log.
+    ///   - throwable: An optional Kotlin exception (ignored here).
+    override func log(severity: Kermit_coreSeverity, message: String, tag: String, throwable: KotlinThrowable?) {
+        adapter.log(
+            severity: mapKermitSeverity(severity),
+            message: message,
+            tag: tag
+        )
+    }
+}
+
+/// A logger implementation that integrates with PowerSync's Kotlin backend using Kermit.
+///
+/// This class bridges Swift log writers with the Kotlin logging system and supports
+/// runtime configuration of severity levels and writer lists.
+public class DatabaseLogger: LoggerProtocol {
+    /// The underlying Kermit logger instance provided by the PowerSyncKotlin SDK.
+    internal let kLogger = PowerSyncKotlin.generateLogger(logger: nil)
+    
+    /// Initializes a new logger with an optional list of writers.
+    ///
+    /// - Parameter writers: An array of Swift log writers. Defaults to an empty array.
+    init(writers: [any LogWriterProtocol] = []) {
+        setWriters(writers)
+    }
+    
+    /// Sets the minimum severity level that will be logged.
+    ///
+    /// Messages below this level will be ignored.
+    ///
+    /// - Parameter severity: The minimum `LogSeverity` to allow through.
+    public func setMinSeverity(_ severity: LogSeverity) {
+        kLogger.mutableConfig.setMinSeverity(
+            mapSeverity(severity)
+        )
+    }
+    
+    /// Sets the list of log writers that will receive log messages.
+    ///
+    /// This updates both the internal writer list and the Kermit logger's configuration.
+    ///
+    /// - Parameter writers: An array of Swift `LogWritterProtocol` implementations.
+    public func setWriters(_ writers: [any LogWriterProtocol]) {
+        kLogger.mutableConfig.setLogWriterList(
+            writers.map { item in KermitLogWriterAdapter(adapter: item) }
+        )
+    }
+    
+    /// Logs a debug-level message.
+    public func debug(_ message: String, tag: String) {
+        kLogger.d(messageString: message, throwable: nil, tag: tag)
+    }
+    
+    /// Logs an info-level message.
+    public func info(_ message: String, tag: String) {
+        kLogger.i(messageString: message, throwable: nil, tag: tag)
+    }
+    
+    /// Logs a warning-level message.
+    public func warning(_ message: String, tag: String) {
+        kLogger.w(messageString: message, throwable: nil, tag: tag)
+    }
+    
+    /// Logs an error-level message.
+    public func error(_ message: String, tag: String) {
+        kLogger.e(messageString: message, throwable: nil, tag: tag)
+    }
+    
+    /// Logs a fault (assert-level) message, typically used for critical issues.
+    public func fault(_ message: String, tag: String) {
+        kLogger.a(messageString: message, throwable: nil, tag: tag)
+    }
+}

--- a/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
+++ b/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
@@ -8,13 +8,15 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
 
     init(
         schema: Schema,
-        dbFilename: String
+        dbFilename: String,
+        logger: DatabaseLogger? = nil
     ) {
         let factory = PowerSyncKotlin.DatabaseDriverFactory()
         kotlinDatabase = PowerSyncDatabase(
             factory: factory,
             schema: KotlinAdapter.Schema.toKotlin(schema),
-            dbFilename: dbFilename
+            dbFilename: dbFilename,
+            logger: logger?.kLogger
         )
     }
 
@@ -231,5 +233,9 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
 
     func readTransaction<R>(callback: @escaping (any PowerSyncTransaction) throws -> R) async throws -> R {
         return try safeCast(await kotlinDatabase.readTransaction(callback: TransactionCallback(callback: callback)), to: R.self)
+    }
+    
+    func close() async throws{
+        try await kotlinDatabase.close()
     }
 }

--- a/Sources/PowerSync/Logger.swift
+++ b/Sources/PowerSync/Logger.swift
@@ -1,0 +1,52 @@
+import OSLog
+
+/// A log writer that bridges custom `LogSeverity` levels to Apple's unified `Logger` framework.
+///
+/// This writer uses `os.Logger` on iOS 14+ and falls back to `print` for earlier versions.
+/// Tags are optionally prefixed to messages in square brackets.
+public class SwiftLogWriter: LogWriterProtocol {
+    
+    /// Logs a message with a given severity and optional tag.
+       ///
+       /// - Parameters:
+       ///   - severity: The severity level of the message.
+       ///   - message: The content of the log message.
+       ///   - tag: An optional tag used to categorize the message. If empty, no brackets are shown.
+    public func log(severity: LogSeverity, message: String, tag: String) {
+        let tagPrefix = tag.isEmpty ? "" : "[\(tag)] "
+        let message = "\(tagPrefix) \(message)"
+        if #available(iOS 14.0, *) {
+            let l = Logger()
+            
+            switch severity {
+                case .info:
+                    l.info("\(message)")
+                case .error:
+                    l.error("\(message)")
+                case .debug:
+                    l.debug("\(message)")
+                case .warning:
+                    l.warning("\(message)")
+                case .fault:
+                    l.fault("\(message)")
+            }
+        } else {
+            print("\(severity.rawValue): \(message)")
+        }
+    }
+}
+
+/// A default logger configuration that uses `SwiftLogWritter` and filters messages by minimum severity.
+///
+/// This logger integrates with your custom logging system and uses `os.Logger` under the hood.
+public class DefaultLogger: DatabaseLogger {
+    
+    /// Initializes the default logger with an optional minimum severity level.
+    ///
+    /// - Parameter minSeverity: The minimum severity level to log. Defaults to `.debug`.
+    public init(minSeverity: LogSeverity = .debug) {
+        super.init()
+        setMinSeverity(minSeverity)
+        setWriters([SwiftLogWriter()])
+    }
+}

--- a/Sources/PowerSync/LoggerProtocol.swift
+++ b/Sources/PowerSync/LoggerProtocol.swift
@@ -1,0 +1,82 @@
+/// Represents the severity level of a log message.
+public enum LogSeverity: String, CaseIterable {
+    /// Informational messages that highlight the progress of the application.
+    case info = "INFO"
+    
+    /// Error events that might still allow the application to continue running.
+    case error = "ERROR"
+    
+    /// Detailed information typically used for debugging.
+    case debug = "DEBUG"
+    
+    /// Potentially harmful situations that are not necessarily errors.
+    case warning = "WARNING"
+    
+    /// Serious errors indicating critical failures, often unrecoverable.
+    case fault = "FAULT"
+}
+
+/// A protocol for writing log messages to a specific backend or output.
+///
+/// Conformers handle the actual writing or forwarding of log messages.
+public protocol LogWriterProtocol {
+    /// Logs a message with the given severity and optional tag.
+    ///
+    /// - Parameters:
+    ///   - severity: The severity level of the log message.
+    ///   - message: The content of the log message.
+    ///   - tag: An optional tag to categorize or group the log message.
+    func log(severity: LogSeverity, message: String, tag: String)
+}
+
+/// A protocol defining the interface for a logger that supports severity filtering and multiple writers.
+///
+/// Conformers provide logging APIs and manage attached log writers.
+public protocol LoggerProtocol {
+    /// Sets the minimum severity level to be logged.
+    ///
+    /// Log messages below this severity will be ignored.
+    ///
+    /// - Parameter severity: The minimum severity level to log.
+    func setMinSeverity(_ severity: LogSeverity)
+    
+    /// Sets the list of log writers that will handle log output.
+    ///
+    /// - Parameter writters: An array of `LogWritterProtocol` conformers.
+    func setWriters(_ writters: [LogWriterProtocol])
+    
+    /// Logs an informational message.
+    ///
+    /// - Parameters:
+    ///   - message: The content of the log message.
+    ///   - tag: An optional tag to categorize the message.
+    func info(_ message: String, tag: String)
+    
+    /// Logs an error message.
+    ///
+    /// - Parameters:
+    ///   - message: The content of the log message.
+    ///   - tag: An optional tag to categorize the message.
+    func error(_ message: String, tag: String)
+    
+    /// Logs a debug message.
+    ///
+    /// - Parameters:
+    ///   - message: The content of the log message.
+    ///   - tag: An optional tag to categorize the message.
+    func debug(_ message: String, tag: String)
+    
+    /// Logs a warning message.
+    ///
+    /// - Parameters:
+    ///   - message: The content of the log message.
+    ///   - tag: An optional tag to categorize the message.
+    func warning(_ message: String, tag: String)
+    
+    /// Logs a fault message, typically used for critical system-level failures.
+    ///
+    /// - Parameters:
+    ///   - message: The content of the log message.
+    ///   - tag: An optional tag to categorize the message.
+    func fault(_ message: String, tag: String)
+}

--- a/Sources/PowerSync/PowerSyncDatabase.swift
+++ b/Sources/PowerSync/PowerSyncDatabase.swift
@@ -7,14 +7,17 @@ public let DEFAULT_DB_FILENAME = "powersync.db"
 /// - Parameters:
 ///   - schema: The database schema
 ///   - dbFilename: The database filename. Defaults to "powersync.db"
+///   - logger: Optional logging interface
 /// - Returns: A configured PowerSyncDatabase instance
 public func PowerSyncDatabase(
     schema: Schema,
-    dbFilename: String = DEFAULT_DB_FILENAME
+    dbFilename: String = DEFAULT_DB_FILENAME,
+    logger: DatabaseLogger = DefaultLogger()
 ) -> PowerSyncDatabaseProtocol {
     
     return KotlinPowerSyncDatabaseImpl(
         schema: schema,
-        dbFilename: dbFilename
+        dbFilename: dbFilename,
+        logger: logger
     )
 }

--- a/Sources/PowerSync/PowerSyncDatabaseProtocol.swift
+++ b/Sources/PowerSync/PowerSyncDatabaseProtocol.swift
@@ -100,6 +100,12 @@ public protocol PowerSyncDatabaseProtocol: Queries {
     ///
     /// - Parameter clearLocal: Set to false to preserve data in local-only tables.
     func disconnectAndClear(clearLocal: Bool) async throws
+    
+    /// Close the database, releasing resources.
+    /// Also disconnects any active connection.
+    ///
+    /// Once close is called, this database cannot be used again - a new one must be constructed.
+    func close() async throws
 }
 
 public extension PowerSyncDatabaseProtocol {

--- a/Tests/PowerSyncTests/Kotlin/TestLogger.swift
+++ b/Tests/PowerSyncTests/Kotlin/TestLogger.swift
@@ -1,0 +1,23 @@
+@testable import PowerSync
+
+
+class TestLogWriterAdapter: LogWriterProtocol {
+    var logs = [String]()
+    
+    func log(severity: LogSeverity, message: String, tag: String) {
+        logs.append("\(severity): \(message) (\(tag))")
+    }
+}
+
+class TestLogger: DefaultLogger {
+    let writer = TestLogWriterAdapter()
+    
+    public var logs: [String] {
+            return writer.logs
+    }
+    
+    override init(minSeverity: LogSeverity = .debug) {
+        super.init(minSeverity: minSeverity)
+        setWriters([writer])
+    }
+}


### PR DESCRIPTION
# Overview

This adds the ability to specify a `logger` when creating a PowerSync database. The minimum log severity can be configured when creating a `DefaultLogger`.

Loggers also have the ability to specify custom `LogWriter`s which can transport logs to custom sinks.

The implementation here declares a Swift logging interface and maps this to a Kotlin Kermit logger which is used internally.