### PR TITLE
[Release] 1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Update core extension to 0.4.5 ([changelog](https://github.com/powersync-ja/powersync-sqlite-core/releases/tag/v0.4.5))
 * Additional Swift 6 Strict Concurrency Checking declarations added for remaining protocols.
+* Fix issue in legacy sync client where local writes made offline could have their upload delayed until a keepalive event was received. This could also cause downloaded updates to be delayed even further until all uploads were completed.
 
 ## 1.5.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.5.1 (unreleased)
+## 1.5.1
 
 * Update core extension to 0.4.5 ([changelog](https://github.com/powersync-ja/powersync-sqlite-core/releases/tag/v0.4.5))
 * Additional Swift 6 Strict Concurrency Checking declarations added for remaining protocols.

--- a/Package.swift
+++ b/Package.swift
@@ -32,8 +32,8 @@ if let kotlinSdkPath = localKotlinSdkOverride {
     // Not using a local build, so download from releases
     conditionalTargets.append(.binaryTarget(
         name: "PowerSyncKotlin",
-        url: "https://github.com/powersync-ja/powersync-kotlin/releases/download/v1.5.0/PowersyncKotlinRelease.zip",
-        checksum: "cb1d717d28411aff0bfdeeaa837ae01514ebf5d64203dc565a9520a2912bae9d"
+        url: "https://github.com/powersync-ja/powersync-kotlin/releases/download/v1.5.1/PowersyncKotlinRelease.zip",
+        checksum: "3a2de1863d2844d49cebf4428d0ab49956ba384dcab9f3cc2ddbc7836013c434"
     ))
 }
 


### PR DESCRIPTION
Release for:

* Update core extension to 0.4.5 ([changelog](https://github.com/powersync-ja/powersync-sqlite-core/releases/tag/v0.4.5))
* Additional Swift 6 Strict Concurrency Checking declarations added for remaining protocols in https://github.com/powersync-ja/powersync-swift/pull/75
* Fix issue in legacy sync client where local writes made offline could have their upload delayed until a keepalive event was received. This could also cause downloaded updates to be delayed even further until all uploads were completed in https://github.com/powersync-ja/powersync-kotlin/pull/255