### PR TITLE
XCode Previews

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -16,9 +16,9 @@ jobs:
           xcode-version: latest-stable
       - name: Build and Test
         run: |
-          xcodebuild test -scheme PowerSync -destination "platform=iOS Simulator,name=iPhone 16"
-          xcodebuild test -scheme PowerSync -destination "platform=macOS,arch=arm64,name=My Mac"
-          xcodebuild test -scheme PowerSync -destination "platform=watchOS Simulator,arch=arm64,name=Apple Watch Ultra 2 (49mm)"
+          xcodebuild test -scheme PowerSync-Package -destination "platform=iOS Simulator,name=iPhone 16"
+          xcodebuild test -scheme PowerSync-Package -destination "platform=macOS,arch=arm64,name=My Mac"
+          xcodebuild test -scheme PowerSync-Package -destination "platform=watchOS Simulator,arch=arm64,name=Apple Watch Ultra 2 (49mm)"
 
   buildSwift6:
     name: Build and test with Swift 6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * *Potential Breaking Change*: Attachment helpers have been updated to better support Swift 6 strict concurrency checking. `Actor` isolation is improved, but developers who customize or extend `AttachmentQueue` will need to update their implementations. The default instantiation of `AttachmentQueue` remains unchanged.
 `AttachmentQueueProtocol` now defines the basic requirements for an attachment queue, with most base functionality provided via an extension. Custom implementations should extend `AttachmentQueueProtocol`.
+* Added `PowerSyncDynamic` product to package. Importing this product should restore XCode preview functionality.
 * [Internal] Instantiate Kotlin Kermit logger directly.
 * [Internal] Improved connection context error handling.
 

--- a/Demo/PowerSyncExample.xcodeproj/project.pbxproj
+++ b/Demo/PowerSyncExample.xcodeproj/project.pbxproj
@@ -39,8 +39,9 @@
 		B666587C2C63B88700159A81 /* SwiftUINavigationCore in Frameworks */ = {isa = PBXBuildFile; productRef = B666587B2C63B88700159A81 /* SwiftUINavigationCore */; };
 		B69F7D862C8EE27400565448 /* AnyCodable in Frameworks */ = {isa = PBXBuildFile; productRef = B69F7D852C8EE27400565448 /* AnyCodable */; };
 		B6B3698A2C64F4B30033C307 /* Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6B369892C64F4B30033C307 /* Navigation.swift */; };
-		B6FFD5322D06DA8000EEE60F /* PowerSync in Frameworks */ = {isa = PBXBuildFile; productRef = B6FFD5312D06DA8000EEE60F /* PowerSync */; };
 		BE2F26EC2DA54B2F0080F1AE /* SupabaseRemoteStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2F26EB2DA54B2A0080F1AE /* SupabaseRemoteStorage.swift */; };
+		BEDBE19C2E5F0299004E1AB5 /* PowerSyncDynamic in Frameworks */ = {isa = PBXBuildFile; productRef = BEDBE19B2E5F0299004E1AB5 /* PowerSyncDynamic */; };
+		BEDBE19D2E5F0299004E1AB5 /* PowerSyncDynamic in Embed Frameworks */ = {isa = PBXBuildFile; productRef = BEDBE19B2E5F0299004E1AB5 /* PowerSyncDynamic */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		BEE4708B2E3BBB2500140D11 /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE4708A2E3BBB2500140D11 /* Secrets.swift */; };
 /* End PBXBuildFile section */
 
@@ -51,6 +52,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
+				BEDBE19D2E5F0299004E1AB5 /* PowerSyncDynamic in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -120,11 +122,11 @@
 				B66658772C63B7BB00159A81 /* IdentifiedCollections in Frameworks */,
 				B69F7D862C8EE27400565448 /* AnyCodable in Frameworks */,
 				B666587C2C63B88700159A81 /* SwiftUINavigationCore in Frameworks */,
-				B6FFD5322D06DA8000EEE60F /* PowerSync in Frameworks */,
 				6A9669022B9EE69500B05DCF /* Supabase in Frameworks */,
 				6A9669002B9EE4FE00B05DCF /* PostgREST in Frameworks */,
 				6A9668FE2B9EE4FE00B05DCF /* Auth in Frameworks */,
 				B666587A2C63B88700159A81 /* SwiftUINavigation in Frameworks */,
+				BEDBE19C2E5F0299004E1AB5 /* PowerSyncDynamic in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -487,7 +489,7 @@
 				B66658792C63B88700159A81 /* SwiftUINavigation */,
 				B666587B2C63B88700159A81 /* SwiftUINavigationCore */,
 				B69F7D852C8EE27400565448 /* AnyCodable */,
-				B6FFD5312D06DA8000EEE60F /* PowerSync */,
+				BEDBE19B2E5F0299004E1AB5 /* PowerSyncDynamic */,
 			);
 			productName = PowerSyncExample;
 			productReference = 6A7315842B9854220004CB17 /* PowerSyncExample.app */;
@@ -885,10 +887,10 @@
 			package = B69F7D842C8EE27300565448 /* XCRemoteSwiftPackageReference "AnyCodable" */;
 			productName = AnyCodable;
 		};
