### PR TITLE
Remove unnecessary Task's in actor

### DIFF
--- a/Sources/PowerSync/attachments/FileManagerLocalStorage.swift
+++ b/Sources/PowerSync/attachments/FileManagerLocalStorage.swift
@@ -13,85 +13,71 @@ public actor FileManagerStorageAdapter: LocalStorageAdapter {
     }
 
     public func saveFile(filePath: String, data: Data) async throws -> Int64 {
-        return try await Task {
-            let url = URL(fileURLWithPath: filePath)
+        let url = URL(fileURLWithPath: filePath)
 
-            // Make sure the parent directory exists
-            try fileManager.createDirectory(at: url.deletingLastPathComponent(),
-                                            withIntermediateDirectories: true)
+        // Make sure the parent directory exists
+        try fileManager.createDirectory(at: url.deletingLastPathComponent(),
+                                        withIntermediateDirectories: true)
 
-            // Write data to file
-            try data.write(to: url)
+        // Write data to file
+        try data.write(to: url)
 
-            // Return the size of the data
-            return Int64(data.count)
-        }.value
+        // Return the size of the data
+        return Int64(data.count)
     }
 
     public func readFile(filePath: String, mediaType _: String?) async throws -> Data {
-        return try await Task {
-            let url = URL(fileURLWithPath: filePath)
+        let url = URL(fileURLWithPath: filePath)
 
-            if !fileManager.fileExists(atPath: filePath) {
-                throw PowerSyncAttachmentError.fileNotFound(filePath)
-            }
+        if !fileManager.fileExists(atPath: filePath) {
+            throw PowerSyncAttachmentError.fileNotFound(filePath)
+        }
 
-            // Read data from file
-            do {
-                return try Data(contentsOf: url)
-            } catch {
-                throw PowerSyncAttachmentError.ioError(error)
-            }
-        }.value
+        // Read data from file
+        do {
+            return try Data(contentsOf: url)
+        } catch {
+            throw PowerSyncAttachmentError.ioError(error)
+        }
     }
 
     public func deleteFile(filePath: String) async throws {
-        try await Task {
-            if fileManager.fileExists(atPath: filePath) {
-                try fileManager.removeItem(atPath: filePath)
-            }
-        }.value
+        if fileManager.fileExists(atPath: filePath) {
+            try fileManager.removeItem(atPath: filePath)
+        }
     }
 
     public func fileExists(filePath: String) async throws -> Bool {
-        return await Task {
-            fileManager.fileExists(atPath: filePath)
-        }.value
+        return fileManager.fileExists(atPath: filePath)
     }
 
     public func makeDir(path: String) async throws {
-        try await Task {
-            try fileManager.createDirectory(atPath: path,
-                                            withIntermediateDirectories: true,
-                                            attributes: nil)
-        }.value
+        try fileManager.createDirectory(atPath: path,
+                                        withIntermediateDirectories: true,
+                                        attributes: nil)
     }
 
     public func rmDir(path: String) async throws {
-        try await Task {
-            if fileManager.fileExists(atPath: path) {
-                try fileManager.removeItem(atPath: path)
-            }
-        }.value
+        if fileManager.fileExists(atPath: path) {
+            try fileManager.removeItem(atPath: path)
+        }
     }
 
     public func copyFile(sourcePath: String, targetPath: String) async throws {
-        try await Task {
-            if !fileManager.fileExists(atPath: sourcePath) {
-                throw PowerSyncAttachmentError.fileNotFound(sourcePath)
-            }
+        if !fileManager.fileExists(atPath: sourcePath) {
+            throw PowerSyncAttachmentError.fileNotFound(sourcePath)
+        }
 
-            // Ensure target directory exists
-            let targetUrl = URL(fileURLWithPath: targetPath)
-            try fileManager.createDirectory(at: targetUrl.deletingLastPathComponent(),
-                                            withIntermediateDirectories: true)
+        // Ensure target directory exists
+        let targetUrl = URL(fileURLWithPath: targetPath)
+        try fileManager.createDirectory(at: targetUrl.deletingLastPathComponent(),
+                                        withIntermediateDirectories: true)
 
-            // If target already exists, remove it first
-            if fileManager.fileExists(atPath: targetPath) {
-                try fileManager.removeItem(atPath: targetPath)
-            }
+        // If target already exists, remove it first
+        if fileManager.fileExists(atPath: targetPath) {
+            try fileManager.removeItem(atPath: targetPath)
+        }
 
-            try fileManager.copyItem(atPath: sourcePath, toPath: targetPath)
-        }.value
+        try fileManager.copyItem(atPath: sourcePath, toPath: targetPath)
     }
 }


### PR DESCRIPTION
A plain Task { ... } (e.g. not defered) inherits the actor’s executor and removing them doesn't change the current behavior. The fact that the functions are actor-isolated is enough to ensure the code won't run on the main actor.

**Discussion**
As long as we're fine with the file system operations being isolated to the same actor (i.e. functions will be able to block each other) this should be a simple and safe solution. The downside being that it might be less performant than some concurrent solution. Is this an issue?

I'm not sure it's trivial to implement an equally safe solution that supports parallell operations. E.g. what about related operations on/in the same file or directory?

Thoughts/input?