### PR TITLE
Prepare Kotlin update, add schema options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## unreleased
 
-- Add sync progress information through `SyncStatusData.downloadProgress`.
+* Add sync progress information through `SyncStatusData.downloadProgress`.
+* Add `trackPreviousValues` option on `Table` which sets `CrudEntry.previousValues` to previous values on updates.
+* Add `trackMetadata` option on `Table` which adds a `_metadata` column that can be used for updates.
+  The configured metadata is available through `CrudEntry.metadata`.
+* Add `ignoreEmptyUpdates` option which skips creating CRUD entries for updates that don't change any values.
 
 # 1.0.0
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,15 +1,6 @@
 {
   "pins" : [
     {
-      "identity" : "powersync-kotlin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/powersync-ja/powersync-kotlin.git",
-      "state" : {
-        "revision" : "ccd2e595195c59d570eb93a878ad6a5cfca72ada",
-        "version" : "1.0.1+SWIFT.0"
-      }
-    },
-    {
       "identity" : "powersync-sqlite-core-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-sqlite-core-swift.git",

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,35 @@
 import PackageDescription
 let packageName = "PowerSync"
 
+// Set this to the absolute path of your Kotlin SDK checkout if you want to use a local Kotlin
+// build. Also see docs/LocalBuild.md for details
+let localKotlinSdkOverride: String? = nil
+
+// Our target and dependency setup is different when a local Kotlin SDK is used. Without the local
+// SDK, we have no package dependency on Kotlin and download the XCFramework from Kotlin releases as
+// a binary target.
+// With a local SDK, we point to a `Package.swift` within the Kotlin SDK containing a target pointing
+// towards a local framework build
+var conditionalDependencies: [Package.Dependency] = []
+var conditionalTargets: [Target] = []
+var kotlinTargetDependency = Target.Dependency.target(name: "PowerSyncKotlin")
+
+if let kotlinSdkPath = localKotlinSdkOverride {
+    // We can't depend on local XCFrameworks outside of this project's root, so there's a Package.swift
+    // in the PowerSyncKotlin project pointing towards a local build.
+    conditionalDependencies.append(.package(path: "\(kotlinSdkPath)/PowerSyncKotlin"))
+
+    kotlinTargetDependency = .product(name: "PowerSyncKotlin", package: "PowerSyncKotlin")
+} else {
+    // Not using a local build, so download from releases
+    conditionalTargets.append(.binaryTarget(
+        name: "PowerSyncKotlin",
+        // TODO: Use GitHub release once https://github.com/powersync-ja/powersync-kotlin/releases/tag/untagged-fde4386dec502ec27067 is published
+        url: "https://fsn1.your-objectstorage.com/simon-public/powersync.zip",
+        checksum: "b6770dc22ae31315adc599e653fea99614226312fe861dbd8764e922a5a83b09"
+    ))
+}
+
 let package = Package(
     name: packageName,
     platforms: [
@@ -18,31 +47,19 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", "0.3.14"..<"0.4.0")
-    ],
+    ] + conditionalDependencies,
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: packageName,
             dependencies: [
-                .target(name: "PowerSyncKotlin"),
+                kotlinTargetDependency,
                 .product(name: "PowerSyncSQLiteCore", package: "powersync-sqlite-core-swift")
             ]),
         .testTarget(
             name: "PowerSyncTests",
             dependencies: ["PowerSync"]
         ),
-        // If you want to use a local build, comment out this reference and update the other.
-        // See docs/LocalBuild.md
-        .binaryTarget(
-            name: "PowerSyncKotlin",
-            // TODO: Use GitHub release once https://github.com/powersync-ja/powersync-kotlin/releases/tag/untagged-fde4386dec502ec27067 is published
-            url: "https://fsn1.your-objectstorage.com/simon-public/powersync.zip",
-            checksum: "b6770dc22ae31315adc599e653fea99614226312fe861dbd8764e922a5a83b09"
-        ),
-        // .binaryTarget(
-        //     name: "PowerSyncKotlin",
-        //     path: "/path/to/powersync-kotlin/PowerSyncKotlin/build/XCFrameworks/debug/PowerSyncKotlin.xcframework"
-        // )
-    ]
+    ] + conditionalTargets
 )

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,6 @@ let package = Package(
             targets: ["PowerSync"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", "1.0.1+SWIFT.0"..<"1.1.0+SWIFT.0"),
         .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", "0.3.14"..<"0.4.0")
     ],
     targets: [
@@ -26,12 +25,24 @@ let package = Package(
         .target(
             name: packageName,
             dependencies: [
-                .product(name: "PowerSyncKotlin", package: "powersync-kotlin"),
+                .target(name: "PowerSyncKotlin"),
                 .product(name: "PowerSyncSQLiteCore", package: "powersync-sqlite-core-swift")
             ]),
         .testTarget(
             name: "PowerSyncTests",
             dependencies: ["PowerSync"]
         ),
+        // If you want to use a local build, comment out this reference and update the other.
+        // See docs/LocalBuild.md
+        .binaryTarget(
+            name: "PowerSyncKotlin",
+            // TODO: Use GitHub release once https://github.com/powersync-ja/powersync-kotlin/releases/tag/untagged-fde4386dec502ec27067 is published
+            url: "https://fsn1.your-objectstorage.com/simon-public/powersync.zip",
+            checksum: "b6770dc22ae31315adc599e653fea99614226312fe861dbd8764e922a5a83b09"
+        ),
+        // .binaryTarget(
+        //     name: "PowerSyncKotlin",
+        //     path: "/path/to/powersync-kotlin/PowerSyncKotlin/build/XCFrameworks/debug/PowerSyncKotlin.xcframework"
+        // )
     ]
 )

--- a/Sources/PowerSync/Kotlin/KotlinAdapter.swift
+++ b/Sources/PowerSync/Kotlin/KotlinAdapter.swift
@@ -23,13 +23,25 @@ enum KotlinAdapter {
 
     struct Table {
         static func toKotlin(_ table: TableProtocol) -> PowerSyncKotlin.Table {
-            PowerSyncKotlin.Table(
+            let trackPreviousKotlin: PowerSyncKotlin.TrackPreviousValuesOptions? = if let track = table.trackPreviousValues {
+                PowerSyncKotlin.TrackPreviousValuesOptions(
+                    columnFilter: track.columnFilter,
+                    onlyWhenChanged: track.onlyWhenChanged
+                )
+            } else {
+                nil
+            }
+            
+            return PowerSyncKotlin.Table(
                 name: table.name,
                 columns: table.columns.map { Column.toKotlin($0) },
                 indexes: table.indexes.map { Index.toKotlin($0) },
                 localOnly: table.localOnly,
                 insertOnly: table.insertOnly,
-                viewNameOverride: table.viewNameOverride
+                viewNameOverride: table.viewNameOverride,
+                trackMetadata: table.trackMetadata,
+                trackPreviousValues: trackPreviousKotlin,
+                ignoreEmptyUpdates: table.ignoreEmptyUpdates,
             )
         }
     }

--- a/Sources/PowerSync/Kotlin/KotlinAdapter.swift
+++ b/Sources/PowerSync/Kotlin/KotlinAdapter.swift
@@ -41,7 +41,7 @@ enum KotlinAdapter {
                 viewNameOverride: table.viewNameOverride,
                 trackMetadata: table.trackMetadata,
                 trackPreviousValues: trackPreviousKotlin,
-                ignoreEmptyUpdates: table.ignoreEmptyUpdates,
+                ignoreEmptyUpdates: table.ignoreEmptyUpdates
             )
         }
     }

--- a/Sources/PowerSync/Kotlin/db/KotlinCrudEntry.swift
+++ b/Sources/PowerSync/Kotlin/db/KotlinCrudEntry.swift
@@ -28,9 +28,17 @@ struct KotlinCrudEntry : CrudEntry {
         entry.transactionId?.int64Value
     }
     
+    var metadata: String? {
+        entry.metadata
+    }
+    
     var opData: [String : String?]? {
         /// Kotlin represents this as Map<String, String?>, but this is
         /// converted to [String: Any] by SKIEE
         entry.opData?.mapValues { $0 as? String }
+    }
+    
+    var previousValues: [String : String?]? {
+        entry.previousValues?.mapValues { $0 as? String }
     }
 }