-		B6FFD5312D06DA8000EEE60F /* PowerSync */ = {
+		BEDBE19B2E5F0299004E1AB5 /* PowerSyncDynamic */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 18F30B282CCA4B3B00A58917 /* XCLocalSwiftPackageReference "../../powersync-swift" */;
-			productName = PowerSync;
+			productName = PowerSyncDynamic;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Demo/PowerSyncExample/Screens/HomeScreen.swift
+++ b/Demo/PowerSyncExample/Screens/HomeScreen.swift
@@ -33,5 +33,6 @@ struct HomeScreen: View {
     NavigationStack{
         HomeScreen()
             .environment(SystemManager())
+            .environment(NavigationModel())
     }
 }

--- a/Demo/PowerSyncExample/Screens/SignInScreen.swift
+++ b/Demo/PowerSyncExample/Screens/SignInScreen.swift
@@ -78,5 +78,6 @@ struct SignInScreen: View {
     NavigationStack {
         SignInScreen()
             .environment(SystemManager())
+            .environment(NavigationModel())
     }
 }

--- a/Demo/PowerSyncExample/Screens/SignUpScreen.swift
+++ b/Demo/PowerSyncExample/Screens/SignUpScreen.swift
@@ -78,5 +78,6 @@ struct SignUpScreen: View {
     NavigationStack {
         SignUpScreen()
             .environment(SystemManager())
+            .environment(NavigationModel())
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -61,6 +61,16 @@ let package = Package(
         .library(
             name: packageName,
             targets: ["PowerSync"]
+        ),
+        .library(
+            name: "\(packageName)Dynamic",
+            // The default value normally specifies that the library is compatible with both static and dynamic linking,
+            // where the value used is typically specified by the consumer - which is usually defaulted to static linking.
+            // It's not straight forward to configure the linking option used by XCode consumers - specifying
+            // this additional product allows consumers to add it to their project, forcing dynamic linking.
+            // Dynamic linking is particularly important for XCode previews.
+            type: .dynamic,
+            targets: ["PowerSync"]
         )
     ],
     dependencies: conditionalDependencies,

--- a/README.md
+++ b/README.md
@@ -80,3 +80,13 @@ For more details, see the [Swift SDK reference](https://docs.powersync.com/clien
 ## Attachments
 
 See the attachments [README](./Sources/PowerSync/attachments/README.md) for more information.
+
+## XCode Previews
+
+XCode previews currently fail to load in a reasonable time after adding PowerSync to an XCode project. XCode requires dynamic linking for previews. This is enabled by enabling `ENABLE_DEBUG_DYLIB` in the XCode project. It seems like the previews fail to load due to PowerSync providing a `binaryTarget` which is linked statically by default.
+
+XCode previews can be enabled by either:
+
+Enabling `Editor -> Canvas -> Use Legacy Previews Execution` in XCode.
+
+Or adding the `PowerSyncDynamic` product when adding PowerSync to your project. This product will assert that PowerSync should be dynamically linked, which restores XCode previews.


### PR DESCRIPTION
# Overview

This applies the workaround mentioned in https://github.com/powersync-ja/powersync-swift/issues/9 for restoring XCode previews.

## Context 

Currently users are required to enable `Use Legacy Previews Execution` in order to use XCode's screen preview functionality. The previews fail to load with an error "Failed to launch app [App name] in reasonable time". The diagnostics report provided does not seem to provide any meaningful information to assist with debugging.

**PowerSync SPM Package Context**

The PowerSync SPM package currently includes a `PowerSync` `library` `product` which uses the default value for the `type` setting. According to the SPM docs for the `type` setting:

```
Creates a library product to allow clients that declare a dependency on this package to use the package's functionality.

A library's product can be either statically or dynamically linked. It's recommended that you don't explicitly declare the type of library, so Swift Package Manager can choose between static or dynamic linking based on the preference of the package's consumer.
```

We therefore currently support both static and dynamic linking with the `PowerSync` library product

**XCode Previews Context**

Some background on how XCode previews are executed can be found [here](https://onee.me/en/blog/how-new-xcode-swiftui-preview-works-under-the-hood/). 

It seems like for Previews XCode will build the application as a dynamically linked project. [ENABLE_DEBUG_DYLIB_SUPPORT](https://developer.apple.com/documentation/xcode/build-settings-reference#Enable-Debug-Dylib-Support) is required for previews to function. 

There are multiple potential issue threads on the XCode forums related to Previews not loading:
- [Suggests](https://developer.apple.com/forums/thread/678505) there might be an issue with running previews when libraries with binaryTargets are loaded statically. 
- [Suggests](https://developer.apple.com/forums/thread/704910) static libraries have known issues with XCode previews

While our SPM package should theoretically allow consumers to specify the linkage type, I could not find any trivial method of configuring the current `PowerSync` framework as dynamically linked in the XCode project settings. This seems to be a limitation with XCode's SPM integration.

## The Fix

The current fix is to add an explicit `PowerSyncDynamic` library product which forces dynamic linking when added. Adding this to an Xcode project restores the preview functionality without the need for enabling the legacy preview mode.

This product has been configured for out PowerSync example demo. The screen previews now function for our demo.

<img width="3326" height="1796" alt="image" src="https://github.com/user-attachments/assets/1598e30a-2a5e-4aac-a8e6-46a531a260b2" />




