### PR TITLE
watchOS support

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -14,3 +14,4 @@ jobs:
         run: |
           xcodebuild test -scheme PowerSync -destination "platform=iOS Simulator,name=iPhone 15"
           xcodebuild test -scheme PowerSync -destination "platform=macOS,arch=arm64,name=My Mac"
+          xcodebuild test -scheme PowerSync -destination "platform=watchOS Simulator,arch=arm64"


### PR DESCRIPTION
This adds watchOS support to the Swift SDK, as well as the ability to test the SDK with a local build of the core extension.