### PR TITLE
Update core extension to 0.4.2

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-sqlite-core-swift.git",
       "state" : {
-        "revision" : "06ae76a152e1868b04630f6810d9fe8a296cad35",
-        "version" : "0.4.1"
+        "revision" : "21057135ce8269b43582022aa4ca56407332e6a8",
+        "version" : "0.4.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ if let corePath = localCoreExtension {
     // Not using a local build, so download from releases
     conditionalDependencies.append(.package(
         url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git",
-        exact: "0.4.1"
+        exact: "0.4.2"
     ))
 }
 


### PR DESCRIPTION
This updates the core extension to 0.4.2. For release notes, see: https://github.com/powersync-ja/powersync-sqlite-core/releases/tag/v0.4.2