### PR TITLE
Add network logging support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.4.0
+## 1.4.0 (unreleased)
 
 * Added the ability to log PowerSync sync network requests.
 
@@ -18,6 +18,7 @@ try await database.connect(
         )
     )
 )
+
 ```
 ## 1.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## 1.4.0
 
-* Added the ability to log PowerSync network requests.
+* Added the ability to log PowerSync sync network requests.
+
 ```swift
-struct InlineLogger: NetworkLogger {
+struct InlineLogger: SyncRequestLogger {
     func log(_ message: String) {
         print("Network: \(message)")
     }
@@ -14,7 +15,7 @@ try await db.connect(
                 connector: connector,
                 options: ConnectOptions(
                     clientConfiguration: SyncClientConfiguration(
-                        networkLogger: NetworkLoggerConfig(
+                        requestLogger: SyncRequestLoggerConfiguration(
                             logLevel: .headers,
                             logger: InlineLogger()
                         )

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 1.4.0
+
+* Added the ability to log PowerSync network requests.
+```swift
+struct InlineLogger: NetworkLogger {
+    func log(_ message: String) {
+        print("Network: \(message)")
+    }
+}
+
+try await db.connect(
+                connector: connector,
+                options: ConnectOptions(
+                    clientConfiguration: SyncClientConfiguration(
+                        networkLogger: NetworkLoggerConfig(
+                            logLevel: .headers,
+                            logger: InlineLogger()
+                        )
+                    )
+                )
+            )
+```
+
 ## 1.3.0
 
 * Use version `0.4.2` of the PowerSync core extension, which improves the reliability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,19 @@
 * Added the ability to log PowerSync sync network requests.
 
 ```swift
-struct InlineLogger: SyncRequestLogger {
-    func log(_ message: String) {
-        print("Network: \(message)")
-    }
-}
-
-try await db.connect(
-                connector: connector,
-                options: ConnectOptions(
-                    clientConfiguration: SyncClientConfiguration(
-                        requestLogger: SyncRequestLoggerConfiguration(
-                            logLevel: .headers,
-                            logger: InlineLogger()
-                        )
-                    )
-                )
-            )
+try await database.connect(
+    connector: Connector(),
+    options: ConnectOptions(
+        clientConfiguration: SyncClientConfiguration(
+            requestLogger: SyncRequestLoggerConfiguration(
+                requestLevel: .headers
+            ) { message in
+                // Handle Network request logs here
+                print(message)
+            }
+        )
+    )
+)
 ```
 ## 1.3.1
 

--- a/Demo/PowerSyncExample/PowerSync/SystemManager.swift
+++ b/Demo/PowerSyncExample/PowerSync/SystemManager.swift
@@ -13,6 +13,12 @@ func getAttachmentsDirectoryPath() throws -> String {
 
 let logTag = "SystemManager"
 
+struct InlineLogger: NetworkLogger {
+    func log(_ message: String) {
+        print("Network: \(message)")
+    }
+}
+
 @Observable
 class SystemManager {
     let connector = SupabaseConnector()
@@ -70,7 +76,17 @@ class SystemManager {
 
     func connect() async {
         do {
-            try await db.connect(connector: connector)
+            try await db.connect(
+                connector: connector,
+                options: ConnectOptions(
+                    clientConfiguration: SyncClientConfiguration(
+                        networkLogger: NetworkLoggerConfig(
+                            logLevel: .headers,
+                            logger: InlineLogger()
+                        )
+                    )
+                )
+            )
             try await attachments?.startSync()
         } catch {
             print("Unexpected error: \(error.localizedDescription)") // Catches any other error

--- a/Demo/PowerSyncExample/PowerSync/SystemManager.swift
+++ b/Demo/PowerSyncExample/PowerSync/SystemManager.swift
@@ -13,7 +13,7 @@ func getAttachmentsDirectoryPath() throws -> String {
 
 let logTag = "SystemManager"
 
-struct InlineLogger: NetworkLogger {
+struct InlineLogger: SyncRequestLogger {
     func log(_ message: String) {
         print("Network: \(message)")
     }
@@ -80,7 +80,7 @@ class SystemManager {
                 connector: connector,
                 options: ConnectOptions(
                     clientConfiguration: SyncClientConfiguration(
-                        networkLogger: NetworkLoggerConfig(
+                        requestLogger: SyncRequestLoggerConfiguration(
                             logLevel: .headers,
                             logger: InlineLogger()
                         )

--- a/Demo/PowerSyncExample/PowerSync/SystemManager.swift
+++ b/Demo/PowerSyncExample/PowerSync/SystemManager.swift
@@ -13,12 +13,6 @@ func getAttachmentsDirectoryPath() throws -> String {
 
 let logTag = "SystemManager"
 
-struct InlineLogger: SyncRequestLogger {
-    func log(_ message: String) {
-        print("Network: \(message)")
-    }
-}
-
 @Observable
 class SystemManager {
     let connector = SupabaseConnector()
@@ -81,9 +75,10 @@ class SystemManager {
                 options: ConnectOptions(
                     clientConfiguration: SyncClientConfiguration(
                         requestLogger: SyncRequestLoggerConfiguration(
-                            logLevel: .headers,
-                            logger: InlineLogger()
-                        )
+                            requestLevel: .headers
+                        ) { message in
+                            self.db.logger.debug(message, tag: "SyncRequest")
+                        }
                     )
                 )
             )

--- a/Package.swift
+++ b/Package.swift
@@ -31,8 +31,8 @@ if let kotlinSdkPath = localKotlinSdkOverride {
     // Not using a local build, so download from releases
     conditionalTargets.append(.binaryTarget(
         name: "PowerSyncKotlin",
-        url: "https://github.com/powersync-ja/powersync-kotlin/releases/download/v1.3.1/PowersyncKotlinRelease.zip",
-        checksum: "b01b72cbf88a2e7b9b67efce966799493fc48d4523b5989d8c645ed182880975"
+        url: "https://github.com/powersync-ja/powersync-kotlin/releases/download/v1.4.0/PowersyncKotlinRelease.zip",
+        checksum: "e800db216fc1c9722e66873deb4f925530267db6dbd5e2114dd845cc62c28cd9"
     ))
 }
 

--- a/Sources/PowerSync/Kotlin/KotlinNetworkLogger.swift
+++ b/Sources/PowerSync/Kotlin/KotlinNetworkLogger.swift
@@ -20,9 +20,9 @@ extension SyncRequestLogLevel {
 extension SyncRequestLoggerConfiguration {
     func toKotlinConfig() -> SwiftRequestLoggerConfig {
         return SwiftRequestLoggerConfig(
-            logLevel: self.logLevel.toKotlin(),
-            log: { [logger] message in
-                logger.log(message)
+            logLevel: self.requestLevel.toKotlin(),
+            log: { [log] message in
+                log(message)
             }
         )
     }

--- a/Sources/PowerSync/Kotlin/KotlinNetworkLogger.swift
+++ b/Sources/PowerSync/Kotlin/KotlinNetworkLogger.swift
@@ -1,25 +1,25 @@
 import PowerSyncKotlin
 
-extension NetworkLogLevel {
-    func toKotlin() -> SwiftNetworkLogLevel {
+extension SyncRequestLogLevel {
+    func toKotlin() -> SwiftSyncRequestLogLevel {
         switch self {
             case .all:
-                return SwiftNetworkLogLevel.all
+                return SwiftSyncRequestLogLevel.all
             case .headers:
-                return SwiftNetworkLogLevel.headers
+                return SwiftSyncRequestLogLevel.headers
             case .body:
-                return SwiftNetworkLogLevel.body
+                return SwiftSyncRequestLogLevel.body
             case .info:
-                return SwiftNetworkLogLevel.info
+                return SwiftSyncRequestLogLevel.info
             case .none:
-                return SwiftNetworkLogLevel.none
+                return SwiftSyncRequestLogLevel.none
         }
     }
 }
 
-extension NetworkLoggerConfig {
-    func toKotlinConfig() -> SwiftNetworkLoggerConfig {
-        return SwiftNetworkLoggerConfig(
+extension SyncRequestLoggerConfiguration {
+    func toKotlinConfig() -> SwiftRequestLoggerConfig {
+        return SwiftRequestLoggerConfig(
             logLevel: self.logLevel.toKotlin(),
             log: { [logger] message in
                 logger.log(message)

--- a/Sources/PowerSync/Kotlin/KotlinNetworkLogger.swift
+++ b/Sources/PowerSync/Kotlin/KotlinNetworkLogger.swift
@@ -1,0 +1,29 @@
+import PowerSyncKotlin
+
+extension NetworkLogLevel {
+    func toKotlin() -> SwiftNetworkLogLevel {
+        switch self {
+            case .all:
+                return SwiftNetworkLogLevel.all
+            case .headers:
+                return SwiftNetworkLogLevel.headers
+            case .body:
+                return SwiftNetworkLogLevel.body
+            case .info:
+                return SwiftNetworkLogLevel.info
+            case .none:
+                return SwiftNetworkLogLevel.none
+        }
+    }
+}
+
+extension NetworkLoggerConfig {
+    func toKotlinConfig() -> SwiftNetworkLoggerConfig {
+        return SwiftNetworkLoggerConfig(
+            logLevel: self.logLevel.toKotlin(),
+            log: { [logger] message in
+                logger.log(message)
+            }
+        )
+    }
+}

--- a/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
+++ b/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
@@ -61,7 +61,7 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
             options: createSyncOptions(
                 newClient: resolvedOptions.newClientImplementation,
                 userAgent: "PowerSync Swift SDK",
-                loggingConfig: resolvedOptions.clientConfiguration?.networkLogger?.toKotlinConfig()
+                loggingConfig: resolvedOptions.clientConfiguration?.requestLogger?.toKotlinConfig()
             )
         )
     }

--- a/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
+++ b/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
@@ -52,10 +52,6 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
         )
 
         let resolvedOptions = options ?? ConnectOptions()
-        let useWebsockets = switch (resolvedOptions.connectionMethod) {
-            case .http: false
-            case .webSocket: true
-        }
 
         try await kotlinDatabase.connect(
             connector: connectorAdapter,
@@ -64,8 +60,8 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
             params: resolvedOptions.params.mapValues { $0.toKotlinMap() },
             options: createSyncOptions(
                 newClient: resolvedOptions.newClientImplementation,
-                webSocket: useWebsockets,
-                userAgent: "PowerSync Swift SDK"
+                userAgent: "PowerSync Swift SDK",
+                loggingConfig: resolvedOptions.clientConfiguration?.networkLogger?.toKotlinConfig()
             )
         )
     }

--- a/Sources/PowerSync/Protocol/NetworkLogger.swift
+++ b/Sources/PowerSync/Protocol/NetworkLogger.swift
@@ -1,0 +1,54 @@
+/// A logger which handles PowerSync network request logs.
+///
+/// Implement this protocol to receive network logging messages at the level
+/// specified in `NetworkLoggerConfig`. The `log(_:)` method will be called
+/// for each network event that meets the configured logging criteria.
+public protocol NetworkLogger {
+    /// Logs a network-related message.
+    /// - Parameter message: The formatted log message to record
+    func log(_ message: String)
+}
+
+/// Level of logs to expose to a `NetworkLogger` handler.
+///
+/// Controls the verbosity of network logging for PowerSync HTTP requests.
+/// The log level is configured once during initialization and determines
+/// which network events will be logged throughout the session.
+public enum NetworkLogLevel {
+    /// Log all network activity including headers, body, and info
+    case all
+    /// Log only request/response headers
+    case headers
+    /// Log only request/response body content
+    case body
+    /// Log basic informational messages about requests
+    case info
+    /// Disable all network logging
+    case none
+}
+
+/// Configuration for PowerSync HTTP request logging.
+///
+/// This configuration is set once during initialization and used throughout
+/// the PowerSync session. The `logLevel` determines which network events
+/// are logged, while the `logger` handles the actual log output.
+///
+/// - Note: The log level cannot be changed after initialization. A new call to `PowerSyncDatabase.connect` is required to change the level.
+public struct NetworkLoggerConfig {
+    /// The logging level that determines which network events are logged.
+    /// Set once during initialization and used throughout the session.
+    public let logLevel: NetworkLogLevel
+    
+    /// The logger instance that receives network log messages.
+    /// Must conform to `NetworkLogger` protocol.
+    public let logger: NetworkLogger
+    
+    /// Creates a new network logger configuration.
+    /// - Parameters:
+    ///   - logLevel: The `NetworkLogLevel` to use for filtering log messages
+    ///   - logger: A `NetworkLogger` instance to handle log output
+    public init(logLevel: NetworkLogLevel, logger: NetworkLogger) {
+        self.logLevel = logLevel
+        self.logger = logger
+    }
+}

--- a/Sources/PowerSync/Protocol/PowerSyncDatabaseProtocol.swift
+++ b/Sources/PowerSync/Protocol/PowerSyncDatabaseProtocol.swift
@@ -8,10 +8,7 @@ public struct SyncClientConfiguration {
     /// Optional configuration for logging PowerSync HTTP requests.
     ///
     /// When provided, network requests will be logged according to the
-    /// specified `SyncRequestLogLevel`. The `logLevel` is set during initialization
-    /// and remains constant throughout the PowerSync session.
-    ///
-    /// Set to `nil` to disable request logging entirely.
+    /// specified `SyncRequestLoggerConfiguration`. Set to `nil` to disable request logging entirely.
     ///
     /// - SeeAlso: `SyncRequestLoggerConfiguration` for configuration options
     public let requestLogger: SyncRequestLoggerConfiguration?

--- a/Sources/PowerSync/Protocol/PowerSyncDatabaseProtocol.swift
+++ b/Sources/PowerSync/Protocol/PowerSyncDatabaseProtocol.swift
@@ -8,18 +8,18 @@ public struct SyncClientConfiguration {
     /// Optional configuration for logging PowerSync HTTP requests.
     ///
     /// When provided, network requests will be logged according to the
-    /// specified `NetworkLogLevel`. The `logLevel` is set during initialization
+    /// specified `SyncRequestLogLevel`. The `logLevel` is set during initialization
     /// and remains constant throughout the PowerSync session.
     ///
-    /// Set to `nil` to disable network logging entirely.
+    /// Set to `nil` to disable request logging entirely.
     ///
-    /// - SeeAlso: `NetworkLoggerConfig` for configuration options
-    public let networkLogger: NetworkLoggerConfig?
+    /// - SeeAlso: `SyncRequestLoggerConfiguration` for configuration options
+    public let requestLogger: SyncRequestLoggerConfiguration?
     
     /// Creates a new sync client configuration.
-    /// - Parameter networkLogger: Optional network logger configuration
-    public init(networkLogger: NetworkLoggerConfig? = nil) {
-        self.networkLogger = networkLogger
+    /// - Parameter requestLogger: Optional network logger configuration
+    public init(requestLogger: SyncRequestLoggerConfiguration? = nil) {
+        self.requestLogger = requestLogger
     }
 }
 

--- a/Sources/PowerSync/Protocol/PowerSyncDatabaseProtocol.swift
+++ b/Sources/PowerSync/Protocol/PowerSyncDatabaseProtocol.swift
@@ -215,7 +215,7 @@ public protocol PowerSyncDatabaseProtocol: Queries {
     /// The database can still be queried after this is called, but the tables
     /// would be empty.
     ///
-    /// - Parameter clearLocal: Set to false to preserve data in local-only tables.
+    /// - Parameter clearLocal: Set to false to preserve data in local-only tables. Defaults to `true`.
     func disconnectAndClear(clearLocal: Bool) async throws
     
     /// Close the database, releasing resources.
@@ -265,8 +265,8 @@ public extension PowerSyncDatabaseProtocol {
         )
     }
     
-    func disconnectAndClear(clearLocal: Bool = true) async throws {
-        try await disconnectAndClear(clearLocal: clearLocal)
+    func disconnectAndClear() async throws {
+        try await disconnectAndClear(clearLocal: true)
     }
     
     func getCrudBatch(limit: Int32 = 100) async throws -> CrudBatch? {

--- a/Sources/PowerSync/Protocol/SyncRequestLogger.swift
+++ b/Sources/PowerSync/Protocol/SyncRequestLogger.swift
@@ -22,7 +22,7 @@ public enum SyncRequestLogLevel {
 /// the PowerSync session. The `requestLevel` determines which network events
 /// are logged.
 ///
-/// - Note: The request levell cannot be changed after initialization. A new call to `PowerSyncDatabase.connect` is required to change the level.
+/// - Note: The request level cannot be changed after initialization. A new call to `PowerSyncDatabase.connect` is required to change the level.
 public struct SyncRequestLoggerConfiguration {
     /// The request logging level that determines which network events are logged.
     /// Set once during initialization and used throughout the session.
@@ -33,7 +33,7 @@ public struct SyncRequestLoggerConfiguration {
     /// Creates a new network logger configuration.
     /// - Parameters:
     ///   - requestLevel: The `SyncRequestLogLevel` to use for filtering log messages
-    ///   - logHandler: A  closure which handles log messages
+    ///   - logHandler: A closure which handles log messages
     public init(
         requestLevel: SyncRequestLogLevel,
         logHandler: @escaping (_ message: String) -> Void)

--- a/Sources/PowerSync/Protocol/SyncRequestLogger.swift
+++ b/Sources/PowerSync/Protocol/SyncRequestLogger.swift
@@ -1,14 +1,3 @@
-/// A logger which handles PowerSync network request logs.
-///
-/// Implement this protocol to receive network request logging messages at the level
-/// specified in `SyncRequestLoggerConfiguration`. The `log(_:)` method will be called
-/// for each network event that meets the configured logging criteria.
-public protocol SyncRequestLogger {
-    /// Logs a network-related message.
-    /// - Parameter message: The formatted log message to record
-    func log(_ message: String)
-}
-
 /// Level of logs to expose to a `SyncRequestLogger` handler.
 ///
 /// Controls the verbosity of network logging for PowerSync HTTP requests.
@@ -30,25 +19,65 @@ public enum SyncRequestLogLevel {
 /// Configuration for PowerSync HTTP request logging.
 ///
 /// This configuration is set once during initialization and used throughout
-/// the PowerSync session. The `logLevel` determines which network events
-/// are logged, while the `logger` handles the actual log output.
+/// the PowerSync session. The `requestLevel` determines which network events
+/// are logged.
 ///
-/// - Note: The log level cannot be changed after initialization. A new call to `PowerSyncDatabase.connect` is required to change the level.
+/// - Note: The request levell cannot be changed after initialization. A new call to `PowerSyncDatabase.connect` is required to change the level.
 public struct SyncRequestLoggerConfiguration {
-    /// The logging level that determines which network events are logged.
+    /// The request logging level that determines which network events are logged.
     /// Set once during initialization and used throughout the session.
-    public let logLevel: SyncRequestLogLevel
+    public let requestLevel: SyncRequestLogLevel
     
-    /// The logger instance that receives network request log messages.
-    /// Must conform to `SyncRequestLogger` protocol.
-    public let logger: SyncRequestLogger
+    private let logHandler: (_ message: String) -> Void
     
     /// Creates a new network logger configuration.
     /// - Parameters:
-    ///   - logLevel: The `SyncRequestLogLevel` to use for filtering log messages
-    ///   - logger: A `SyncRequestLogger` instance to handle log output
-    public init(logLevel: SyncRequestLogLevel, logger: SyncRequestLogger) {
-        self.logLevel = logLevel
-        self.logger = logger
+    ///   - requestLevel: The `SyncRequestLogLevel` to use for filtering log messages
+    ///   - logHandler: A  closure which handles log messages
+    public init(
+        requestLevel: SyncRequestLogLevel,
+        logHandler: @escaping (_ message: String) -> Void)
+    {
+        self.requestLevel = requestLevel
+        self.logHandler = logHandler
+    }
+    
+    public func log(_ message: String) {
+        logHandler(message)
+    }
+    
+    /// Creates a new network logger configuration using a `LoggerProtocol` instance.
+    ///
+    /// This initializer allows integration with an existing logging framework by adapting
+    /// a `LoggerProtocol` to conform to `SyncRequestLogger`. The specified `logSeverity`
+    /// controls the severity level at which log messages are recorded. An optional `logTag`
+    /// may be used to help categorize logs.
+    ///
+    /// - Parameters:
+    ///   - requestLevel: The `SyncRequestLogLevel` to use for filtering which network events are logged.
+    ///   - logger: An object conforming to `LoggerProtocol` that will receive log messages.
+    ///   - logSeverity: The severity level to use for all log messages (defaults to `.debug`).
+    ///   - logTag: An optional tag to include with each log message, for use by the logging backend.
+    public init(
+        requestLevel: SyncRequestLogLevel,
+        logger: LoggerProtocol,
+        logSeverity: LogSeverity = .debug,
+        logTag: String? = nil)
+    {
+        self.requestLevel = requestLevel
+        self.logHandler = { message in
+            switch logSeverity {
+                case .debug:
+                    logger.debug(message, tag: logTag)
+                case .info:
+                    logger.info(message, tag: logTag)
+                case .warning:
+                    logger.warning(message, tag: logTag)
+                case .error:
+                    logger.error(message, tag: logTag)
+                case .fault:
+                    logger.fault(message, tag: logTag)
+            }
+        }
     }
 }

--- a/Sources/PowerSync/Protocol/SyncRequestLogger.swift
+++ b/Sources/PowerSync/Protocol/SyncRequestLogger.swift
@@ -1,20 +1,20 @@
 /// A logger which handles PowerSync network request logs.
 ///
-/// Implement this protocol to receive network logging messages at the level
-/// specified in `NetworkLoggerConfig`. The `log(_:)` method will be called
+/// Implement this protocol to receive network request logging messages at the level
+/// specified in `SyncRequestLoggerConfiguration`. The `log(_:)` method will be called
 /// for each network event that meets the configured logging criteria.
-public protocol NetworkLogger {
+public protocol SyncRequestLogger {
     /// Logs a network-related message.
     /// - Parameter message: The formatted log message to record
     func log(_ message: String)
 }
 
-/// Level of logs to expose to a `NetworkLogger` handler.
+/// Level of logs to expose to a `SyncRequestLogger` handler.
 ///
 /// Controls the verbosity of network logging for PowerSync HTTP requests.
 /// The log level is configured once during initialization and determines
 /// which network events will be logged throughout the session.
-public enum NetworkLogLevel {
+public enum SyncRequestLogLevel {
     /// Log all network activity including headers, body, and info
     case all
     /// Log only request/response headers
@@ -34,20 +34,20 @@ public enum NetworkLogLevel {
 /// are logged, while the `logger` handles the actual log output.
 ///
 /// - Note: The log level cannot be changed after initialization. A new call to `PowerSyncDatabase.connect` is required to change the level.
-public struct NetworkLoggerConfig {
+public struct SyncRequestLoggerConfiguration {
     /// The logging level that determines which network events are logged.
     /// Set once during initialization and used throughout the session.
-    public let logLevel: NetworkLogLevel
+    public let logLevel: SyncRequestLogLevel
     
-    /// The logger instance that receives network log messages.
-    /// Must conform to `NetworkLogger` protocol.
-    public let logger: NetworkLogger
+    /// The logger instance that receives network request log messages.
+    /// Must conform to `SyncRequestLogger` protocol.
+    public let logger: SyncRequestLogger
     
     /// Creates a new network logger configuration.
     /// - Parameters:
-    ///   - logLevel: The `NetworkLogLevel` to use for filtering log messages
-    ///   - logger: A `NetworkLogger` instance to handle log output
-    public init(logLevel: NetworkLogLevel, logger: NetworkLogger) {
+    ///   - logLevel: The `SyncRequestLogLevel` to use for filtering log messages
+    ///   - logger: A `SyncRequestLogger` instance to handle log output
+    public init(logLevel: SyncRequestLogLevel, logger: SyncRequestLogger) {
         self.logLevel = logLevel
         self.logger = logger
     }

--- a/Tests/PowerSyncTests/ConnectTests.swift
+++ b/Tests/PowerSyncTests/ConnectTests.swift
@@ -128,5 +128,7 @@ final class ConnectTests: XCTestCase {
         )
         
         await fulfillment(of: [expectation], timeout: 5)
+        
+        try await database.disconnectAndClear()
     }
 }

--- a/Tests/PowerSyncTests/ConnectTests.swift
+++ b/Tests/PowerSyncTests/ConnectTests.swift
@@ -96,7 +96,7 @@ final class ConnectTests: XCTestCase {
         
         let fakeUrl = "https://fakepowersyncinstance.fakepowersync.local"
         
-        struct InlineLogger: NetworkLogger {
+        struct InlineLogger: SyncRequestLogger {
             let logger: (_: String) -> Void
             
             func log(_ message: String) {
@@ -130,7 +130,7 @@ final class ConnectTests: XCTestCase {
             connector: TestConnector(url: fakeUrl),
             options: ConnectOptions(
                 clientConfiguration: SyncClientConfiguration(
-                    networkLogger: NetworkLoggerConfig(
+                    requestLogger: SyncRequestLoggerConfiguration(
                         logLevel:
                         .all,
                         logger: testLogger

--- a/Tests/PowerSyncTests/ConnectTests.swift
+++ b/Tests/PowerSyncTests/ConnectTests.swift
@@ -96,21 +96,6 @@ final class ConnectTests: XCTestCase {
         
         let fakeUrl = "https://fakepowersyncinstance.fakepowersync.local"
         
-        struct InlineLogger: SyncRequestLogger {
-            let logger: (_: String) -> Void
-            
-            func log(_ message: String) {
-                logger(message)
-            }
-        }
-        
-        let testLogger = InlineLogger { message in
-            // We want to see a request to the specified instance
-            if message.contains(fakeUrl) {
-                expectation.fulfill()
-            }
-        }
-        
         class TestConnector: PowerSyncBackendConnector {
             let url: String
             
@@ -131,10 +116,13 @@ final class ConnectTests: XCTestCase {
             options: ConnectOptions(
                 clientConfiguration: SyncClientConfiguration(
                     requestLogger: SyncRequestLoggerConfiguration(
-                        logLevel:
-                        .all,
-                        logger: testLogger
-                    )
+                        requestLevel: .all
+                    ) { message in
+                        // We want to see a request to the specified instance
+                        if message.contains(fakeUrl) {
+                            expectation.fulfill()
+                        }
+                    }
                 )
             )
         )


### PR DESCRIPTION
# Overview

This adds the ability to log PowerSync network requests. This is the Swift port of https://github.com/powersync-ja/powersync-kotlin/pull/229.

This also removes the experimental `ConnectionMethod` options which have recently been removed from the Kotlin SDK.