### PR TITLE
Fix `readTransaction` throwing for connection pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.14.2
+
+* Fix `readTransaction` throwing. This issue was introduced in version 1.14.0.
+
 ## 1.14.1
 
 * [Internal] The GRDB integration uses high-level GRDB APIs to run statements.

--- a/Sources/PowerSync/CurrentVersion.swift
+++ b/Sources/PowerSync/CurrentVersion.swift
@@ -1,2 +1,2 @@
 // The current version of the PowerSync Swift SDK. This should be updated to the latest version in `CHANGELOG.md` when a new version is released.
-let libraryVersion = "1.14.1"
+let libraryVersion = "1.14.2"

--- a/Sources/PowerSync/Implementation/AsyncConnectionPool.swift
+++ b/Sources/PowerSync/Implementation/AsyncConnectionPool.swift
@@ -90,9 +90,6 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
 
         if isWriter {
             let _ = try context.execute(sql: "pragma journal_mode = WAL", parameters: [])
-        } else {
-            // This is mainly an additional safety element, we also open read connections SQLITE_READONLY.
-            let _ = try context.execute(sql: "pragma query_only = TRUE", parameters: [])
         }
 
         let _ = try context.execute(sql: "pragma journal_size_limit = \(6 * 1024 * 1024)", parameters: [])

--- a/Tests/PowerSyncTests/Implementation/DatabaseImplementationTests.swift
+++ b/Tests/PowerSyncTests/Implementation/DatabaseImplementationTests.swift
@@ -11,7 +11,7 @@ struct DatabaseImplementationTests {
             logger: DefaultLogger()
         )
 
-        let error = try await db.readTransaction { tx in
+        let description = try await db.readTransaction { tx in
             try tx.get(sql: "SELECT 1", parameters: [], mapper: { cursor in  })
             
             // Writing to the database in a read-only connection must fail.
@@ -21,6 +21,6 @@ struct DatabaseImplementationTests {
             return try #require(error?.errorDescription)
         }
         try await db.close(deleteDatabase: true)
-        #expect(error.contains("attempt to write a readonly database") == true)
+        #expect(description.contains("attempt to write a readonly database"))
     }
 }

--- a/Tests/PowerSyncTests/Implementation/DatabaseImplementationTests.swift
+++ b/Tests/PowerSyncTests/Implementation/DatabaseImplementationTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+@testable import PowerSync
+import Testing
+
+struct DatabaseImplementationTests {
+    @Test func readTransaction() async throws {
+        // Regression test for https://github.com/powersync-ja/powersync-swift/issues/142.
+        let db = PowerSyncDatabase(
+            schema: Schema(),
+            dbFilename: "read-tx-regression-test",
+            logger: DefaultLogger()
+        )
+
+        let error = try await db.readTransaction { tx in
+            try tx.get(sql: "SELECT 1", parameters: [], mapper: { cursor in  })
+            
+            // Writing to the database in a read-only connection must fail.
+            let error = #expect(throws: PowerSyncError.self) {
+                try tx.execute(sql: "DELETE FROM ps_kv", parameters: [])
+            }
+            return try #require(error?.errorDescription)
+        }
+        try await db.close(deleteDatabase: true)
+        #expect(error.contains("attempt to write a readonly database") == true)
+    }
+}


### PR DESCRIPTION
Matching the behavior from our Dart and JavaScript SDKs, the Swift SDK started using `BEGIN IMMEDIATE` for read transactions in version 1.14.0. The reason for this is that we want to start the transaction as soon as possible, instead of having the WAL cutoff at the first statement used in the callback.

Unfortunately, the Swift SDK also enables `pragma query_only = TRUE` on read connections, which prevents `BEGIN IMMEDIATE`. This is not actually necessary though, we also open connections with `SQLITE_READONLY` to prevent writes. So, the fix is to simply not do that.

This also adds a test verifying that read transaction work on connection pools (the default tests with in-memory database don't catch this issue) and that we can't write in them.

Closes #142.