### PR TITLE
fix: Potential CancellationError swallowing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Don't attempt to create WebSocket connections on watchOS.
 * Update default SQLite cache size to 50MB, this was previously erroneously set to 200MB.
 * Skip creating `ps_crud` entries when clearing raw tables.
+* Prevent swallowing `CancellationError`s for PowerSync wrapped operations. 
 
 ## 1.13.0
 
@@ -14,7 +15,6 @@
   * Fix sync loop terminating permanently when the server rejects the connection.
   * Fix sync loop stalling indefinitely after a transport-layer failure (dead socket, network
 dropout).
-* Prevent swallowing `CancellationError`s for PowerSync wrapped operations. 
 
 ## 1.12.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
   * Fix sync loop terminating permanently when the server rejects the connection.
   * Fix sync loop stalling indefinitely after a transport-layer failure (dead socket, network
 dropout).
-
+* Prevent swallowing `CancellationError`s for PowerSync wrapped operations. 
 
 ## 1.12.0
 

--- a/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
+++ b/Sources/PowerSync/Kotlin/KotlinPowerSyncDatabaseImpl.swift
@@ -353,6 +353,9 @@ final class KotlinPowerSyncDatabaseImpl: PowerSyncDatabaseProtocol,
         do {
             return try await handler()
         } catch {
+            if error is CancellationError {
+                throw error
+            }
             // Try and parse errors back from the Kotlin side
             if let mapperError = SqlCursorError.fromDescription(error.localizedDescription) {
                 throw mapperError


### PR DESCRIPTION
# Overview

Some of our SDK methods run certain operations which could throw exceptions. Any potential exceptions are wrapped in a PowerSyncException for better visibility in consumer code. 

While investigating a potential watched query cancellation issue. I noticed in the debugger that our Swift Cancellation Errors were wrapped in a `.operationError`. While our watched queries cancel the consuming task regardless of the error type, we should generally not wrap `CancellationError`s. 

This rethrows cancellation errors in our `wrapPowerSyncException` wrapper.