### PR TITLE
Implement schema serialization in Swift

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -8,6 +8,7 @@ jobs:
   build:
     name: Build and test
     runs-on: macos-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Set up XCode

--- a/Sources/PowerSync/Protocol/Schema/Column.swift
+++ b/Sources/PowerSync/Protocol/Schema/Column.swift
@@ -15,14 +15,26 @@ public protocol ColumnProtocol: Equatable, Sendable {
     var type: ColumnData { get }
 }
 
-public enum ColumnData: Sendable {
+public enum ColumnData: Sendable, Encodable {
     case text
     case integer
     case real
+    
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .text:
+            try container.encode("text")
+        case .integer:
+            try container.encode("integer")
+        case .real:
+            try container.encode("real")
+        }
+    }
 }
 
 /// A single column in a table schema.
-public struct Column: ColumnProtocol {
+public struct Column: ColumnProtocol, Encodable {
     public let name: String
     public let type: ColumnData
 

--- a/Sources/PowerSync/Protocol/Schema/Index.swift
+++ b/Sources/PowerSync/Protocol/Schema/Index.swift
@@ -12,7 +12,7 @@ public protocol IndexProtocol: Sendable {
     var columns: [IndexedColumnProtocol] { get }
 }
 
-public struct Index: IndexProtocol {
+public struct Index: IndexProtocol, Encodable {
     public let name: String
     public let columns: [IndexedColumnProtocol]
 
@@ -46,5 +46,26 @@ public struct Index: IndexProtocol {
         column: String
     ) -> Index {
         return ascending(name: name, columns: [column])
+    }
+    
+    public func encode(to encoder: any Encoder) throws {
+        enum CodingKeys: CodingKey {
+            case name
+            case columns
+        }
+
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(name, forKey: .name)
+        var columnsContainer = container.nestedUnkeyedContainer(forKey: .columns)
+        for column in columns {
+            enum CodingKeys: CodingKey {
+                case name
+                case ascending
+            }
+
+            var container = columnsContainer.nestedContainer(keyedBy: CodingKeys.self)
+            try container.encode(column.column, forKey: .name)
+            try container.encode(column.ascending, forKey: .ascending)
+        }
     }
 }

--- a/Sources/PowerSync/Protocol/Schema/Index.swift
+++ b/Sources/PowerSync/Protocol/Schema/Index.swift
@@ -58,12 +58,12 @@ public struct Index: IndexProtocol, Encodable {
         try container.encode(name, forKey: .name)
         var columnsContainer = container.nestedUnkeyedContainer(forKey: .columns)
         for column in columns {
-            enum CodingKeys: CodingKey {
+            enum IndexedColumnCodingKeys: CodingKey {
                 case name
                 case ascending
             }
 
-            var container = columnsContainer.nestedContainer(keyedBy: CodingKeys.self)
+            var container = columnsContainer.nestedContainer(keyedBy: IndexedColumnCodingKeys.self)
             try container.encode(column.column, forKey: .name)
             try container.encode(column.ascending, forKey: .ascending)
         }

--- a/Sources/PowerSync/Protocol/Schema/RawTable.swift
+++ b/Sources/PowerSync/Protocol/Schema/RawTable.swift
@@ -11,7 +11,7 @@
 ///
 /// Note that raw tables are only supported when ``ConnectOptions/newClientImplementation``
 /// is enabled.
-public struct RawTable: BaseTableProtocol {
+public struct RawTable: BaseTableProtocol, Encodable {
     /// The name of the table as it appears in sync rules.
     ///
     /// This doesn't necessarily have to match the statement that ``RawTable/put`` and ``RawTable/delete``
@@ -57,12 +57,43 @@ public struct RawTable: BaseTableProtocol {
     /// 
     /// The output of this can be passed to the `powersync_create_raw_table_crud_trigger` SQL
     /// function to define triggers for this table.
-    public func jsonDescription() -> String {
-        return KotlinAdapter.Table.toKotlin(self).jsonDescription()
+    public func jsonDescription() throws -> String {
+        let serialized = try Schema.encoder.encode(self)
+        return String(data: serialized, encoding: .utf8)!
+    }
+    
+    internal func validate() throws(TableError) {
+        if let schema {
+            try schema.options.validate(tableName: name)
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        enum CodingKeys: String, CodingKey {
+            case name
+            case put
+            case delete
+            case clear
+            // For schema
+            case tableName = "table_name"
+            case syncedColumns = "synced_columns"
+        }
+        typealias Keys = TableOptionsCodingKeys<CodingKeys>
+
+        var container = encoder.container(keyedBy: Keys.self)
+        try container.encode(name, forKey: .outer(.name))
+        try container.encodeIfPresent(put, forKey: .outer(.put))
+        try container.encodeIfPresent(delete, forKey: .outer(.delete))
+        try container.encodeIfPresent(clear, forKey: .outer(.clear))
+        if let schema {
+            try container.encode(schema.tableName ?? name, forKey: .outer(.tableName))
+            try container.encodeIfPresent(schema.syncedColumns, forKey: .outer(.syncedColumns))
+            try schema.options.serializeTo(container)
+        }
     }
 }
 
-/// THe schema of a ``RawTable`` in the local database.
+/// The schema of a ``RawTable`` in the local database.
 /// 
 /// This information is optional when declaring raw tables. However, providing it allows the sync
 /// client to infer ``RawTable/put`` and ``RawTable/delete`` statements automatically.
@@ -95,7 +126,7 @@ public struct RawTableSchema: Sendable {
 }
 
 /// A statement to run to sync server-side changes into a local raw table.
-public struct PendingStatement: Sendable {
+public struct PendingStatement: Sendable, Encodable {
     /// The SQL statement to execute.
     public let sql: String
     /// For parameters in the prepared statement, the values to fill in.
@@ -108,10 +139,21 @@ public struct PendingStatement: Sendable {
         self.sql = sql
         self.parameters = parameters
     }
+
+    public func encode(to encoder: any Encoder) throws {
+        enum CodingKeys: String, CodingKey {
+            case sql
+            case parameters = "params"
+         }
+
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.sql, forKey: .sql)
+        try container.encode(self.parameters, forKey: .parameters)
+    }
 }
 
 /// A parameter that can be used in a ``PendingStatement``.
-public enum PendingStatementParameter: Sendable {
+public enum PendingStatementParameter: Sendable, Encodable {
     /// A value that resolves to the textual id of the row to insert, update or delete.
     case id
     /// A value that resolves to the value of a column in a `PUT` operation for inserts or updates.
@@ -122,4 +164,22 @@ public enum PendingStatementParameter: Sendable {
     /// Resolves to a JSON object containing all columns from the synced row that haven't been matched
     /// by a ``PendingStatementParameter/column`` value in the same statement.
     case rest
+
+    public func encode(to encoder: any Encoder) throws {
+        switch self {
+        case .id:
+            var container = encoder.singleValueContainer()
+            try container.encode("Id")
+        case .column(let name):
+            enum CodingKeys: String, CodingKey {
+                case column = "Column"
+            }
+
+            var container = encoder.container(keyedBy: CodingKeys.self)
+            try container.encode(name, forKey: .column)
+        case .rest:
+            var container = encoder.singleValueContainer()
+            try container.encode("Rest")
+        }
+    }
 }

--- a/Sources/PowerSync/Protocol/Schema/RawTable.swift
+++ b/Sources/PowerSync/Protocol/Schema/RawTable.swift
@@ -69,7 +69,7 @@ public struct RawTable: BaseTableProtocol, Encodable {
             // That could also throw an exception (which would crash the process), but that
             // was overlooked due to a missing @Throws annotation.
             // Now, we can't mark this as throws without breaking backwards compatibility.
-            // We should conver this to be throwing in a future major release.
+            // We should convert this to be throwing in a future major release.
             fatalError("Serializing a raw table failed: \(error)")
         }
     }

--- a/Sources/PowerSync/Protocol/Schema/RawTable.swift
+++ b/Sources/PowerSync/Protocol/Schema/RawTable.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// A table that is managed by the user instead of being auto-created and migrated by the PowerSync SDK.
 ///
 /// These tables give application developers full control over the table (including table and column constraints).
@@ -57,11 +59,21 @@ public struct RawTable: BaseTableProtocol, Encodable {
     /// 
     /// The output of this can be passed to the `powersync_create_raw_table_crud_trigger` SQL
     /// function to define triggers for this table.
-    public func jsonDescription() throws -> String {
-        let serialized = try Schema.encoder.encode(self)
-        return String(data: serialized, encoding: .utf8)!
+    public func jsonDescription() -> String {
+        let encoder = JSONEncoder()
+        do {
+            let serialized = try encoder.encode(self)
+            return String(data: serialized, encoding: .utf8)!
+        } catch {
+            // An older version of the Swift SDK used to implement this method in Kotlin.
+            // That could also throw an exception (which would crash the process), but that
+            // was overlooked due to a missing @Throws annotation.
+            // Now, we can't mark this as throws without breaking backwards compatibility.
+            // We should conver this to be throwing in a future major release.
+            fatalError("Serializing a raw table failed: \(error)")
+        }
     }
-    
+
     internal func validate() throws(TableError) {
         if let schema {
             try schema.options.validate(tableName: name)

--- a/Sources/PowerSync/Protocol/Schema/Schema.swift
+++ b/Sources/PowerSync/Protocol/Schema/Schema.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 public protocol SchemaProtocol: Sendable {
     ///
     /// Tables used in Schema
@@ -54,6 +52,10 @@ public struct Schema: SchemaProtocol, Encodable {
         }
         
         for table in rawTables {
+            // Only check for duplicate names if the raw table has a fixed local schema
+            // name. By default, the name in raw tables refers to the name of the table as
+            // defined in Sync Streams. The local table populated by put/delete statements
+            // might be different and we can't check that.
             if let schema = table.schema {
                 let name = schema.tableName ?? table.name
                 if !tableNames.insert(name).inserted {
@@ -64,8 +66,17 @@ public struct Schema: SchemaProtocol, Encodable {
             try table.validate()
         }
     }
-    
-    internal static let encoder = JSONEncoder()
+
+    public func encode(to encoder: any Encoder) throws {
+        enum CodingKeys: String, CodingKey {
+            case tables
+            case rawTables = "raw_tables"
+        }
+
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.tables, forKey: .tables)
+        try container.encode(self.rawTables, forKey: .rawTables)
+    }
 }
 
 public enum SchemaError: Error {

--- a/Sources/PowerSync/Protocol/Schema/Schema.swift
+++ b/Sources/PowerSync/Protocol/Schema/Schema.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public protocol SchemaProtocol: Sendable {
     ///
     /// Tables used in Schema
@@ -12,7 +14,7 @@ public protocol SchemaProtocol: Sendable {
     func validate() throws
 }
 
-public struct Schema: SchemaProtocol {
+public struct Schema: SchemaProtocol, Encodable {
     public let tables: [Table]
     public let rawTables: [RawTable]
 
@@ -50,7 +52,20 @@ public struct Schema: SchemaProtocol {
             }
             try table.validate()
         }
+        
+        for table in rawTables {
+            if let schema = table.schema {
+                let name = schema.tableName ?? table.name
+                if !tableNames.insert(name).inserted {
+                    throw SchemaError.duplicateTableName(name)
+                }
+            }
+            
+            try table.validate()
+        }
     }
+    
+    internal static let encoder = JSONEncoder()
 }
 
 public enum SchemaError: Error {

--- a/Sources/PowerSync/Protocol/Schema/Table.swift
+++ b/Sources/PowerSync/Protocol/Schema/Table.swift
@@ -30,7 +30,7 @@ private let MAX_AMOUNT_OF_COLUMNS = 63
 ///
 /// A single table in the schema.
 ///
-public struct Table: TableProtocol {
+public struct Table: TableProtocol, Encodable {
     public let name: String
     public let columns: [Column]
     public let indexes: [Index]
@@ -119,15 +119,7 @@ public struct Table: TableProtocol {
             throw TableError.invalidViewName(viewName: viewNameOverride)
         }
 
-        if localOnly {
-            if trackPreviousValues != nil {
-                throw TableError.trackPreviousForLocalTable(tableName: name)
-            }
-            if trackMetadata {
-                throw TableError.metadataForLocalTable(tableName: name)
-            }
-        }
-
+        try options.validate(tableName: name)
         var columnNames = Set<String>(["id"])
 
         for column in columns {
@@ -183,6 +175,23 @@ public struct Table: TableProtocol {
 
             indexNames.insert(index.name)
         }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        enum CodingKeys: String, CodingKey {
+            case name
+            case viewName = "view_name"
+            case columns
+            case indexes
+        }
+        typealias Keys = TableOptionsCodingKeys<CodingKeys>
+        
+        var container = encoder.container(keyedBy: Keys.self)
+        try container.encode(name, forKey: .outer(.name))
+        try container.encodeIfPresent(viewNameOverride, forKey: .outer(.viewName))
+        try container.encode(columns, forKey: .outer(.columns))
+        try container.encode(indexes, forKey: .outer(.indexes))
+        try options.serializeTo(container)
     }
 }
 

--- a/Sources/PowerSync/Protocol/Schema/TableOptions.swift
+++ b/Sources/PowerSync/Protocol/Schema/TableOptions.swift
@@ -132,7 +132,7 @@ internal enum TableOptionsCodingKeys<T: CodingKey>: CodingKey {
     case includeMetadata
     case includeOldOnlyWhenChanged
     case ignoreEmptyUpdate
-     
+
     // We don't use these for decoding, so we can return nil here.
     init?(stringValue: String) {
         return nil

--- a/Sources/PowerSync/Protocol/Schema/TableOptions.swift
+++ b/Sources/PowerSync/Protocol/Schema/TableOptions.swift
@@ -71,6 +71,26 @@ public struct TableOptions: TableOptionsProtocol {
         self.trackPreviousValues = trackPreviousValues
         self.ignoreEmptyUpdates = ignoreEmptyUpdates
     }
+    
+    internal func validate(tableName: String) throws(TableError) {
+        if localOnly {
+            if trackPreviousValues != nil {
+                throw TableError.trackPreviousForLocalTable(tableName: tableName)
+            }
+            if trackMetadata {
+                throw TableError.metadataForLocalTable(tableName: tableName)
+            }
+        }
+    }
+
+    internal func serializeTo<T: CodingKey>(_ container: KeyedEncodingContainer<TableOptionsCodingKeys<T>>) throws {
+        var container = container
+        try container.encode(localOnly, forKey: .localOnly)
+        try container.encode(insertOnly, forKey: .insertOnly)
+        try container.encode(trackMetadata, forKey: .includeMetadata)
+        try container.encode(ignoreEmptyUpdates, forKey: .ignoreEmptyUpdate)
+        try trackPreviousValues?.serializeTo(container)
+    }
 }
 
 /// Options to include old values in ``CrudEntry/previousValues`` for update statements.
@@ -90,5 +110,58 @@ public struct TrackPreviousValuesOptions: Sendable {
     public init(columnFilter: [String]? = nil, onlyWhenChanged: Bool = false) {
         self.columnFilter = columnFilter
         self.onlyWhenChanged = onlyWhenChanged
+    }
+
+    internal func serializeTo<T: CodingKey>(_ container: KeyedEncodingContainer<TableOptionsCodingKeys<T>>) throws {
+        var container = container
+        if let columnFilter {
+            try container.encode(columnFilter, forKey: .diffIncludeOld)
+        } else {
+            try container.encode(true, forKey: .diffIncludeOld)
+        }
+        try container.encode(onlyWhenChanged, forKey: .includeOldOnlyWhenChanged)
+    }
+}
+
+/// Coding keys for table options (which are always embedded into another outer object.
+internal enum TableOptionsCodingKeys<T: CodingKey>: CodingKey {
+    case outer(T)
+    case diffIncludeOld
+    case localOnly
+    case insertOnly
+    case includeMetadata
+    case includeOldOnlyWhenChanged
+    case ignoreEmptyUpdate
+     
+    // We don't use these for decoding, so we can return nil here.
+    init?(stringValue: String) {
+        return nil
+    }
+    init?(intValue: Int) {
+        return nil
+    }
+
+    var stringValue: String {
+        switch self {
+        case .outer(let field):
+            return field.stringValue
+        case .diffIncludeOld:
+            return "include_old"
+        case .localOnly:
+            return "local_only"
+        case .insertOnly:
+            return "insert_only"
+        case .includeMetadata:
+            return "include_metadata"
+        case .includeOldOnlyWhenChanged:
+            return "include_old_only_when_changed"
+        case .ignoreEmptyUpdate:
+            return "ignore_empty_update"
+        }
+    }
+
+    // We'll only encode into string-keyed dictionaries (JSON objects).
+    var intValue: Int? {
+        nil
     }
 }

--- a/Tests/PowerSyncTests/Schema/SchemaTests.swift
+++ b/Tests/PowerSyncTests/Schema/SchemaTests.swift
@@ -122,4 +122,12 @@ final class SchemaTests: XCTestCase {
         XCTAssertEqual(schema.tables[0].name, users.name)
         XCTAssertEqual(schema.tables[1].name, posts.name)
     }
+    
+    func testEncode() throws {
+        let schema = Schema()
+        let encoder = JSONEncoder()
+        encoder.outputFormatting.insert(.sortedKeys)
+        let serialized = String(data: try encoder.encode(schema), encoding: .utf8)
+        XCTAssertEqual(serialized, #"{"raw_tables":[],"tables":[]}"#)
+    }
 }

--- a/Tests/PowerSyncTests/Schema/SchemaTests.swift
+++ b/Tests/PowerSyncTests/Schema/SchemaTests.swift
@@ -66,7 +66,22 @@ final class SchemaTests: XCTestCase {
             XCTAssertEqual(tableName, "users")
         }
     }
-    
+
+    func testDuplicateTableOneRaw() {
+        let schema = Schema(
+            makeValidTable(name: "users"),
+            RawTable(name: "source_from_sync_streams", schema: RawTableSchema(tableName: "users"))
+        )
+
+        XCTAssertThrowsError(try schema.validate()) { error in
+            guard case SchemaError.duplicateTableName(let tableName) = error else {
+                XCTFail("Expected duplicateTableName error")
+                return
+            }
+            XCTAssertEqual(tableName, "users")
+        }
+    }
+
     func testCascadingTableValidation() {
         let schema = Schema(
             makeValidTable(name: "users"),

--- a/Tests/PowerSyncTests/Schema/TableTests.swift
+++ b/Tests/PowerSyncTests/Schema/TableTests.swift
@@ -285,7 +285,7 @@ final class TableTests: XCTestCase {
 """)
     }
 
-    func testRawTableSerialize() throws {
+    func testRawTableSerializeSimple() throws {
         let table = RawTable(
             name: "users",
             put: PendingStatement(sql: "SELECT 1", parameters: [.id]),
@@ -319,4 +319,33 @@ final class TableTests: XCTestCase {
 }
 """)
     }
+
+    func testRawTableSerializeWithOptions() throws {
+        let table = RawTable(
+            name: "users",
+            schema: RawTableSchema(
+                syncedColumns: ["foo"],
+                options: TableOptions(insertOnly: true)
+            )
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting.insert(.prettyPrinted)
+        encoder.outputFormatting.insert(.sortedKeys)
+        let serialized = String(data: try encoder.encode(table), encoding: .utf8)
+
+        XCTAssertEqual(serialized, """
+{
+  "ignore_empty_update" : false,
+  "include_metadata" : false,
+  "insert_only" : true,
+  "local_only" : false,
+  "name" : "users",
+  "synced_columns" : [
+    "foo"
+  ],
+  "table_name" : "users"
+}
+""")
+    }
+
 }

--- a/Tests/PowerSyncTests/Schema/TableTests.swift
+++ b/Tests/PowerSyncTests/Schema/TableTests.swift
@@ -230,4 +230,93 @@ final class TableTests: XCTestCase {
         
         XCTAssertNoThrow(try table.validate())
     }
+    
+    func testSerialize() throws {
+        let table = Table(
+            name: "users",
+            columns: makeValidColumns(),
+            indexes: [makeValidIndex()],
+            localOnly: false,
+            insertOnly: false,
+            trackPreviousValues: TrackPreviousValuesOptions(columnFilter: ["name"], onlyWhenChanged: true)
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting.insert(.prettyPrinted)
+        encoder.outputFormatting.insert(.sortedKeys)
+        let serialized = String(data: try encoder.encode(table), encoding: .utf8)
+
+        XCTAssertEqual(serialized, """
+{
+  "columns" : [
+    {
+      "name" : "name",
+      "type" : "text"
+    },
+    {
+      "name" : "age",
+      "type" : "integer"
+    },
+    {
+      "name" : "score",
+      "type" : "real"
+    }
+  ],
+  "ignore_empty_update" : false,
+  "include_metadata" : false,
+  "include_old" : [
+    "name"
+  ],
+  "include_old_only_when_changed" : true,
+  "indexes" : [
+    {
+      "columns" : [
+        {
+          "ascending" : true,
+          "name" : "name"
+        }
+      ],
+      "name" : "test_index"
+    }
+  ],
+  "insert_only" : false,
+  "local_only" : false,
+  "name" : "users"
+}
+""")
+    }
+
+    func testRawTableSerialize() throws {
+        let table = RawTable(
+            name: "users",
+            put: PendingStatement(sql: "SELECT 1", parameters: [.id]),
+            delete: PendingStatement(sql: "SELECT 2", parameters: [.column("a"), .rest]),
+            clear: "SELECT 3"
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting.insert(.prettyPrinted)
+        encoder.outputFormatting.insert(.sortedKeys)
+        let serialized = String(data: try encoder.encode(table), encoding: .utf8)
+
+        XCTAssertEqual(serialized, """
+{
+  "clear" : "SELECT 3",
+  "delete" : {
+    "params" : [
+      {
+        "Column" : "a"
+      },
+      "Rest"
+    ],
+    "sql" : "SELECT 2"
+  },
+  "name" : "users",
+  "put" : {
+    "params" : [
+      "Id"
+    ],
+    "sql" : "SELECT 1"
+  }
+}
+""")
+    }
 }


### PR DESCRIPTION
The core extension expects a JSON-serialized schema to setup tables, views, triggers and the sync client. Currently, the Swift SDK maps its table structures to Kotlin which is then responsible for the serialization.

This implements the necessary steps in Swift through the `Encodable` protocol. This is not that useful on its own because we still have to go through Kotlin, but this will be helpful as we eventually remove the Kotlin dependency here.