### PR TITLE
Ability to Delete SQLite files on Close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,17 @@
 ## 1.6.1 (unreleased)
 
 * Update Kotlin SDK to 1.7.0.
+* Add `close(deleteDatabase:)` method to `PowerSyncDatabaseProtocol` for deleting SQLite database files when closing the database. This includes the main database file and all WAL mode files (.wal, .shm, .journal). Files that don't exist are ignored, but an error is thrown if a file exists but cannot be deleted.
 
+```swift
+// Close the database and delete all SQLite files
+try await database.close(deleteDatabase: true)
+
+// Close the database without deleting files (default behavior)
+try await database.close(deleteDatabase: false)
+// or simply
+try await database.close()
+```
 ## 1.6.0
 
 * Update core extension to 0.4.6 ([changelog](https://github.com/powersync-ja/powersync-sqlite-core/releases/tag/v0.4.6))


### PR DESCRIPTION
# Overview

Users have requested for the PowerSync SDK to be able to delete the SQLite files it created. 

This adds the ability to delete potentially opened files when calling `close` on the PowerSync client. (We should only delete the files once we've closed active connections).

This code could have been implemented in the Kotlin SDK and used here. I've opted not to do this for now, since updating the Kotlin SDK currently requires other changes. Implementing this functionality in Swift directly allows for a faster release cycle. 