### PR TITLE
[POC] Structured Queries

### DIFF
--- a/Demo/StructuredQueriesExample/README.md
+++ b/Demo/StructuredQueriesExample/README.md
@@ -1,0 +1,9 @@
+# Structured Queries Example
+
+This used PowerSync along side the [structured-queries](https://github.com/pointfreeco/swift-structured-queries) library to perform DB operations using a typed query builder syntax.
+
+This demo can be executed with
+
+```bash
+swift run StructuredQueriesExample
+```

--- a/Demo/StructuredQueriesExample/Sources/entry.swift
+++ b/Demo/StructuredQueriesExample/Sources/entry.swift
@@ -1,0 +1,78 @@
+import Foundation
+import PowerSync
+import PowerSyncStructuredQueries
+import StructuredQueries
+
+@StructuredQueries.Table("users")
+struct User {
+    var id: String
+    var name: String
+    var birthday: Date?
+}
+
+@StructuredQueries.Table("posts")
+struct Post {
+    var id: String
+    var description: String
+    // TODO, inserts seem to break with this
+    @StructuredQueries.Column("user_id")
+    var userId: String
+}
+
+@main
+struct Main {
+    static func main() async throws {
+        // TODO, check if the schema can be shared in some way
+        let powersync = PowerSyncDatabase(
+            schema: Schema(
+                tables: [
+                    Table(
+                        name: "users",
+                        columns: [
+                            .text("name"),
+                            .text("birthday"),
+                        ]
+                    ),
+                    Table(
+                        name: "posts",
+                        columns: [
+                            .text("description"),
+                            .text("user_id"),
+                        ]
+                    ),
+                ],
+            ),
+            dbFilename: "test.sqlite"
+        )
+
+        let testUserID = UUID().uuidString
+
+        try await User.insert {
+            ($0.id, $0.name, $0.birthday)
+        } values: {
+            (testUserID, "Steven", Date())
+        }.execute(powersync)
+
+        try await User.insert {
+            User(
+                id: UUID().uuidString,
+                name: "Nevets"
+            )
+        }.execute(powersync)
+
+        let users = try await User.all.fetchAll(powersync)
+        print("The users are:")
+        for user in users {
+            print(user)
+        }
+
+        // TODO: column aliases seem to be broken
+        // try await Post.insert { Post(
+        //     id: UUID().uuidString, description: "A Post", userId: testUserID
+        // ) }.execute(powersync)
+
+        // // TODO: fix typing in order to execute joined queries
+        // let postsWithUsers = Post.join(User.all) { $0.userId == $1.id }
+        //     .select { ($0.description, $1.name) }
+    }
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -8,6 +8,60 @@
         "revision" : "3396dd7eb9d4264b19e3d95bfe0d77347826f4c2",
         "version" : "0.4.4"
       }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
+        "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "d7e40607dcd6bc26543f5d9433103f06e0b28f8f",
+        "version" : "1.18.6"
+      }
+    },
+    {
+      "identity" : "swift-structured-queries",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-structured-queries",
+      "state" : {
+        "revision" : "2468f4e34d909d11c053d773562c03ffea40a72e",
+        "version" : "0.12.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
+      }
+    },
+    {
+      "identity" : "swift-tagged",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-tagged",
+      "state" : {
+        "revision" : "3907a9438f5b57d317001dc99f3f11b46882272b",
+        "version" : "0.10.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "b2ed9eabefe56202ee4939dd9fc46b6241c88317",
+        "version" : "1.6.1"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -62,8 +62,14 @@ let package = Package(
             name: packageName,
             targets: ["PowerSync"]
         ),
+        .library(
+            name: "PowerSyncStructuredQueries",
+            targets: ["PowerSyncStructuredQueries"]
+        ),
     ],
-    dependencies: conditionalDependencies,
+    dependencies: [
+        .package(url: "https://github.com/pointfreeco/swift-structured-queries", from: "0.4.0"),
+    ] + conditionalDependencies,
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
@@ -77,6 +83,21 @@ let package = Package(
         .testTarget(
             name: "PowerSyncTests",
             dependencies: ["PowerSync"]
+        ),
+        .target(
+            name: "PowerSyncStructuredQueries",
+            dependencies: [
+                .byName(name: packageName),
+                .product(name: "StructuredQueries", package: "swift-structured-queries"),
+            ],
+            path: "Sources/StructuredQueries"
+        ),
+        .executableTarget(
+            name: "StructuredQueriesExample",
+            dependencies: [
+                .byName(name: "PowerSyncStructuredQueries"),
+            ],
+            path: "Demo/StructuredQueriesExample"
         ),
     ] + conditionalTargets
 )

