### PR TITLE
Update powersync-kotlin version

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -13,3 +13,4 @@ jobs:
       - name: Build and Test
         run: |
           xcodebuild test -scheme PowerSync -destination "platform=iOS Simulator,name=iPhone 15"
+          xcodebuild test -scheme PowerSync -destination "platform=macOS,arch=arm64,name=My Mac"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 1.0.0-Beta.10 (unreleased)
+# 1.0.0-Beta.10
 
 * Added the ability to specify a custom logging implementation
 ```swift
@@ -20,6 +20,13 @@
 )
 ```
 * added `.close()` method on `PowerSyncDatabaseProtocol`
+* Update `powersync-kotlin` dependency to version `1.0.0-BETA29`, which fixes these issues:
+  * Fix potential race condition between jobs in `connect()` and `disconnect()`.
+  * Fix race condition causing data received during uploads not to be applied.
+  * Fixed issue where automatic driver migrations would fail with the error:
+```
+Sqlite operation failure database is locked attempted to run migration and failed. closing connection
+```
 
 ## 1.0.0-Beta.9
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-kotlin.git",
       "state" : {
-        "revision" : "443df078f4b9352de137000b993d564d4ab019b7",
-        "version" : "1.0.0-BETA28.0"
+        "revision" : "f306c059580b4c4ee2b36eec3c68f4d5326a454c",
+        "version" : "1.0.0-BETA29.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,7 @@ let package = Package(
     name: packageName,
     platforms: [
         .iOS(.v13),
+        .macOS(.v10_15)
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
@@ -16,7 +17,7 @@ let package = Package(
             targets: ["PowerSync"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "1.0.0-BETA28.0"),
+        .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "1.0.0-BETA29.0"),
         .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", "0.3.12"..<"0.4.0")
     ],
     targets: [

--- a/Sources/PowerSync/PowerSyncBackendConnectorAdapter.swift
+++ b/Sources/PowerSync/PowerSyncBackendConnectorAdapter.swift
@@ -14,7 +14,7 @@ class PowerSyncBackendConnectorAdapter: KotlinPowerSyncBackendConnector {
             let result = try await swiftBackendConnector.fetchCredentials()
             return result?.kotlinCredentials
         } catch {
-            if #available(iOS 14.0, *) {
+            if #available(iOS 14.0, macOS 11.0, *) {
                 Logger().error("🔴 Failed to fetch credentials: \(error.localizedDescription)")
             } else {
                 print("🔴 Failed to fetch credentials: \(error.localizedDescription)")
@@ -28,7 +28,7 @@ class PowerSyncBackendConnectorAdapter: KotlinPowerSyncBackendConnector {
         do {
             return  try await swiftBackendConnector.uploadData(database: swiftDatabase)
         } catch {
-            if #available(iOS 14.0, *) {
+            if #available(iOS 14.0, macOS 11.0, *) {
                 Logger().error("🔴 Failed to upload data: \(error)")
             } else {
                 print("🔴 Failed to upload data: \(error)")


### PR DESCRIPTION
This updates `powersync-kotlin` to version `1.0.0-BETA29` and enables testing on macOS.