### PR TITLE
[Internal] Logger Updates

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -10,6 +10,11 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up XCode
+        if: runner.os == 'macOS'
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
       - name: Build and Test
         run: |
           xcodebuild test -scheme PowerSync -destination "platform=iOS Simulator,name=iPhone 15"

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -17,6 +17,6 @@ jobs:
           xcode-version: latest-stable
       - name: Build and Test
         run: |
-          xcodebuild test -scheme PowerSync -destination "platform=iOS Simulator,name=iPhone 15"
+          xcodebuild test -scheme PowerSync -destination "platform=iOS Simulator,name=iPhone 16"
           xcodebuild test -scheme PowerSync -destination "platform=macOS,arch=arm64,name=My Mac"
           xcodebuild test -scheme PowerSync -destination "platform=watchOS Simulator,arch=arm64"

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -19,4 +19,4 @@ jobs:
         run: |
           xcodebuild test -scheme PowerSync -destination "platform=iOS Simulator,name=iPhone 16"
           xcodebuild test -scheme PowerSync -destination "platform=macOS,arch=arm64,name=My Mac"
-          xcodebuild test -scheme PowerSync -destination "platform=watchOS Simulator,arch=arm64"
+          xcodebuild test -scheme PowerSync -destination "platform=watchOS Simulator,arch=arm64name=Apple Watch Ultra 2"

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -11,7 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up XCode
-        if: runner.os == 'macOS'
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: latest-stable
@@ -19,4 +18,4 @@ jobs:
         run: |
           xcodebuild test -scheme PowerSync -destination "platform=iOS Simulator,name=iPhone 16"
           xcodebuild test -scheme PowerSync -destination "platform=macOS,arch=arm64,name=My Mac"
-          xcodebuild test -scheme PowerSync -destination "platform=watchOS Simulator,arch=arm64name=Apple Watch Ultra 2"
+          xcodebuild test -scheme PowerSync -destination "platform=watchOS Simulator,arch=arm64,name=Apple Watch Ultra 2 (49mm)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* [Internal] Instantiate Kotlin Kermit logger directly.
+
 ## 1.4.0
 
 * Added the ability to log PowerSync sync network requests.

--- a/Sources/PowerSync/Kotlin/DatabaseLogger.swift
+++ b/Sources/PowerSync/Kotlin/DatabaseLogger.swift
@@ -40,13 +40,23 @@ private class KermitLogWriterAdapter: Kermit_coreLogWriter {
     }
 }
 
+class KotlinKermitLoggerConfig: PowerSyncKotlin.Kermit_coreLoggerConfig {
+    var logWriterList: [Kermit_coreLogWriter]
+    var minSeverity: PowerSyncKotlin.Kermit_coreSeverity
+    
+    init(logWriterList: [Kermit_coreLogWriter], minSeverity: PowerSyncKotlin.Kermit_coreSeverity) {
+        self.logWriterList = logWriterList
+        self.minSeverity = minSeverity
+    }
+}
+
 /// A logger implementation that integrates with PowerSync's Kotlin core using Kermit.
 ///
 /// This class bridges Swift log writers with the Kotlin logging system and supports
 /// runtime configuration of severity levels and writer lists.
 class DatabaseLogger: LoggerProtocol {
     /// The underlying Kermit logger instance provided by the PowerSyncKotlin SDK.
-    public let kLogger = PowerSyncKotlin.generateLogger(logger: nil)
+    public let kLogger: PowerSyncKotlin.KermitLogger
     public let logger: any LoggerProtocol
     
     /// Initializes a new logger with an optional list of writers.
@@ -55,9 +65,12 @@ class DatabaseLogger: LoggerProtocol {
     init(_ logger: any LoggerProtocol) {
         self.logger = logger
         // Set to the lowest severity. The provided logger should filter by severity
-        kLogger.mutableConfig.setMinSeverity(Kermit_coreSeverity.verbose)
-        kLogger.mutableConfig.setLogWriterList(
-            [KermitLogWriterAdapter(logger: logger)]
+        self.kLogger = PowerSyncKotlin.KermitLogger(
+            config: KotlinKermitLoggerConfig(
+                logWriterList: [KermitLogWriterAdapter(logger: logger)],
+                minSeverity: Kermit_coreSeverity.verbose
+            ),
+            tag: "PowerSync"
         )
     }
     


### PR DESCRIPTION
# Overview

This internally updates the Kotlin Kermit logger instantiation to be performed directly in the Swift Adapter. We previously relied on the `generateLogger` method of the Kotlin SDK. This method might be updated or removed in future - e.g. as in https://github.com/powersync-ja/powersync-kotlin/pull/242