--- a/README.md
+++ b/README.md
@@ -10,15 +10,21 @@ This is the PowerSync SDK for Swift clients. The SDK reference is available [her
 
 ## Structure: Packages
 
-- [Sources](./Sources/)
+- [Sources](./Sources/PowerSync)
 
   - This is the Swift SDK implementation.
+
+- [Sources](./Sources/StructuredQueries)
+
+  - A typed query builder using [structured-queries](https://github.com/pointfreeco/swift-structured-queries).
 
 ## Demo Apps / Example Projects
 
 The easiest way to test the PowerSync Swift SDK is to run our demo application.
 
 - [Demo/PowerSyncExample](./Demo/README.md): A simple to-do list application demonstrating the use of the PowerSync Swift SDK using a Supabase connector.
+
+- [Demo/StructuredQueriesExample](./Demo/StructuredQueriesExample/README.md): A simple Swift executable which uses the `PowerSyncStructuredQueries` library.
 
 ## Installation
 

--- a/Sources/StructuredQueries/PowerSyncQueryDecoder.swift
+++ b/Sources/StructuredQueries/PowerSyncQueryDecoder.swift
@@ -1,0 +1,99 @@
+import Foundation
+import PowerSync
+import StructuredQueries
+
+@usableFromInline
+struct PowerSyncQueryDecoder: QueryDecoder {
+    /// The structured queries library will decode the typed struct's columns in
+    /// the same order which it compiled the SELECT statement's column list.
+    /// The library will call the correct typed `decode` method, we just need to keep
+    /// track of which column index we're on.
+    @usableFromInline
+    var currentIndex: Int = 0
+
+    /// The PowerSync `SqlCursor` provided in the `mapper` closure.
+    @usableFromInline
+    var cursor: SqlCursor
+
+    @usableFromInline
+    init(cursor: SqlCursor) {
+        self.cursor = cursor
+    }
+
+    /// Decodes a single tuple of the given type starting from the current column.
+    ///
+    /// - Parameter columnTypes: The types to decode as.
+    /// - Returns: A tuple of the requested types.
+    @inlinable
+    @inline(__always)
+    public mutating func decodeColumns<each T: QueryRepresentable>(
+        _: (repeat each T).Type
+    ) throws -> (repeat (each T).QueryOutput) {
+        try (repeat (each T)(decoder: &self).queryOutput)
+    }
+
+    @inlinable
+    mutating func decode(_: [UInt8].Type) throws -> [UInt8]? {
+        defer { currentIndex += 1 }
+        // TODO: blob support
+        return nil
+    }
+
+    @inlinable
+    mutating func decode(_: Bool.Type) throws -> Bool? {
+        try decode(Int64.self).map { $0 != 0 }
+    }
+
+    @inlinable
+    mutating func decode(_: Date.Type) throws -> Date? {
+        try decode(String.self).map {
+            let formatter = ISO8601DateFormatter()
+            guard let date = formatter.date(from: $0) else {
+                throw InvalidDate()
+            }
+            return date
+        }
+    }
+
+    @inlinable
+    mutating func decode(_: Double.Type) throws -> Double? {
+        defer { currentIndex += 1 }
+        return cursor.getDoubleOptional(index: currentIndex)
+    }
+
+    @inlinable
+    mutating func decode(_: Int.Type) throws -> Int? {
+        try decode(Int64.self).map(Int.init)
+    }
+
+    @inlinable
+    mutating func decode(_: Int64.Type) throws -> Int64? {
+        defer { currentIndex += 1 }
+        return cursor.getInt64Optional(index: currentIndex)
+    }
+
+    @inlinable
+    mutating func decode(_: String.Type) throws -> String? {
+        defer { currentIndex += 1 }
+        return cursor.getStringOptional(index: currentIndex)
+    }
+
+    @inlinable
+    mutating func decode(_: UUID.Type) throws -> UUID? {
+        guard let uuidString = try decode(String.self) else { return nil }
+        guard let uuid = UUID(uuidString: uuidString) else { throw InvalidUUID() }
+        return uuid
+    }
+}
+
+@usableFromInline
+struct InvalidUUID: Error {
+    @usableFromInline
+    init() {}
+}
+
+@usableFromInline
+struct InvalidDate: Error {
+    @usableFromInline
+    init() {}
+}

--- a/Sources/StructuredQueries/QueryCursor.swift
+++ b/Sources/StructuredQueries/QueryCursor.swift
@@ -1,0 +1,71 @@
+import Foundation
+import PowerSync
+import StructuredQueries
+
+/// The Structured Queries library is dialect agnostic.
+/// For our purposes, we can use "?" for placeholders.
+public extension QueryFragment {
+    func prepareSqlite() -> (sql: String, bindings: [QueryBinding]) {
+        return prepare { _ in "?" }
+    }
+}
+
+@usableFromInline
+final class QueryValueCursor<QueryValue: QueryRepresentable> {
+    public typealias Element = QueryValue.QueryOutput
+    @usableFromInline
+    let powerSync: PowerSyncDatabaseProtocol
+
+    @usableFromInline
+    let query: QueryFragment
+
+    @usableFromInline
+    init(powerSync: PowerSyncDatabaseProtocol, query: QueryFragment) throws {
+        self.powerSync = powerSync
+        self.query = query
+    }
+
+    /// Performs a `PowerSyncDatabaseProtocol.getAll` to execute a SELECT query.
+    /// A decoder users the provided `SqlCursor` to map the columns to the Structured Table type.
+    @inlinable
+    public func elements() async throws -> [Element] {
+        let preparedQuery = query.prepareSqlite()
+        return try await powerSync.getAll(
+            sql: preparedQuery.sql,
+            parameters: preparedQuery.bindings.map { try $0.powerSyncValue }
+        ) { psCursor in
+
+            var decoder = PowerSyncQueryDecoder(cursor: psCursor)
+            return try QueryValue(decoder: &decoder).queryOutput
+        }
+    }
+}
+
+/// The bindings provided by `prepare` seem to be wrapped in a Swift class
+/// which causes binding to fail. This converts values to be usable by the Kotlin SDK.
+extension QueryBinding {
+    @inlinable
+    var powerSyncValue: Sendable? {
+        get throws {
+            switch self {
+            case let .blob(blob):
+                return blob
+            case let .date(date):
+                let formatter = ISO8601DateFormatter()
+                return formatter.string(from: date)
+            case let .double(double):
+                return double
+            case let .int(int):
+                return int
+            case .null:
+                return nil
+            case let .text(text):
+                return text
+            case let .uuid(uuid):
+                return uuid.uuidString
+            case let .invalid(error):
+                throw error
+            }
+        }
+    }
+}

--- a/Sources/StructuredQueries/Statement+PowerSync.swift
+++ b/Sources/StructuredQueries/Statement+PowerSync.swift
@@ -1,0 +1,141 @@
+import Foundation
+import PowerSync
+import StructuredQueriesCore
+
+public extension StructuredQueriesCore.Statement {
+    /// Executes a structured query on the given database connection.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// let db = PowerSyncDatabase(...)
+    /// try await Player.insert { $0.name } values: { "Arthur" }
+    ///     .execute(db)
+    /// // INSERT INTO "players" ("name")
+    /// // VALUES ('Arthur');
+    /// ```
+    ///
+    /// - Parameter powerSync: A PowerSync database connection.
+    @inlinable
+    @MainActor
+    func execute(_ powerSync: PowerSyncDatabaseProtocol) async throws where QueryValue == () {
+        let preparedQuery = query.prepareSqlite()
+        try await powerSync.execute(
+            sql: preparedQuery.sql,
+            parameters: preparedQuery.bindings.map { try $0.powerSyncValue }
+        )
+    }
+
+    /// Returns an array of all values fetched from the database.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// let db = PowerSyncDatabase(...)
+    /// let lastName = "O'Reilly"
+    /// let players = try await Player
+    ///     .where { $0.lastName == lastName }
+    ///     .fetchAll(db)
+    /// // SELECT … FROM "players"
+    /// // WHERE "players"."lastName" = 'O''Reilly'
+    /// ```
+    ///
+    /// - Parameter powerSync: A PowerSync database connection.
+    /// - Returns: An array of all values decoded from the database.
+    @inlinable
+    func fetchAll(_ powerSync: PowerSyncDatabaseProtocol) async throws -> [QueryValue.QueryOutput]
+        where QueryValue: QueryRepresentable
+    {
+        let cursor: QueryValueCursor<Self.QueryValue> = try QueryValueCursor<QueryValue>(
+            powerSync: powerSync,
+            query: query
+        )
+        return try await cursor.elements()
+    }
+
+    /// Returns a single value fetched from the database.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// let db = PowerSyncDatabase(...)
+    /// let lastName = "O'Reilly"
+    /// let player = try await Player
+    ///     .where { $0.lastName == lastName }
+    ///     .limit(1)
+    ///     .fetchOne(db)
+    /// // SELECT … FROM "players"
+    /// // WHERE "players"."lastName" = 'O''Reilly'
+    /// // LIMIT 1
+    /// ```
+    ///
+    /// - Parameter powerSync: A PowerSync database connection.
+    /// - Returns: A single value decoded from the database.
+    @inlinable
+    func fetchOne(_ powerSync: PowerSyncDatabaseProtocol) async throws -> QueryValue.QueryOutput?
+        where QueryValue: QueryRepresentable
+    {
+        let all = try await fetchAll(powerSync)
+        return all.first
+    }
+}
+
+public extension SelectStatement where QueryValue == (), Joins == () {
+    /// Returns the number of rows fetched by the query.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// let db = PowerSyncDatabase(...)
+    /// let count = try await Player.all.fetchCount(db)
+    /// ```
+    ///
+    /// - Parameter powerSync: A PowerSync database connection.
+    /// - Returns: The number of rows fetched by the query.
+    @inlinable
+    func fetchCount(_ powerSync: PowerSyncDatabaseProtocol) async throws -> Int {
+        let query = asSelect().count()
+        return try await query.fetchOne(powerSync) ?? 0
+    }
+}
+
+extension SelectStatement where QueryValue == (), Joins == () {
+    /// Returns an array of all values fetched from the database.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// let db = PowerSyncDatabase(...)
+    /// let users = try await User.all.fetchAll(db)
+    /// ```
+    ///
+    /// - Parameter powerSync: A PowerSync database connection.
+    /// - Returns: An array of all values decoded from the database.
+    @_documentation(visibility: private)
+    @inlinable
+    public func fetchAll(_ powerSync: PowerSyncDatabaseProtocol) async throws -> [From.QueryOutput] {
+        let cursor = try QueryValueCursor<From>(
+            powerSync: powerSync,
+            query: query
+        )
+        return try await cursor.elements()
+    }
+
+    /// Returns a single value fetched from the database.
+    ///
+    /// For example:
+    ///
+    /// ```swift
+    /// let db = PowerSyncDatabase(...)
+    /// let user = try await User.all.fetchOne(db)
+    /// ```
+    ///
+    /// - Parameter powerSync: A PowerSync database connection.
+    /// - Returns: A single value decoded from the database.
+    @_documentation(visibility: private)
+    @inlinable
+    public func fetchOne(_ powerSync: PowerSyncDatabaseProtocol) async throws -> From.QueryOutput? {
+        let all = try await fetchAll(powerSync)
+        return all.first
+    }
+}


### PR DESCRIPTION
# Overview

This adds an integration with the [Structured Queries](https://github.com/pointfreeco/swift-structured-queries) library in order to provide typed query execution.

A new `PowerSyncStructuredQueries` library Product has been added to the monorepo with a small example Swift executable `StructuredQueriesExample` which uses the library.

## Background

PowerSync currently only allows using raw SQL statements and `SqlCursor`s to execute SQL operations. Queries are specified as SQL strings and the result for `SELECT` operations are mapped to the result type using a `mapper` closure which uses a `SqlCursor` to access result set column values.

```swift
let user: User = try await database.get(
    sql: "SELECT id, name, email FROM users WHERE id = ?",
    parameters: ["1"]
) { cursor in
    try User (
        id: cursor.getString(name: "id"),
        name: cursor.getString(name: "name"),
        email: cursor.getString(name: "email")
    )
}
```

Where `User` above can be a Swift `struct` which is manually instantiated inside the `mapper` closure.

A structured query approach would involve:

1. Combining the data class definitions (e.g. `User` above) with the SQL table definitions.
2. Using the data class definitions to construct the relevant query operations.
3. Executing query operations and returning the typed result set values automatically

## Structured Queries

> StructuredQueries provides a suite of tools that empower you to write safe, expressive, composable SQL with Swift. By simply attaching macros to types that represent your database schema

The Structured Queries library takes care of `1` and `2`, but it lacks any concrete SQL driver implementations for `3`.

The [sharing-grdb](https://github.com/pointfreeco/sharing-grdb) project provides an integration with the GRDB SQLite driver to perform `3`.

PowerSync is currently not directly compatible with GRDB (although this might change in the future). The work here follows the patterns of Sharing GRDB to include PowerSync as the SQLite driver for executing structured queries.

```swift

@StructuredQueries.Table("users")
struct User {
    var id: String
    var name: String
    var birthday: Date?
}

let powersync = PowerSyncDatabase(...)

try await User.insert {
    ($0.id, $0.name, $0.birthday)
} values: {
    (testUserID, "Steven", Date())
}.execute(powersync)

let users = try await User.all.fetchAll(powersync)

```

## Outstanding work

The Structured Query table definitions are currently not shared with the PowerSync client side schema definition. It should be possible to potentially declare this once.

This work here extends the `Statement` protocol in order to add the `execute` and `fetchAll` methods (similar to the sharing-grdb implementation). Additional extensions are required for for more complex queries like joins.

The `sharing-grdb` library exposes reactive macros for fetching observable data in UI applications. This is not implemented here yet.



