### PR TITLE
Update Kotlin SDK and core extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.13.1
+
+* Don't attempt to create WebSocket connections on watchOS.
+* Update default SQLite cache size to 50MB, this was previously erroneously set to 200MB.
+* Skip creating `ps_crud` entries when clearing raw tables.
+
 ## 1.13.0
 
 * Add optional `logger` parameter on `openPowerSyncWithGRDB` to enable custom loggers.

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5a84f0be5aa7dc57f98fc82f285fda174f987edb92cbe202dbdb9db1b5d7b3a7",
+  "originHash" : "5d24af35f5a7f9f12e6f8486efe9c263534391d1a45bc446da2b60a7c2faf9a6",
   "pins" : [
     {
       "identity" : "csqlite",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-sqlite-core-swift.git",
       "state" : {
-        "revision" : "fcc63dec574d12be25a15659ea22f9007dbe4f51",
-        "version" : "0.4.11"
+        "revision" : "aa35758afca6cc97db836e1545ad28e4c5ddc50d",
+        "version" : "0.4.12"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -34,8 +34,8 @@ if let kotlinSdkPath = localKotlinSdkOverride {
         .binaryTarget(
             name: "PowerSyncKotlin",
             url:
-            "https://github.com/powersync-ja/powersync-kotlin/releases/download/v1.11.1/PowersyncKotlinRelease.zip",
-            checksum: "a50fdce3a38ea490e27e1759bdf75edbde2399cca6ad77dc15ebd2399a9f9ac8"
+            "https://github.com/powersync-ja/powersync-kotlin/releases/download/v1.11.2/PowersyncKotlinRelease.zip",
+            checksum: "bd4f9a4411a10a30bd67c3231d1d0d0dde42f0ec19161ccbd26d4e58b31efdfd"
         ))
 }
 
@@ -48,7 +48,7 @@ if let corePath = localCoreExtension {
     conditionalDependencies.append(
         .package(
             url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git",
-            exact: "0.4.11",
+            exact: "0.4.12",
         ))
 }
 

--- a/Sources/PowerSync/CurrentVersion.swift
+++ b/Sources/PowerSync/CurrentVersion.swift
@@ -1,3 +1,3 @@
 // The current version of the PowerSync Swift SDK. This should be updated to the latest version in `CHANGELOG.md` when a new version is released.
-let libraryVersion = "1.13.0"
+let libraryVersion = "1.13.1"
 


### PR DESCRIPTION
This updates the core extension to 0.4.12 ([release notes](https://github.com/powersync-ja/powersync-sqlite-core/releases/tag/v0.4.12)) and the Kotlin SDK to 1.11.2 ([release notes](https://github.com/powersync-ja/powersync-kotlin/releases/tag/v1.11.2)).