### PR TITLE
Update PowerSync Kotlin SDK to 1.2.1

### DIFF
--- a/Demo/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,21 +11,12 @@
       }
     },
     {
-      "identity" : "powersync-kotlin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/powersync-ja/powersync-kotlin.git",
-      "state" : {
-        "revision" : "ccd2e595195c59d570eb93a878ad6a5cfca72ada",
-        "version" : "1.0.1+SWIFT.0"
-      }
-    },
-    {
       "identity" : "powersync-sqlite-core-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-sqlite-core-swift.git",
       "state" : {
-        "revision" : "3a7fcb3be83db5b450effa5916726b19828cbcb7",
-        "version" : "0.3.14"
+        "revision" : "532952161e6150653e73cc3d59ef3f12b64b6a93",
+        "version" : "0.4.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,8 @@ if let kotlinSdkPath = localKotlinSdkOverride {
     // Not using a local build, so download from releases
     conditionalTargets.append(.binaryTarget(
         name: "PowerSyncKotlin",
-        url: "https://github.com/powersync-ja/powersync-kotlin/releases/download/v1.2.0/PowersyncKotlinRelease.zip",
-        checksum: "7454481a245b46b1b63a42419ec27f88f2fcb7fba9b763e3085cb49db59dfd58"
+        url: "https://github.com/powersync-ja/powersync-kotlin/releases/download/v1.2.1/PowersyncKotlinRelease.zip",
+        checksum: "c52c8c78d0b8f2225ec88f2e18163d01f707ecac66be5a0696f5fdd623ec80e5"
     ))
 }
 


### PR DESCRIPTION
This updates the Kotlin SDK to 1.2.1, fixing some issues with the Rust client (see the [changelog](https://github.com/powersync-ja/powersync-kotlin/releases/tag/v1.2.1)) as well as unblocking watchOS support.