### PR TITLE
Fix crud upload error loop

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -6,6 +6,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 permissions: {}
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.14.3
+
+- Fix CRUD uploads entering a `Delaying due to previously encountered CRUD item` loop.
+
 ## 1.14.2
 
 * Fix `readTransaction` throwing. This issue was introduced in version 1.14.0.

--- a/Sources/PowerSync/CurrentVersion.swift
+++ b/Sources/PowerSync/CurrentVersion.swift
@@ -1,2 +1,2 @@
 // The current version of the PowerSync Swift SDK. This should be updated to the latest version in `CHANGELOG.md` when a new version is released.
-let libraryVersion = "1.14.2"
+let libraryVersion = "1.14.3"

--- a/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
+++ b/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
@@ -45,10 +45,9 @@ final class StreamingSyncClient: Sendable {
             async let crudThrottleDelay = sleepForSeconds(seconds: self.options.crudThrottle)
             try await uploadAllCrud()
             
-            db.logger.debug("crud upload: notify completion \(self.options.crudThrottle)", tag: tag)
+            db.logger.debug("crud upload: notify completion", tag: tag)
             signals.notifyCrudUploadComplete()
             try await crudThrottleDelay
-            db.logger.debug("crud upload: delay done \(self.options.crudThrottle)", tag: tag)
         } while try await allTriggers.next() != nil
     }
     

--- a/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
+++ b/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
@@ -37,18 +37,16 @@ final class StreamingSyncClient: Sendable {
     }
 
     private func uploadLoop(signals: SyncSignals) async throws {
-        // TODO: Replace with better watch mechanism once we've dropped the Kotlin dependency and can use onChange.
-        let options = WatchOptions(sql: "SELECT 1 FROM ps_crud LIMIT 1", throttle: options.crudThrottle, mapper: { _ in ()})
-        let watch = try db.watch(options: options)
-            .dropFirst() // Skip initial result, we just want to watch changes
-            .map { _ in () }
-        let allTriggers = AsyncAlgorithms.merge(watch, signals.signalCrudUpload.subscribe())
+        let updates = db.pool.tableUpdates.filter { updates in updates.contains("ps_crud") }.map { _ in () }
+        let allTriggers = MergeItemSequence(inner: AsyncAlgorithms.merge(updates, signals.signalCrudUpload.subscribe()))
         
         for try await _ in allTriggers {
+            async let crudThrottleDelay = sleepForSeconds(seconds: self.options.crudThrottle)
             try await uploadAllCrud()
             
             db.logger.debug("crud upload: notify completion", tag: tag)
             signals.notifyCrudUploadComplete()
+            try await crudThrottleDelay
         }
     }
     
@@ -84,7 +82,7 @@ The next upload iteration will be delayed.
                 if error is CancellationError {
                     return
                 }
