### PR TITLE
Add changelog for 1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.14.1
+
+* [Internal] The GRDB integration uses high-level GRDB APIs to run statements.
+  Previously, it would use the raw connection pointer only.
+
 ## 1.14.0
 
 * Remove internal dependency on the PowerSync Kotlin SDK. Going forward, the Swift SDK is implemented in Swift!


### PR DESCRIPTION
The only change since the last release is https://github.com/powersync-ja/powersync-swift/pull/140. But since we don't really have anything else queued up, I think it's worth getting that out. This prepares a patch release (`CurrentVersion.swift` is already up-to-date), I'll trigger the release workflow after an approval.