### PR TITLE
Default Param for CrudBatch Complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.1 (unreleased)
 
-* Added default `nil` value for `writeCheckpoint` parameter when calling `CrudBatch.complete()`. Developers no longer need to specify `nil` as an argument
+* Improved `CrudBatch` and `CrudTransaction` `complete` function extensions. Developers no longer need to specify `nil` as an argument for `writeCheckpoint` when calling `CrudBatch.complete`. The base `complete` functions still accepts an optional `writeCheckpoint` argument if developers use custom write checkpoints. 
 ``` diff
 guard let finalBatch = try await powersync.getCrudBatch(limit: 100) else {
   return nil

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.1.1 (unreleased)
 
-* Improved `CrudBatch` and `CrudTransaction` `complete` function extensions. Developers no longer need to specify `nil` as an argument for `writeCheckpoint` when calling `CrudBatch.complete`. The base `complete` functions still accepts an optional `writeCheckpoint` argument if developers use custom write checkpoints. 
+* Improved `CrudBatch` and `CrudTransaction` `complete` function extensions. Developers no longer need to specify `nil` as an argument for `writeCheckpoint` when calling `CrudBatch.complete`. The base `complete` functions still accept an optional `writeCheckpoint` argument if developers use custom write checkpoints. 
 ``` diff
 guard let finalBatch = try await powersync.getCrudBatch(limit: 100) else {
   return nil

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.1.1 (unreleased)
+
+* Added default `nil` value for `writeCheckpoint` parameter when calling `CrudBatch.complete()`. Developers no longer need to specify `nil` as an argument
+``` diff
+guard let finalBatch = try await powersync.getCrudBatch(limit: 100) else {
+  return nil
+}
+- try await batch.complete(writeCheckpoint: nil)
++ try await batch.complete()
+```
+
 ## 1.1.0
 
 * Add sync progress information through `SyncStatusData.downloadProgress`.

--- a/Sources/PowerSync/Protocol/db/CrudBatch.swift
+++ b/Sources/PowerSync/Protocol/db/CrudBatch.swift
@@ -16,11 +16,9 @@ public protocol CrudBatch {
 
 public extension CrudBatch {
     /// Call to remove the changes from the local queue, once successfully uploaded.
-    ///
-    /// `writeCheckpoint` is optional.
-    func complete(writeCheckpoint: String? = nil) async throws {
+    func complete() async throws {
         try await self.complete(
-            writeCheckpoint: writeCheckpoint
+            writeCheckpoint: nil
         )
     }
 }

--- a/Sources/PowerSync/Protocol/db/CrudBatch.swift
+++ b/Sources/PowerSync/Protocol/db/CrudBatch.swift
@@ -13,3 +13,14 @@ public protocol CrudBatch {
     /// `writeCheckpoint` is optional.
     func complete(writeCheckpoint: String?) async throws
 }
+
+public extension CrudBatch {
+    /// Call to remove the changes from the local queue, once successfully uploaded.
+    ///
+    /// `writeCheckpoint` is optional.
+    func complete(writeCheckpoint: String? = nil) async throws {
+        try await self.complete(
+            writeCheckpoint: writeCheckpoint
+        )
+    }
+}

--- a/Sources/PowerSync/Protocol/db/CrudTransaction.swift
+++ b/Sources/PowerSync/Protocol/db/CrudTransaction.swift
@@ -18,11 +18,9 @@ public protocol CrudTransaction {
 
 public extension CrudTransaction {
     /// Call to remove the changes from the local queue, once successfully uploaded.
-    ///
-    /// `writeCheckpoint` is optional.
-    func complete(writeCheckpoint: String? = nil) async throws {
+    func complete() async throws {
         try await self.complete(
-            writeCheckpoint: writeCheckpoint
+            writeCheckpoint: nil
         )
     }
 }


### PR DESCRIPTION
# Overview

The current `CrudBatch` protocol does not provide a default value for the `complete` method's optional `writeCheckpoint` parameter. This PR adds a Protocol extension which provides the default value.

