### PR TITLE
Update Kotlin SDK to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.3.1
+
+* Update SQLite to 3.50.3.
+* Support receiving binary sync lines over HTTP when the Rust client is enabled.
+* Remove the experimental websocket transport mode.
+
 ## 1.3.0
 
 * Use version `0.4.2` of the PowerSync core extension, which improves the reliability

--- a/Package.swift
+++ b/Package.swift
@@ -31,8 +31,8 @@ if let kotlinSdkPath = localKotlinSdkOverride {
     // Not using a local build, so download from releases
     conditionalTargets.append(.binaryTarget(
         name: "PowerSyncKotlin",
-        url: "https://github.com/powersync-ja/powersync-kotlin/releases/download/v1.3.0/PowersyncKotlinRelease.zip",
-        checksum: "5351c0a89e74ceaad570cd5c016c8ea4b8e10dc404daff3c20485ae0b6b989fa"
+        url: "https://github.com/powersync-ja/powersync-kotlin/releases/download/v1.3.1/PowersyncKotlinRelease.zip",
+        checksum: "b01b72cbf88a2e7b9b67efce966799493fc48d4523b5989d8c645ed182880975"
     ))
 }
 

--- a/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
+++ b/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
@@ -52,11 +52,6 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
         )
 
         let resolvedOptions = options ?? ConnectOptions()
-        let useWebsockets = switch (resolvedOptions.connectionMethod) {
-            case .http: false
-            case .webSocket: true
-        }
-
         try await kotlinDatabase.connect(
             connector: connectorAdapter,
             crudThrottleMs: Int64(resolvedOptions.crudThrottle * 1000),
@@ -64,7 +59,6 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol {
             params: resolvedOptions.params.mapValues { $0.toKotlinMap() },
             options: createSyncOptions(
                 newClient: resolvedOptions.newClientImplementation,
-                webSocket: useWebsockets,
                 userAgent: "PowerSync Swift SDK"
             )
         )

--- a/Sources/PowerSync/Protocol/PowerSyncDatabaseProtocol.swift
+++ b/Sources/PowerSync/Protocol/PowerSyncDatabaseProtocol.swift
@@ -65,19 +65,13 @@ public struct ConnectOptions {
         crudThrottle: TimeInterval = 1,
         retryDelay: TimeInterval = 5,
         params: JsonParam = [:],
-        newClientImplementation: Bool = false,
+        newClientImplementation: Bool = false
     ) {
         self.crudThrottle = crudThrottle
         self.retryDelay = retryDelay
         self.params = params
         self.newClientImplementation = newClientImplementation
     }
-}
-
-@_spi(PowerSyncExperimental)
-public enum ConnectionMethod {
-    case http
-    case webSocket
 }
 
 /// A PowerSync managed database.

--- a/Sources/PowerSync/Protocol/PowerSyncDatabaseProtocol.swift
+++ b/Sources/PowerSync/Protocol/PowerSyncDatabaseProtocol.swift
@@ -41,14 +41,6 @@ public struct ConnectOptions {
     /// We encourage interested users to try the new client.
     @_spi(PowerSyncExperimental)
     public var newClientImplementation: Bool
-
-    /// The connection method used to connect to the Powersync service.
-    ///
-    /// The default method is ``ConnectionMethod/http``. Using ``ConnectionMethod/webSocket(_:)`` can
-    /// improve performance as a more efficient binary protocol is used. However, using the websocket connection method
-    /// requires enabling ``ConnectOptions/newClientImplementation``.
-    @_spi(PowerSyncExperimental)
-    public var connectionMethod: ConnectionMethod
     
     /// Initializes a `ConnectOptions` instance with optional values.
     ///
@@ -65,7 +57,6 @@ public struct ConnectOptions {
         self.retryDelay = retryDelay
         self.params = params
         self.newClientImplementation = false
-        self.connectionMethod = .http
     }
     
     /// Initializes a ``ConnectOptions`` instance with optional values, including experimental options.
@@ -75,13 +66,11 @@ public struct ConnectOptions {
         retryDelay: TimeInterval = 5,
         params: JsonParam = [:],
         newClientImplementation: Bool = false,
-        connectionMethod: ConnectionMethod = .http
     ) {
         self.crudThrottle = crudThrottle
         self.retryDelay = retryDelay
         self.params = params
         self.newClientImplementation = newClientImplementation
-        self.connectionMethod = connectionMethod
     }
 }
 


### PR DESCRIPTION
This updates the Kotlin SDK framework to 1.3.1, removes the option to connect with websockets and prepares a release of the Swift SDK.