--- a/Sources/PowerSync/Protocol/db/CrudEntry.swift
+++ b/Sources/PowerSync/Protocol/db/CrudEntry.swift
@@ -44,6 +44,20 @@ public protocol CrudEntry {
     /// The transaction ID associated with the entry, if any.
     var transactionId: Int64? { get }
     
+    /// User-defined metadata that can be attached to writes.
+    ///
+    /// This is the value the `_metadata` column had when the write to the database was made,
+    /// allowing backend connectors to e.g. identify a write and tear it specially.
+    ///
+    /// Note that the `_metadata` column and this field are only available when ``Table/trackMetadata``
+    /// is enabled.
+    var metadata: String? { get }
+    
     /// The operation data associated with the entry, represented as a dictionary of column names to their values.
     var opData: [String: String?]? { get }
+
+    /// Previous values before this change.
+    ///
+    /// These values can be tracked for `UPDATE` statements when ``Table/trackPreviousValues`` is enabled.
+    var previousValues: [String: String?]? { get }
 }

--- a/Tests/PowerSyncTests/Schema/TableTests.swift
+++ b/Tests/PowerSyncTests/Schema/TableTests.swift
@@ -190,6 +190,35 @@ final class TableTests: XCTestCase {
         }
     }
     
+    func testInvalidLocalOnlyTrackMetadata() {
+        let table = Table(name: "test", columns: [Column.text("name")], localOnly: true, trackMetadata: true)
+        
+        XCTAssertThrowsError(try table.validate()) { error in
+            guard case TableError.metadataForLocalTable(let tableName) = error else {
+                XCTFail("Expected metadataForLocalTable error")
+                return
+            }
+            XCTAssertEqual(tableName, "test")
+        }
+    }
+    
+    func testInvalidLocalOnlyTrackPrevious() {
+        let table = Table(
+            name: "test_prev",
+            columns: [Column.text("name")],
+            localOnly: true,
+            trackPreviousValues: TrackPreviousValuesOptions()
+        )
+        
+        XCTAssertThrowsError(try table.validate()) { error in
+            guard case TableError.trackPreviousForLocalTable(let tableName) = error else {
+                XCTFail("Expected trackPreviousForLocalTable error")
+                return
+            }
+            XCTAssertEqual(tableName, "test_prev")
+        }
+    }
+    
     func testValidTableValidation() throws {
         let table = Table(
             name: "users",

--- a/docs/LocalBuild.md
+++ b/docs/LocalBuild.md
@@ -1,12 +1,23 @@
 # PowerSync Swift SDK
 
-## Run against a local kotlin build
+## Run against a local Kotlin build
 
-* To run using the local kotlin build you need to apply the following change in the `Package.swift` file:
+Especially when working on the Kotlin SDK, it may be helpful to test your local changes
+with the Swift SDK too.
+To do this, first create an XCFramework from your Kotlin checkout:
 
-  ```swift
-      dependencies: [
-          .package(url: "https://github.com/powersync-ja/powersync-kotlin.git", exact: "x.y.z"), <-- Comment this
-  //        .package(path: "../powersync-kotlin"), <-- Include this line and put in the path to you powersync-kotlin repo
-  ```
-* To quickly make a local build to apply changes you made in `powersync-kotlin` for local development in the Swift SDK run the gradle task `spmDevBuild` in `PowerSyncKotlin` in the `powersync-kotlin` repo. This will update the files and the changes will be reflected in the Swift SDK.
+```bash
+./gradlew PowerSyncKotlin:assemblePowerSyncKotlinDebugXCFramework
+```
+
+Then, point the `binaryTarget` dependency in `Package.swift` towards the path of your generated
+XCFramework:
+
+```Swift
+.binaryTarget(
+    name: "PowerSyncKotlin",
+    path: "/path/to/powersync-kotlin/PowerSyncKotlin/build/XCFrameworks/debug/PowerSyncKotlin.xcframework"
+)
+```
+
+Subsequent Kotlin changes should get picked up after re-assembling the Kotlin XCFramework.

--- a/docs/LocalBuild.md
+++ b/docs/LocalBuild.md
@@ -10,14 +10,12 @@ To do this, first create an XCFramework from your Kotlin checkout:
 ./gradlew PowerSyncKotlin:assemblePowerSyncKotlinDebugXCFramework
 ```
 
-Then, point the `binaryTarget` dependency in `Package.swift` towards the path of your generated
-XCFramework:
+Next, you need to update the `Package.swift` to, instead of downloading a
+prebuilt XCFramework archive from a Kotlin release, use your local build.
+For this, set the `localKotlinSdkOverride` variable to your path:
 
 ```Swift
-.binaryTarget(
-    name: "PowerSyncKotlin",
-    path: "/path/to/powersync-kotlin/PowerSyncKotlin/build/XCFrameworks/debug/PowerSyncKotlin.xcframework"
-)
+let localKotlinSdkOverride: String? = "/path/to/powersync-kotlin/"
 ```
 
 Subsequent Kotlin changes should get picked up after re-assembling the Kotlin XCFramework.


### PR DESCRIPTION
This prepares to update the Kotlin SDK (but we'll need to release the pending draft release first, which is the first one attaching the XCFramework). I've also changed the build logic to allow setting a local Kotlin build as a source in one place.

Additionally, this ports the new table options over with the same interface used on our other SDKs.

This depends on the draft release created by https://github.com/powersync-ja/powersync-kotlin/pull/190 to be released.