### PR TITLE
Update Kotlin, prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## 1.2.1 (unreleased)
+## 1.2.1
 
 * Use version `0.4.1` of the PowerSync core extension, which fixes an issue with the
   new Rust client implementation.
+* Fix crud uploads when web sockets are used as a connection method.
 
 ## 1.2.0
 

--- a/Demo/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-sqlite-core-swift.git",
       "state" : {
-        "revision" : "532952161e6150653e73cc3d59ef3f12b64b6a93",
-        "version" : "0.4.0"
+        "revision" : "06ae76a152e1868b04630f6810d9fe8a296cad35",
+        "version" : "0.4.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -31,8 +31,8 @@ if let kotlinSdkPath = localKotlinSdkOverride {
     // Not using a local build, so download from releases
     conditionalTargets.append(.binaryTarget(
         name: "PowerSyncKotlin",
-        url: "https://github.com/powersync-ja/powersync-kotlin/releases/download/v1.2.1/PowersyncKotlinRelease.zip",
-        checksum: "c52c8c78d0b8f2225ec88f2e18163d01f707ecac66be5a0696f5fdd623ec80e5"
+        url: "https://github.com/powersync-ja/powersync-kotlin/releases/download/v1.2.2/PowersyncKotlinRelease.zip",
+        checksum: "51ddc7d48fa85e881c33a26ca63e4aae694ae16789368f9fbba20a467279fb97"
     ))
 }
 


### PR DESCRIPTION
This updates the PowerSync Kotlin SDK to the most recent version (1.2.2) and updates the changelog to prepare a release for the Swift SDK.