### PR TITLE
Enable zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 7

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -4,15 +4,34 @@ on:
   push:
   workflow_call:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+permissions: {}
+
 jobs:
+  zizmor:
+    permissions:
+      security-events: write # Needed to upload findings as code scanning results.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          persona: pedantic
+
   build:
     name: Build and test
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up XCode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # 1.7.0
         with:
           xcode-version: latest-stable
 

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up XCode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # 1.7.0
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -3,19 +3,21 @@ name: Deploy Docs
 on:
   push:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   build:
     name: Build
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Set up XCode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # 1.7.0
         with:
           xcode-version: latest-stable
       - name: Build Docs
@@ -55,7 +57,10 @@ jobs:
       url: ${{ needs.build.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      pages: write # To deploy pages
+      id-token: write # to verify the deployment originates from an appropriate source
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Set up XCode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # 1.7.0
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: latest-stable
       - name: Build Docs

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
           TAG: ${{ github.event.inputs.version }}
           NOTES: ${{ github.event.inputs.release_notes }}
         run: |
-          gh release create $TAG --notes $NOTES
+          gh release create $TAG --notes "$NOTES"
       - name: Create GitHub Pre-Release
         if: ${{ steps.version_check.outputs.is_prerelease }}
         env:
@@ -66,4 +66,4 @@ jobs:
           TAG: ${{ github.event.inputs.version }}
           NOTES: ${{ github.event.inputs.release_notes }}
         run: |
-          gh release create $TAG --notes $NOTES -p
+          gh release create $TAG --notes "$NOTES" --prerelease

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,24 +12,32 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   build:
     uses: ./.github/workflows/build_and_test.yaml
+
   release:
+    permissions:
+      contents: write # To create the release
     needs: build
     runs-on: macos-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Validate version format and set prerelease flag
         id: version_check
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          if [[ ${{ github.event.inputs.version }} =~ ^[0-9]+\.[0-9]+\.[0-9]+(-Beta\.[0-9]+)?$ ]]; then
-            if [[ ${{ github.event.inputs.version }} =~ -Beta\.[0-9]+$ ]]; then
+          if [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+(-Beta\.[0-9]+)?$ ]]; then
+            if [[ $VERSION =~ -Beta\.[0-9]+$ ]]; then
               echo "is_prerelease=true" >> $GITHUB_OUTPUT
               echo "Version is valid Beta format"
             else
@@ -43,17 +51,19 @@ jobs:
             exit 1
           fi
 
-      - name: Create Git tag
-        run: |
-          git tag ${{ github.event.inputs.version }}
-          git push origin ${{ github.event.inputs.version }}
-
       - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ github.event.inputs.version }}
-          name: PowerSync ${{ github.event.inputs.version }}
-          body: ${{ github.event.inputs.release_notes }}
-          draft: false
-          prerelease: ${{ steps.version_check.outputs.is_prerelease }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+        if: ${{ !steps.version_check.outputs.is_prerelease }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.version }}
+          NOTES: ${{ github.event.inputs.release_notes }}
+        run: |
+          gh release create $TAG --notes $NOTES
+      - name: Create GitHub Pre-Release
+        if: ${{ steps.version_check.outputs.is_prerelease }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.version }}
+          NOTES: ${{ github.event.inputs.release_notes }}
+        run: |
+          gh release create $TAG --notes $NOTES -p

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -4,7 +4,6 @@ rules:
     config:
       policies:
         "actions/*": ref-pin
-        "Homebrew/actions/*": ref-pin
   anonymous-definition:
     disable: true
   concurrency-limits:

--- a/.github/zizmor.yaml
+++ b/.github/zizmor.yaml
@@ -1,0 +1,14 @@
+# Configuration for https://zizmor.sh/, a static analysis tool for GitHub actions.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        "actions/*": ref-pin
+        "Homebrew/actions/*": ref-pin
+  anonymous-definition:
+    disable: true
+  concurrency-limits:
+    ignore:
+      # We don't need to limit concurrency for publishing, as only maintainers can
+      # push tags.
+      - release.yaml:3:1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.14.0 (unreleased)
+## 1.14.0-Beta.0
 
 * Remove internal dependency on the PowerSync Kotlin SDK. Going forward, the Swift SDK is implemented in Swift!
   __Important__: While these changes are tested, they are a full rewrite of the internal connection pool logic.

--- a/Sources/PowerSync/CurrentVersion.swift
+++ b/Sources/PowerSync/CurrentVersion.swift
@@ -1,3 +1,3 @@
 // The current version of the PowerSync Swift SDK. This should be updated to the latest version in `CHANGELOG.md` when a new version is released.
-let libraryVersion = "1.13.1"
+let libraryVersion = "1.14.0-Beta.0"
 


### PR DESCRIPTION
This enables zizmor as a static analysis tool for GitHub actions, using the same configuration as the [Dart SDK](https://github.com/powersync-ja/powersync.dart/pull/416).

This mainly involves setting `permissions: {}` for most jobs and adding a concurrency limit. Also, the release process has been changed a bit:

1. We don't need to push a tag manually since `gh release create` is supposed to do that ([docs](https://cli.github.com/manual/gh_release_create), "If a matching git tag does not yet exist, one will automatically get created from the latest state of the default branch.").
2. Zizmor wants us to use `gh release` directly instead of `ncipollo/release-action`.

While refactoring the release process, I realized we have the option of doing pre-releases! So, this also prepares a beta release for 1.14.0, which we can release without waiting for potential GRDB changes we might want to add as well.