-                
+                lastUploadItem = nil
                 db.syncStatus.mutateStatus {
                     $0.uploading = false
                     $0.internalUploadError = error

--- a/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
+++ b/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
@@ -38,16 +38,18 @@ final class StreamingSyncClient: Sendable {
 
     private func uploadLoop(signals: SyncSignals) async throws {
         let updates = db.pool.tableUpdates.filter { updates in updates.contains("ps_crud") }.map { _ in () }
-        let allTriggers = MergeItemSequence(inner: AsyncAlgorithms.merge(updates, signals.signalCrudUpload.subscribe()))
+        let allTriggers = MergeItemSequence(inner: AsyncAlgorithms.merge(updates, signals.signalCrudUpload.subscribe())).makeAsyncIterator()
         
-        for try await _ in allTriggers {
+        // Use a do-while loop to ensure we start an upload iteration even if we can't connect to the service.
+        repeat {
             async let crudThrottleDelay = sleepForSeconds(seconds: self.options.crudThrottle)
             try await uploadAllCrud()
             
-            db.logger.debug("crud upload: notify completion", tag: tag)
+            db.logger.debug("crud upload: notify completion \(self.options.crudThrottle)", tag: tag)
             signals.notifyCrudUploadComplete()
             try await crudThrottleDelay
-        }
+            db.logger.debug("crud upload: delay done \(self.options.crudThrottle)", tag: tag)
+        } while try await allTriggers.next() != nil
     }
     
     private func uploadAllCrud() async throws {

--- a/Tests/PowerSyncTests/AttachmentTests.swift
+++ b/Tests/PowerSyncTests/AttachmentTests.swift
@@ -290,7 +290,7 @@ public func waitForMatch<T: Sendable, E: Error>(
 func waitFor(
     timeout: TimeInterval = 0.5,
     interval: TimeInterval = 0.1,
-    predicate: () async throws -> Void
+    predicate: @Sendable () async throws -> Void
 ) async throws {
     let intervalNanoseconds = UInt64(interval * 1_000_000_000)
 

--- a/Tests/PowerSyncTests/SyncTests.swift
+++ b/Tests/PowerSyncTests/SyncTests.swift
@@ -200,6 +200,40 @@ class InMemorySyncIntegrationTests {
         try #require(try await query.next() == ["from server"])
     }
     
+    @Test @MainActor func recoversFromUploadErrors() async throws {
+        let channel = AsyncThrowingChannel<PowerSync.SyncLine, any Error>()
+        let mockClient = MockHttpClient { request in channel }
+        let db = openDatabase(mockClient)
+        mockClient.writeCheckpoint = 1
+        var isFirstUpload = true
+
+        try await db.execute(sql: "INSERT INTO users (id, name) VALUES (uuid(), ?)", parameters: ["local write"])
+        try await db.connect(connector: TestConnector { @MainActor db in
+            if isFirstUpload {
+                isFirstUpload = false
+                throw PowerSyncError.operationFailed(message: "Deliberate failure in upload for test", underlyingError: nil)
+            }
+            let tx = try await db.getNextCrudTransaction()
+            try await tx?.complete()
+        }, options: ConnectOptions(retryDelay: 0.5))
+        await waitForStatus(db.currentStatus) { $0.uploadError != nil }
+
+        var query = try db.watch("SELECT name FROM users") { try $0.getString(index: 0) }.makeAsyncIterator()
+        try #require(try await query.next() == ["local write"])
+
+        try await channel.pushLine(.fullCheckpoint(Checkpoint(last_op_id: "1", buckets: [BucketChecksum(bucket: "a", checksum: 0)], writeCheckpoint: "1")))
+        try await channel.pushLine(.syncDataBucket(SyncDataBucket(bucket: "a", data: [OplogEntry(
+            checksum: 0,
+            op_id: "1",
+            object_id: "1",
+            object_type: "users",
+            op: .put,
+            data: #"{"id": "test1", "name": "from server"}"#,
+        )])))
+        try await channel.pushLine(.checkpointComplete(lastOpId: "1"))
+        try #require(try await query.next() == ["from server"])
+    }
+    
     @Test @MainActor func uploadsOfflineWrites() async throws {
         let channel = AsyncThrowingChannel<PowerSync.SyncLine, any Error>()
         var allowConnection = false
@@ -232,23 +266,6 @@ class InMemorySyncIntegrationTests {
         )])))
         try await channel.pushLine(.checkpointComplete(lastOpId: "1"))
         try #require(try await query.next() == ["from server"])
-    }
-    
-    @Test @MainActor func appliesCrudThrottle() async throws {
-        let mockClient = MockHttpClient { request in AsyncThrowingChannel<PowerSync.SyncLine, any Error>() }
-
-        let db = openDatabase(mockClient)
-        var crudUploadCalls = 0
-        
-        try await db.connect(connector: TestConnector { @MainActor db in crudUploadCalls += 1 }, options: ConnectOptions(crudThrottle: 20))
-        await waitForStatus(db.currentStatus) { $0.connected }
-        // Wait for the initial upload on connect()
-        try await waitFor { @MainActor #expect(crudUploadCalls == 1) }
-        
-        // Updating something now should not trigger another upload due to the long throttle.
-        try await db.execute(sql: "INSERT INTO users (id, name) VALUES (uuid(), ?)", parameters: ["local write"])
-        try await sleepForSeconds(seconds: 1)
-        #expect(crudUploadCalls == 1)
     }
 
     @Test func tokenExpired() async throws {

--- a/Tests/PowerSyncTests/SyncTests.swift
+++ b/Tests/PowerSyncTests/SyncTests.swift
@@ -233,6 +233,23 @@ class InMemorySyncIntegrationTests {
         try await channel.pushLine(.checkpointComplete(lastOpId: "1"))
         try #require(try await query.next() == ["from server"])
     }
+    
+    @Test @MainActor func appliesCrudThrottle() async throws {
+        let mockClient = MockHttpClient { request in AsyncThrowingChannel<PowerSync.SyncLine, any Error>() }
+
+        let db = openDatabase(mockClient)
+        var crudUploadCalls = 0
+        
+        try await db.connect(connector: TestConnector { @MainActor db in crudUploadCalls += 1 }, options: ConnectOptions(crudThrottle: 20))
+        await waitForStatus(db.currentStatus) { $0.connected }
+        // Wait for the initial upload on connect()
+        try await waitFor { @MainActor #expect(crudUploadCalls == 1) }
+        
+        // Updating something now should not trigger another upload due to the long throttle.
+        try await db.execute(sql: "INSERT INTO users (id, name) VALUES (uuid(), ?)", parameters: ["local write"])
+        try await sleepForSeconds(seconds: 1)
+        #expect(crudUploadCalls == 1)
+    }
 
     @Test func tokenExpired() async throws {
         final actor BackendConnector: PowerSyncBackendConnectorProtocol {

--- a/Tests/PowerSyncTests/SyncTests.swift
+++ b/Tests/PowerSyncTests/SyncTests.swift
@@ -175,7 +175,7 @@ class InMemorySyncIntegrationTests {
         await waitForStatus(db.currentStatus) { $0.connected }
     }
 
-    @Test func uploadsOfflineWrites() async throws {
+    @Test func uploadsWritesMadeBeforeConnecting() async throws {
         let channel = AsyncThrowingChannel<PowerSync.SyncLine, any Error>()
         let mockClient = MockHttpClient { request in channel }
         let db = openDatabase(mockClient)
@@ -187,6 +187,40 @@ class InMemorySyncIntegrationTests {
         var query = try db.watch("SELECT name FROM users") { try $0.getString(index: 0) }.makeAsyncIterator()
         try #require(try await query.next() == ["local write"])
 
+        try await channel.pushLine(.fullCheckpoint(Checkpoint(last_op_id: "1", buckets: [BucketChecksum(bucket: "a", checksum: 0)], writeCheckpoint: "1")))
+        try await channel.pushLine(.syncDataBucket(SyncDataBucket(bucket: "a", data: [OplogEntry(
+            checksum: 0,
+            op_id: "1",
+            object_id: "1",
+            object_type: "users",
+            op: .put,
+            data: #"{"id": "test1", "name": "from server"}"#,
+        )])))
+        try await channel.pushLine(.checkpointComplete(lastOpId: "1"))
+        try #require(try await query.next() == ["from server"])
+    }
+    
+    @Test @MainActor func uploadsOfflineWrites() async throws {
+        let channel = AsyncThrowingChannel<PowerSync.SyncLine, any Error>()
+        var allowConnection = false
+        let mockClient = MockHttpClient { @MainActor request in
+            if allowConnection {
+                return channel
+            }
+            throw PowerSyncError.operationFailed(message: "Fake IO error for test", underlyingError: nil)
+        }
+        let db = openDatabase(mockClient)
+        mockClient.writeCheckpoint = 1
+
+        // Connect but simulate an IO error from an offline device.
+        try await db.connect(connector: TestConnector(), options: ConnectOptions(retryDelay: 0.1))
+        await waitForStatus(db.currentStatus) { $0.downloadError != nil }
+
+        try await db.execute(sql: "INSERT INTO users (id, name) VALUES (uuid(), ?)", parameters: ["local write"])
+        var query = try db.watch("SELECT name FROM users") { try $0.getString(index: 0) }.makeAsyncIterator()
+        try #require(try await query.next() == ["local write"])
+        
+        allowConnection = true
         try await channel.pushLine(.fullCheckpoint(Checkpoint(last_op_id: "1", buckets: [BucketChecksum(bucket: "a", checksum: 0)], writeCheckpoint: "1")))
         try await channel.pushLine(.syncDataBucket(SyncDataBucket(bucket: "a", data: [OplogEntry(
             checksum: 0,
@@ -796,7 +830,7 @@ func expectUserCount(_ db: PowerSyncDatabaseProtocol, _ amount: Int32) async thr
     try #require(users.count == amount)
 }
 
-func waitForStatus(_ status: SyncStatus, predicate: (borrowing SyncStatusData) -> Bool) async {
+func waitForStatus(_ status: SyncStatus, predicate: @Sendable (borrowing SyncStatusData) -> Bool) async {
     if predicate(status) {
         return
     }


### PR DESCRIPTION
In `uploadAllCrud()`, we have a check to emit a warning when `uploadData` is invoked without completing the oldest CRUD item. Unfortunately, we're not clearing that on errors, leading to cases like these:

1. We set `lastUploadItem` to the oldest item.
2. We invoke `uploadData`, which may throw due to e.g. the device being offline.
3. We wait for the retry delay.
4. We fetch the oldest item, realize that it's the same as last time, emit the warning and wait for the retry delay.
5. ... this repeats indefinitely.

The solution is to do what we do on other SDKs as well, clear `lastUploadItem` on errors.

This also fixes an open todo about using change notifications from the underlying pool instead of other writes and ensures we start an upload on `connect()`.