### PR TITLE
Update core extension to 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.1 (unreleased)
+
+* Use version `0.4.1` of the PowerSync core extension, which fixes an issue with the
+  new Rust client implementation.
+
 ## 1.2.0
 
 * Improved `CrudBatch` and `CrudTransaction` `complete` function extensions. Developers no longer need to specify `nil` as an argument for `writeCheckpoint` when calling `CrudBatch.complete`. The base `complete` functions still accept an optional `writeCheckpoint` argument if developers use custom write checkpoints. 

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-sqlite-core-swift.git",
       "state" : {
-        "revision" : "532952161e6150653e73cc3d59ef3f12b64b6a93",
-        "version" : "0.4.0"
+        "revision" : "06ae76a152e1868b04630f6810d9fe8a296cad35",
+        "version" : "0.4.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,7 @@ let package = Package(
             targets: ["PowerSync"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", exact: "0.4.0")
+        .package(url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git", exact: "0.4.1")
     ] + conditionalDependencies,
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.


### PR DESCRIPTION
This updates the version of the core extension to 0.4.1 ([release notes](https://github.com/powersync-ja/powersync-sqlite-core/releases/tag/v0.4.1)). The main benefit is that we properly reset statements with the new sync client with this update.