### PR TITLE
Move zizmor check into its own workflow

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -9,19 +9,6 @@ concurrency:
 permissions: {}
 
 jobs:
-  zizmor:
-    permissions:
-      security-events: write # Needed to upload findings as code scanning results.
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - name: Run zizmor 🌈
-        uses: zizmorcore/zizmor-action@a16621b09c6db4281f81a93cb393b05dcd7b7165 # v0.5.5
-        with:
-          persona: pedantic
-
   build:
     name: Build and test
     runs-on: macos-latest

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -1,0 +1,25 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  zizmor:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # Needed to upload findings as code scanning results.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
This moves the zizmor check into its own workflow. Previously, it was part of `build_and_test.yaml`, a workflow also triggered during a release. GitHub doesn't allow nested jobs to request additional permissions, causing [release runs to fail](https://github.com/powersync-ja/powersync-swift/actions/runs/26503903916/workflow).

This should fix the issue, I'll try a release from this branch after an approval to be sure.