### PR TITLE
feat: Add dbDirectory parameter for custom database storage locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.11.0 (unreleased)
 
 * Add support for [sync streams](https://docs.powersync.com/sync/streams/overview).
+* Add `dbDirectory` parameter to `PowerSyncDatabase()` to support custom database storage locations. This enables storing the database in a shared App Group container for access from Share Extensions and other app extensions.
 
 ## 1.10.0
 

--- a/Sources/PowerSync/PowerSyncDatabase.swift
+++ b/Sources/PowerSync/PowerSyncDatabase.swift
@@ -7,18 +7,29 @@ public let DEFAULT_DB_FILENAME = "powersync.db"
 /// - Parameters:
 ///   - schema: The database schema
 ///   - dbFilename: The database filename. Defaults to "powersync.db"
+///   - dbDirectory: Optional custom directory path for the database file.
+///     When `nil`, the database is stored in the default application support directory.
+///     Use this to store the database in a shared App Group container, e.g.:
+///     ```swift
+///     let containerURL = FileManager.default.containerURL(
+///         forSecurityApplicationGroupIdentifier: "group.com.example.app"
+///     )
+///     let dbDirectory = containerURL?.path
+///     ```
 ///   - logger: Optional logging interface
 ///   - initialStatements: An optional list of statements to run as the database is opened.
 /// - Returns: A configured PowerSyncDatabase instance
 public func PowerSyncDatabase(
     schema: Schema,
     dbFilename: String = DEFAULT_DB_FILENAME,
+    dbDirectory: String? = nil,
     logger: (any LoggerProtocol) = DefaultLogger(),
     initialStatements: [String] = []
 ) -> PowerSyncDatabaseProtocol {
     return openKotlinDBDefault(
         schema: schema,
         dbFilename: dbFilename,
+        dbDirectory: dbDirectory,
         logger: DatabaseLogger(logger),
         initialStatements: initialStatements
     )


### PR DESCRIPTION
## Summary

- Adds a `dbDirectory` parameter to `PowerSyncDatabase()` that allows specifying a custom directory path for the database file
- Enables storing the database in a shared **App Group container**, which is essential for iOS apps that need to share data between the main app and extensions (e.g. Share Extensions, widgets)
- The underlying Kotlin SDK already supports `dbDirectory` — this change threads it through the Swift API layer

## Motivation

Currently, `dbFilename` only accepts a filename (not a path), and the database is always stored in the hardcoded Application Support directory. This makes it impossible to share the database between the main app and app extensions without going through a cloud round-trip.

**Before:** Share Extension writes to its own PowerSync database → syncs to cloud → main app syncs from cloud (slow, requires connectivity)

**After:** Both main app and Share Extension point to the same database file in the App Group container (instant local access)

## Usage

```swift
let containerURL = FileManager.default.containerURL(
    forSecurityApplicationGroupIdentifier: "group.com.example.app"
)

let db = PowerSyncDatabase(
    schema: schema,
    dbFilename: "powersync.db",
    dbDirectory: containerURL?.path
)
```

## Changes

| File | Change |
|------|--------|
| `PowerSyncDatabase.swift` | Add `dbDirectory: String? = nil` parameter to the public API |
| `KotlinPowerSyncDatabaseImpl.swift` | Thread `dbDirectory` through to the Kotlin SDK; use it in `deleteDatabase()` |
| `KotlinPowerSyncDatabaseImplTests.swift` | Add tests for custom directory creation, file location, and deletion |
| `CHANGELOG.md` | Document the new feature |

## Test plan

- [x] Verify build compiles (`swift build` ✅)
- [x] Verify tests compile (`swift build --build-tests` ✅)
- [ ] `testCustomDbDirectory` — verifies database is created in custom directory, not the default
- [ ] `testCustomDbDirectoryCloseWithDeleteDatabase` — verifies all SQLite files (db, wal, shm) are cleaned up from custom directory
- [ ] Existing tests continue to pass (default behavior unchanged when `dbDirectory` is `nil`)