### PR TITLE
Support version 0.4.0 of powersync-sqlite-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ guard let finalBatch = try await powersync.getCrudBatch(limit: 100) else {
 + try await batch.complete()
 ```
 * Fix reported progress around compactions / defrags on the sync service.
-* Support version `0.4.0` of the core extension, which improves sync performance.
+* Use version `0.4.0` of the PowerSync core extension, which improves sync performance.
 
 ## 1.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ guard let finalBatch = try await powersync.getCrudBatch(limit: 100) else {
 + try await batch.complete()
 ```
 * Fix reported progress around compactions / defrags on the sync service.
+* Support version `0.4.0` of the core extension, which improves sync performance.
 
 ## 1.1.0
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-sqlite-core-swift.git",
       "state" : {
-        "revision" : "3a7fcb3be83db5b450effa5916726b19828cbcb7",
-        "version" : "0.3.14"
+        "revision" : "532952161e6150653e73cc3d59ef3f12b64b6a93",
+        "version" : "0.4.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
             targets: ["PowerSync"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", "0.3.14"..<"0.5.0")
+        .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", exact: "0.4.0")
     ] + conditionalDependencies,
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
             targets: ["PowerSync"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", "0.3.14"..<"0.4.0")
+        .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", "0.3.14"..<"0.5.0")
     ] + conditionalDependencies,
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
This tests the Swift SDK with version `0.4.0` of the core extension. It also adopts an exact dependency on `powersync-sqlite-core`, so that users downgrading the Swift SDK are guaranteed to also downgrade the core version.