### PR TITLE
Add PowerSyncSwiftData: a SwiftData custom DataStore backed by PowerSync (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@
   as-is so the database can live in an App Group container shared with app extensions.
   Plain filenames keep the existing behavior. The SDK coordinates opening the database to
   avoid conflicts and can share update notifications across the main app and extensions.
+* Added Alpha `PowerSyncSwiftData` product: a SwiftData custom `DataStore` backed by
+  PowerSync, so apps can use `@Model`/`@Query`/`ModelContext` with PowerSync storage and
+  sync (iOS 18 / macOS 15 / watchOS 11 / tvOS 18). Includes derived PowerSync schemas
+  (`PowerSyncSchema(for:)`), predicate/sort translation to SQL, relationships, live
+  updates via `PowerSyncChangeObserver`, and a read-only mode for widgets and app
+  extensions. Combined with the multi-process support above, `PowerSyncSwiftData`
+  extensions can read and write the shared database with live `@Query` updates in the
+  app. See `Sources/PowerSyncSwiftData/README.md`.
+* Added optional `PowerSyncSwiftDataMacros` product with the `@PowerSyncModel` macro,
+  which generates a `PredicateCodableKeyPathProviding` conformance so models expose their
+  key paths through public API instead of the reflection fallback.
 
 ## 1.14.4
 

--- a/Demos/SwiftDataDemo/README.md
+++ b/Demos/SwiftDataDemo/README.md
@@ -1,0 +1,145 @@
+# PowerSync SwiftData Demo
+
+A Todo List app built with **SwiftData** (`@Model`, `@Query`, `ModelContext`) whose storage is
+**PowerSync**, using the `PowerSyncSwiftData` product of this package. It includes a
+**read-only Widget Extension** that renders synced data from the same PowerSync database
+file via an App Group — the use case from
+[powersync-swift#126](https://github.com/powersync-ja/powersync-swift/issues/126).
+
+How it fits together:
+
+- `PowerSyncSchema(for: [TodoList.self, Todo.self])` derives the PowerSync schema (tables
+  `todo_list` and `todo`) from the SwiftData models — the models are declared once.
+- `PowerSyncDataStoreConfiguration` + `ModelContainer` route every SwiftData fetch and save
+  through PowerSync, so local writes land in the upload queue and sync to Supabase.
+- `PowerSyncChangeObserver` re-injects sync downloads into SwiftData, so plain `@Query`
+  views update live.
+- The PowerSync database file lives in the App Group container; the widget opens its own
+  read-only store over the same file, without connecting to the sync service.
+
+## Set up your Supabase and PowerSync projects
+
+To run this demo, you need Supabase and PowerSync projects. Detailed instructions for
+integrating PowerSync with Supabase can be found in
+[the integration guide](https://docs.powersync.com/integration-guides/supabase).
+
+### 1. Create the tables
+
+The PowerSync tables are derived from the SwiftData models: entity names become snake_case
+table names (`TodoList` → `todo_list`, `Todo` → `todo`), attribute names become column
+names verbatim, and the to-one relationship `Todo.list` becomes a `list_id` column.
+Create the matching Postgres tables in the Supabase SQL editor:
+
+```sql
+create table public.todo_list (
+    id uuid not null default gen_random_uuid() primary key,
+    name text not null
+);
+
+create table public.todo (
+    id uuid not null default gen_random_uuid() primary key,
+    "descriptionText" text not null,
+    completed boolean not null default false,
+    list_id uuid references public.todo_list (id) on delete cascade
+);
+```
+
+> Note the quotes around `"descriptionText"`: the column name preserves the Swift property
+> name's camelCase, so it must be quoted in Postgres.
+
+### 2. Create the PowerSync publication
+
+```sql
+create publication powersync for table public.todo_list, public.todo;
+```
+
+### 3. Create a PowerSync instance and deploy sync rules
+
+Create a new PowerSync instance connected to the Supabase database (see
+[instructions](https://docs.powersync.com/integration-guides/supabase-+-powersync#connect-powersync-to-your-supabase)),
+then deploy these sync rules:
+
+```yaml
+bucket_definitions:
+  global:
+    data:
+      - SELECT * FROM todo_list
+      - SELECT * FROM todo
+```
+
+> The demo models intentionally have no owner column, so the rules sync everything to every
+> signed-in user. A real app would add e.g. an `owner_id` column and bucket parameters.
+
+## Configure the app
+
+1. Copy the secrets template and insert the credentials of your Supabase and PowerSync
+   projects:
+
+   ```bash
+   cp SwiftDataDemo/Secrets.template.swift SwiftDataDemo/Secrets.swift
+   ```
+
+   `Secrets.swift` is gitignored.
+
+2. Generate the Xcode project with [XcodeGen](https://github.com/yonaskolb/XcodeGen):
+
+   ```bash
+   xcodegen
+   ```
+
+3. Open `SwiftDataDemo.xcodeproj`, select your development team for both targets, and run
+   the `SwiftDataDemo` scheme. Sign in or register a new user, create lists and todos, then
+   add the "Pending Todos" widget to your home screen.
+
+### App Group
+
+The app and the widget share the PowerSync database file through the App Group
+`group.co.powersync.swiftdatademo` (see the `.entitlements` files of both targets). The
+database is opened with an **absolute** `dbFilename` pointing into the group container:
+
+```swift
+FileManager.default
+    .containerURL(forSecurityApplicationGroupIdentifier: "group.co.powersync.swiftdatademo")!
+    .appendingPathComponent("powersync.db").path
+```
+
+To run on a device you must register that App Group (or your own identifier — change it in
+`Shared/SharedDatabase.swift`, both `.entitlements` files and `project.yml`) under your
+Apple Developer team. On the simulator it works out of the box.
+
+## The widget is read-only
+
+The widget opens its **own** `PowerSyncDatabase` over the same file but:
+
+- it never calls `connect()` — only the app talks to the PowerSync service;
+- its `PowerSyncDataStoreConfiguration` uses `readOnly: true`, so the store refuses every
+  write (`DataStoreError.unsupportedFeature`) and nothing can ever land in the upload queue
+  from the extension;
+- it fetches the first 5 pending todos plus the total count, builds value snapshots, closes
+  the database and returns the timeline. The timeline asks for a refresh after 15 minutes
+  (`.after(now + 15min)`); the system refreshes on its own cadence as well.
+
+### Manually validating extension suspension behavior
+
+App extensions that hold SQLite locks while being suspended get killed with `0xDEAD10CC`.
+The widget avoids this by keeping reads short and never writing. To validate manually:
+
+1. Run the app, sign in, and let it sync some todos. Add the widget to the home screen.
+2. Background the app and force a timeline reload (edit a todo on another device, or just
+   wait for the 15-minute refresh; while developing you can run the `SwiftDataDemoWidget`
+   scheme to attach the debugger to the extension).
+3. Watch the device log in Console.app (filter by `SwiftDataDemoWidget`): each reload should
+   open the database, fetch, close and exit within milliseconds.
+4. Confirm there are no `0xDEAD10CC` termination reports for the widget process under
+   *Settings → Privacy & Security → Analytics & Improvements → Analytics Data* (or in
+   Console crash reports).
+5. Optional negative test: temporarily flip `readOnly` to `false` in
+   `PendingTodosProvider.loadEntry()` and try inserting from the widget — with
+   `readOnly: true` restored, `context.save()` must throw, proving the extension cannot
+   write to the upload queue.
+
+## Project generation
+
+The Xcode project is generated from `project.yml` with XcodeGen (`xcodegen` from this
+directory). The local package (`../..`) provides the `PowerSync` and `PowerSyncSwiftData`
+products to both targets; `supabase-swift` is linked into the app target only.

--- a/Demos/SwiftDataDemo/Shared/Models/Todo.swift
+++ b/Demos/SwiftDataDemo/Shared/Models/Todo.swift
@@ -1,0 +1,26 @@
+import Foundation
+import SwiftData
+
+/// A single todo item.
+///
+/// Stored in the PowerSync table `todo` with columns `descriptionText` (text),
+/// `completed` (integer) and `list_id` (text, the to-one relationship's foreign key).
+@Model
+final class Todo {
+    var id: String
+    var descriptionText: String
+    var completed: Bool
+    var list: TodoList?
+
+    init(
+        id: String = UUID().uuidString.lowercased(),
+        descriptionText: String,
+        completed: Bool = false,
+        list: TodoList? = nil
+    ) {
+        self.id = id
+        self.descriptionText = descriptionText
+        self.completed = completed
+        self.list = list
+    }
+}

--- a/Demos/SwiftDataDemo/Shared/Models/TodoList.swift
+++ b/Demos/SwiftDataDemo/Shared/Models/TodoList.swift
@@ -1,0 +1,21 @@
+import Foundation
+import SwiftData
+
+/// A list of todos.
+///
+/// Stored in the PowerSync table `todo_list` (the snake_case form of the entity name,
+/// derived by `PowerSyncSchema(for:)`). The `todos` relationship is resolved through the
+/// inverse `list_id` column on the `todo` table; no extra column exists on this table.
+@Model
+final class TodoList {
+    var id: String
+    var name: String
+
+    @Relationship(deleteRule: .cascade, inverse: \Todo.list)
+    var todos: [Todo] = []
+
+    init(id: String = UUID().uuidString.lowercased(), name: String) {
+        self.id = id
+        self.name = name
+    }
+}

--- a/Demos/SwiftDataDemo/Shared/SharedDatabase.swift
+++ b/Demos/SwiftDataDemo/Shared/SharedDatabase.swift
@@ -1,0 +1,40 @@
+import Foundation
+import PowerSync
+import PowerSyncSwiftData
+import SwiftData
+
+/// Shared constants and helpers used by both the app and the widget extension.
+///
+/// The PowerSync database file lives in the App Group container so the widget process can
+/// open (and read) the exact same file the app writes and syncs.
+enum SharedDatabase {
+    /// The App Group both targets belong to.
+    static let appGroupID = "group.co.powersync.swiftdatademo"
+
+    /// The SwiftData models persisted through PowerSync. The PowerSync schema (tables
+    /// `todo_list` and `todo`) is derived from these with `PowerSyncSchema(for:)`.
+    static let models: [any PersistentModel.Type] = [TodoList.self, Todo.self]
+
+    /// Absolute path to the PowerSync database file inside the App Group container.
+    ///
+    /// `PowerSyncDatabase(dbFilename:)` treats a filename starting with "/" as an absolute
+    /// path and uses it as-is, which is what allows the app and the widget to share a file
+    /// outside the app sandbox's default database directory.
+    static var databasePath: String {
+        guard let container = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: appGroupID
+        ) else {
+            fatalError("App Group \(appGroupID) is not configured for this target.")
+        }
+        return container.appendingPathComponent("powersync.db").path
+    }
+
+    /// Opens the PowerSync database over the shared App Group file, deriving the PowerSync
+    /// schema from the SwiftData models.
+    static func openDatabase() throws -> any PowerSyncDatabaseProtocol {
+        PowerSyncDatabase(
+            schema: try PowerSyncSchema(for: models),
+            dbFilename: databasePath
+        )
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo.xcodeproj/project.pbxproj
+++ b/Demos/SwiftDataDemo/SwiftDataDemo.xcodeproj/project.pbxproj
@@ -1,0 +1,654 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		01143FB943A0862824B1EDF9 /* PowerSyncSwiftData in Frameworks */ = {isa = PBXBuildFile; productRef = F3A854934D7B1FBB36362E20 /* PowerSyncSwiftData */; };
+		0B469C16F411D83ACA0B8609 /* TodoListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C1BE36A0544125FAB82C9C /* TodoListRow.swift */; };
+		10937974D40B6E6106A4B7A1 /* Todo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37BDCE8C3D7DE9E8B6F6BCB /* Todo.swift */; };
+		1113A7077A6C7FA905C6B202 /* TodoList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CC2D88B69DB5AE8FC44927B /* TodoList.swift */; };
+		192D560506E893FF7F9746A2 /* SwiftDataDemoWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 4448C21AFC939C8452623833 /* SwiftDataDemoWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		1D21D86946566A597C8E3F85 /* SupabaseConnector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD7AE033D5AEE0275B2CA5CC /* SupabaseConnector.swift */; };
+		26C0073F5323187B1FB63433 /* SharedDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30CFF77BFD8C5EA177FA1E6 /* SharedDatabase.swift */; };
+		26F3F194742C03DA2DEAE5A2 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = D619272DA8BA546403A7704C /* Supabase */; };
+		3BFA23C74DA44186E467725E /* TodoList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CC2D88B69DB5AE8FC44927B /* TodoList.swift */; };
+		49CA2383F87AA29E3076F637 /* Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC05B2A3DA847FADC0AF867F /* Navigation.swift */; };
+		4BF8DE26CB3D164FBFC2689E /* SwiftDataDemoApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05D4014EABDAABCF4174B122 /* SwiftDataDemoApp.swift */; };
+		4C2BEAFA3E7E24985FF9B8FA /* CompleteTodoIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04E6F590CF09DD1BD1B582B0 /* CompleteTodoIntent.swift */; };
+		57A31EB6DBE8654D7715A559 /* PendingTodosProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57952C57F700F41A60072C6 /* PendingTodosProvider.swift */; };
+		61401015D4E9BE6CD1E657B0 /* _Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DC441468AFEB6B8ED8C71C /* _Secrets.swift */; };
+		6C95225957B26A8CC49F4125 /* TodoRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4EB95F78245220D9083ED438 /* TodoRow.swift */; };
+		7630AE4D5DF29335DE1DB9D4 /* SwiftDataDemoWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0188AE18DBD1A7E852814BBF /* SwiftDataDemoWidgetBundle.swift */; };
+		7898CD330579BBB525F6D93A /* PowerSyncSwiftData in Frameworks */ = {isa = PBXBuildFile; productRef = 3431FCE321F87BF67C4825B3 /* PowerSyncSwiftData */; };
+		7E4EC0136514A19676ACBCC7 /* ListsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27D71CA91367388836648723 /* ListsScreen.swift */; };
+		806B38BA1C2C361C5C73A120 /* ErrorText.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38DC13D202C0362CDFC95F6 /* ErrorText.swift */; };
+		81DD209CEEDD6507E7C30E4A /* PowerSync in Frameworks */ = {isa = PBXBuildFile; productRef = B14EC7634DC9EEA4890FC27A /* PowerSync */; };
+		8461AA82426CA7C947897F34 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1ED89E24A76DCCE6D71C5C5 /* Constants.swift */; };
+		846EFC47CAD60268AAE9E20A /* PendingTodosWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1267E7EF50FFA57F7230A4D /* PendingTodosWidget.swift */; };
+		8BE9EA4634B3D49A686E5EF4 /* SignUpScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392816B402BB0E98F383C4A4 /* SignUpScreen.swift */; };
+		A3ED35323733701C02A86E29 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0B3C673C05CE1440F7179D /* RootView.swift */; };
+		A72C5C272DF28A1CD8B211D4 /* SharedDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30CFF77BFD8C5EA177FA1E6 /* SharedDatabase.swift */; };
+		AC4FE9E920F040B0B1BDFEE0 /* SignInScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = E15CEAA7702AD2F189F95FBB /* SignInScreen.swift */; };
+		C0A83A25153A1C1A9E69389F /* Todo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37BDCE8C3D7DE9E8B6F6BCB /* Todo.swift */; };
+		CF0CE954A712333DEB5391C1 /* TodosScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F04E50FDC83A9CE1F74A915A /* TodosScreen.swift */; };
+		DA89E4A23BCF30ACB05E0DEE /* PowerSync in Frameworks */ = {isa = PBXBuildFile; productRef = DEF1B36909AB3820D7C08E7B /* PowerSync */; };
+		DC71950E670DA111B63FC989 /* Secrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 30C986D99609BFBA7A328BB7 /* Secrets.swift */; };
+		DEBBBAAD7A116E85E4EA4C23 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D29DD41397A390F4CD1492AC /* Assets.xcassets */; };
+		E2E17D8CA6FF90B2CC21F9DC /* SystemManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90A64E43C5B5CCB9D97280A9 /* SystemManager.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		961EF3C18330697DC0721E16 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = E04EFBE8DD7279AFF99E51E2 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C470005A8E09D7879B2A72A2;
+			remoteInfo = SwiftDataDemoWidget;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		856BC4CDB0AAE182B4F7AB7E /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				192D560506E893FF7F9746A2 /* SwiftDataDemoWidget.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		0188AE18DBD1A7E852814BBF /* SwiftDataDemoWidgetBundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataDemoWidgetBundle.swift; sourceTree = "<group>"; };
+		04E6F590CF09DD1BD1B582B0 /* CompleteTodoIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompleteTodoIntent.swift; sourceTree = "<group>"; };
+		05D4014EABDAABCF4174B122 /* SwiftDataDemoApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftDataDemoApp.swift; sourceTree = "<group>"; };
+		1CC2D88B69DB5AE8FC44927B /* TodoList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoList.swift; sourceTree = "<group>"; };
+		1E0B3C673C05CE1440F7179D /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		1FF1C5A8F395607342AE0737 /* SwiftDataDemo.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftDataDemo.entitlements; sourceTree = "<group>"; };
+		27D71CA91367388836648723 /* ListsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListsScreen.swift; sourceTree = "<group>"; };
+		29C1BE36A0544125FAB82C9C /* TodoListRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoListRow.swift; sourceTree = "<group>"; };
+		30C986D99609BFBA7A328BB7 /* Secrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secrets.swift; sourceTree = "<group>"; };
+		392816B402BB0E98F383C4A4 /* SignUpScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignUpScreen.swift; sourceTree = "<group>"; };
+		3ECB8AC616454957EFB4C667 /* powersync-swift */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "powersync-swift"; path = ../..; sourceTree = SOURCE_ROOT; };
+		4448C21AFC939C8452623833 /* SwiftDataDemoWidget.appex */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = "wrapper.app-extension"; path = SwiftDataDemoWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		4EB95F78245220D9083ED438 /* TodoRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodoRow.swift; sourceTree = "<group>"; };
+		50B3074EEE9205657DC0EDE2 /* SwiftDataDemo.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = SwiftDataDemo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		58DC441468AFEB6B8ED8C71C /* _Secrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = _Secrets.swift; sourceTree = "<group>"; };
+		8C07603D4F0222DCABDA1633 /* SwiftDataDemoWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = SwiftDataDemoWidget.entitlements; sourceTree = "<group>"; };
+		90A64E43C5B5CCB9D97280A9 /* SystemManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SystemManager.swift; sourceTree = "<group>"; };
+		A09F9D0B96CE50A28DB90801 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		B57952C57F700F41A60072C6 /* PendingTodosProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTodosProvider.swift; sourceTree = "<group>"; };
+		C1267E7EF50FFA57F7230A4D /* PendingTodosWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingTodosWidget.swift; sourceTree = "<group>"; };
+		CD7AE033D5AEE0275B2CA5CC /* SupabaseConnector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupabaseConnector.swift; sourceTree = "<group>"; };
+		D29DD41397A390F4CD1492AC /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		D37BDCE8C3D7DE9E8B6F6BCB /* Todo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Todo.swift; sourceTree = "<group>"; };
+		D38DC13D202C0362CDFC95F6 /* ErrorText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorText.swift; sourceTree = "<group>"; };
+		DC05B2A3DA847FADC0AF867F /* Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Navigation.swift; sourceTree = "<group>"; };
+		DC2D034CB889BBA15C66D7F4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		E15CEAA7702AD2F189F95FBB /* SignInScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInScreen.swift; sourceTree = "<group>"; };
+		E30CFF77BFD8C5EA177FA1E6 /* SharedDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDatabase.swift; sourceTree = "<group>"; };
+		EA3C9BC22013757876B9CA62 /* Secrets.template.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Secrets.template.swift; sourceTree = "<group>"; };
+		F04E50FDC83A9CE1F74A915A /* TodosScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodosScreen.swift; sourceTree = "<group>"; };
+		F1ED89E24A76DCCE6D71C5C5 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		3536810908E160C5F72E2D33 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA89E4A23BCF30ACB05E0DEE /* PowerSync in Frameworks */,
+				7898CD330579BBB525F6D93A /* PowerSyncSwiftData in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CB383209E35B395B98DF533E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				81DD209CEEDD6507E7C30E4A /* PowerSync in Frameworks */,
+				01143FB943A0862824B1EDF9 /* PowerSyncSwiftData in Frameworks */,
+				26F3F194742C03DA2DEAE5A2 /* Supabase in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		0266CBAE7B1437090610F72C /* Screens */ = {
+			isa = PBXGroup;
+			children = (
+				27D71CA91367388836648723 /* ListsScreen.swift */,
+				E15CEAA7702AD2F189F95FBB /* SignInScreen.swift */,
+				392816B402BB0E98F383C4A4 /* SignUpScreen.swift */,
+				F04E50FDC83A9CE1F74A915A /* TodosScreen.swift */,
+			);
+			path = Screens;
+			sourceTree = "<group>";
+		};
+		32564151818C8C31A654A4DE /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				D37BDCE8C3D7DE9E8B6F6BCB /* Todo.swift */,
+				1CC2D88B69DB5AE8FC44927B /* TodoList.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		34AD30B0B8C53CD6ADBD688F /* PowerSync */ = {
+			isa = PBXGroup;
+			children = (
+				CD7AE033D5AEE0275B2CA5CC /* SupabaseConnector.swift */,
+				90A64E43C5B5CCB9D97280A9 /* SystemManager.swift */,
+			);
+			path = PowerSync;
+			sourceTree = "<group>";
+		};
+		39298EFCD1CAD5D01065A0DC /* SwiftDataDemoWidget */ = {
+			isa = PBXGroup;
+			children = (
+				04E6F590CF09DD1BD1B582B0 /* CompleteTodoIntent.swift */,
+				DC2D034CB889BBA15C66D7F4 /* Info.plist */,
+				B57952C57F700F41A60072C6 /* PendingTodosProvider.swift */,
+				C1267E7EF50FFA57F7230A4D /* PendingTodosWidget.swift */,
+				8C07603D4F0222DCABDA1633 /* SwiftDataDemoWidget.entitlements */,
+				0188AE18DBD1A7E852814BBF /* SwiftDataDemoWidgetBundle.swift */,
+			);
+			path = SwiftDataDemoWidget;
+			sourceTree = "<group>";
+		};
+		414456FADE8D5B5DED77391F = {
+			isa = PBXGroup;
+			children = (
+				A9DE59CFEFACBA1036FABCCF /* Packages */,
+				D79DF103F3DC392A8EF1F9C7 /* Shared */,
+				7CE97FACD88BFD4DE23E3023 /* SwiftDataDemo */,
+				39298EFCD1CAD5D01065A0DC /* SwiftDataDemoWidget */,
+				8009F9713AC0A99F939811B2 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		5D3D6CDD7CB342768AD64478 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				29C1BE36A0544125FAB82C9C /* TodoListRow.swift */,
+				4EB95F78245220D9083ED438 /* TodoRow.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		7CE97FACD88BFD4DE23E3023 /* SwiftDataDemo */ = {
+			isa = PBXGroup;
+			children = (
+				58DC441468AFEB6B8ED8C71C /* _Secrets.swift */,
+				D29DD41397A390F4CD1492AC /* Assets.xcassets */,
+				F1ED89E24A76DCCE6D71C5C5 /* Constants.swift */,
+				D38DC13D202C0362CDFC95F6 /* ErrorText.swift */,
+				A09F9D0B96CE50A28DB90801 /* Info.plist */,
+				DC05B2A3DA847FADC0AF867F /* Navigation.swift */,
+				1E0B3C673C05CE1440F7179D /* RootView.swift */,
+				30C986D99609BFBA7A328BB7 /* Secrets.swift */,
+				EA3C9BC22013757876B9CA62 /* Secrets.template.swift */,
+				1FF1C5A8F395607342AE0737 /* SwiftDataDemo.entitlements */,
+				05D4014EABDAABCF4174B122 /* SwiftDataDemoApp.swift */,
+				5D3D6CDD7CB342768AD64478 /* Components */,
+				34AD30B0B8C53CD6ADBD688F /* PowerSync */,
+				0266CBAE7B1437090610F72C /* Screens */,
+			);
+			path = SwiftDataDemo;
+			sourceTree = "<group>";
+		};
+		8009F9713AC0A99F939811B2 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				50B3074EEE9205657DC0EDE2 /* SwiftDataDemo.app */,
+				4448C21AFC939C8452623833 /* SwiftDataDemoWidget.appex */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A9DE59CFEFACBA1036FABCCF /* Packages */ = {
+			isa = PBXGroup;
+			children = (
+				3ECB8AC616454957EFB4C667 /* powersync-swift */,
+			);
+			name = Packages;
+			sourceTree = "<group>";
+		};
+		D79DF103F3DC392A8EF1F9C7 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				E30CFF77BFD8C5EA177FA1E6 /* SharedDatabase.swift */,
+				32564151818C8C31A654A4DE /* Models */,
+			);
+			path = Shared;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		AA59079BF0EC05F40196C49B /* SwiftDataDemo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B8287841A15A1A2AA7E6FAFE /* Build configuration list for PBXNativeTarget "SwiftDataDemo" */;
+			buildPhases = (
+				2F06652AB9F36EF772143F7C /* Sources */,
+				21F33FAD4D95AC9AB969D90E /* Resources */,
+				CB383209E35B395B98DF533E /* Frameworks */,
+				856BC4CDB0AAE182B4F7AB7E /* Embed Foundation Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				83468164C1B5CE030AB764AE /* PBXTargetDependency */,
+			);
+			name = SwiftDataDemo;
+			packageProductDependencies = (
+				B14EC7634DC9EEA4890FC27A /* PowerSync */,
+				F3A854934D7B1FBB36362E20 /* PowerSyncSwiftData */,
+				D619272DA8BA546403A7704C /* Supabase */,
+			);
+			productName = SwiftDataDemo;
+			productReference = 50B3074EEE9205657DC0EDE2 /* SwiftDataDemo.app */;
+			productType = "com.apple.product-type.application";
+		};
+		C470005A8E09D7879B2A72A2 /* SwiftDataDemoWidget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1996ECC061FCE231E46F6198 /* Build configuration list for PBXNativeTarget "SwiftDataDemoWidget" */;
+			buildPhases = (
+				979045D1E393BF66E9FB07D2 /* Sources */,
+				3536810908E160C5F72E2D33 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = SwiftDataDemoWidget;
+			packageProductDependencies = (
+				DEF1B36909AB3820D7C08E7B /* PowerSync */,
+				3431FCE321F87BF67C4825B3 /* PowerSyncSwiftData */,
+			);
+			productName = SwiftDataDemoWidget;
+			productReference = 4448C21AFC939C8452623833 /* SwiftDataDemoWidget.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E04EFBE8DD7279AFF99E51E2 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 1430;
+				TargetAttributes = {
+					AA59079BF0EC05F40196C49B = {
+						ProvisioningStyle = Automatic;
+					};
+					C470005A8E09D7879B2A72A2 = {
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 9D9CBBC401FC7AF4A166A9F9 /* Build configuration list for PBXProject "SwiftDataDemo" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = 414456FADE8D5B5DED77391F;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				34C1B3565807B4CB990F9027 /* XCRemoteSwiftPackageReference "supabase-swift" */,
+				DDA316616CC92CA3A68753FF /* XCLocalSwiftPackageReference "../.." */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 8009F9713AC0A99F939811B2 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				AA59079BF0EC05F40196C49B /* SwiftDataDemo */,
+				C470005A8E09D7879B2A72A2 /* SwiftDataDemoWidget */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		21F33FAD4D95AC9AB969D90E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DEBBBAAD7A116E85E4EA4C23 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		2F06652AB9F36EF772143F7C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8461AA82426CA7C947897F34 /* Constants.swift in Sources */,
+				806B38BA1C2C361C5C73A120 /* ErrorText.swift in Sources */,
+				7E4EC0136514A19676ACBCC7 /* ListsScreen.swift in Sources */,
+				49CA2383F87AA29E3076F637 /* Navigation.swift in Sources */,
+				A3ED35323733701C02A86E29 /* RootView.swift in Sources */,
+				DC71950E670DA111B63FC989 /* Secrets.swift in Sources */,
+				26C0073F5323187B1FB63433 /* SharedDatabase.swift in Sources */,
+				AC4FE9E920F040B0B1BDFEE0 /* SignInScreen.swift in Sources */,
+				8BE9EA4634B3D49A686E5EF4 /* SignUpScreen.swift in Sources */,
+				1D21D86946566A597C8E3F85 /* SupabaseConnector.swift in Sources */,
+				4BF8DE26CB3D164FBFC2689E /* SwiftDataDemoApp.swift in Sources */,
+				E2E17D8CA6FF90B2CC21F9DC /* SystemManager.swift in Sources */,
+				C0A83A25153A1C1A9E69389F /* Todo.swift in Sources */,
+				1113A7077A6C7FA905C6B202 /* TodoList.swift in Sources */,
+				0B469C16F411D83ACA0B8609 /* TodoListRow.swift in Sources */,
+				6C95225957B26A8CC49F4125 /* TodoRow.swift in Sources */,
+				CF0CE954A712333DEB5391C1 /* TodosScreen.swift in Sources */,
+				61401015D4E9BE6CD1E657B0 /* _Secrets.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		979045D1E393BF66E9FB07D2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C2BEAFA3E7E24985FF9B8FA /* CompleteTodoIntent.swift in Sources */,
+				57A31EB6DBE8654D7715A559 /* PendingTodosProvider.swift in Sources */,
+				846EFC47CAD60268AAE9E20A /* PendingTodosWidget.swift in Sources */,
+				A72C5C272DF28A1CD8B211D4 /* SharedDatabase.swift in Sources */,
+				7630AE4D5DF29335DE1DB9D4 /* SwiftDataDemoWidgetBundle.swift in Sources */,
+				10937974D40B6E6106A4B7A1 /* Todo.swift in Sources */,
+				3BFA23C74DA44186E467725E /* TodoList.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		83468164C1B5CE030AB764AE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C470005A8E09D7879B2A72A2 /* SwiftDataDemoWidget */;
+			targetProxy = 961EF3C18330697DC0721E16 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		466B1EDB6737DBF4F48A1579 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = SwiftDataDemo/SwiftDataDemo.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = SwiftDataDemo/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.powersync.swiftdatademo;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		58F01F4BB95117E6E211E8CF /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Release;
+		};
+		6BF9D371C0BF3AFAA5B5CECB /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = SwiftDataDemo/SwiftDataDemo.entitlements;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = SwiftDataDemo/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.powersync.swiftdatademo;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		8A2882FA51EA05D2C66B3A0E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = SwiftDataDemoWidget/SwiftDataDemoWidget.entitlements;
+				INFOPLIST_FILE = SwiftDataDemoWidget/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.powersync.swiftdatademo.widget;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		C506B25C5AA4BD1F1F3A2FDC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Automatic;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"DEBUG=1",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		EF6B9A38F53E024C5E28E887 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = SwiftDataDemoWidget/SwiftDataDemoWidget.entitlements;
+				INFOPLIST_FILE = SwiftDataDemoWidget/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = co.powersync.swiftdatademo.widget;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1996ECC061FCE231E46F6198 /* Build configuration list for PBXNativeTarget "SwiftDataDemoWidget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EF6B9A38F53E024C5E28E887 /* Debug */,
+				8A2882FA51EA05D2C66B3A0E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		9D9CBBC401FC7AF4A166A9F9 /* Build configuration list for PBXProject "SwiftDataDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				C506B25C5AA4BD1F1F3A2FDC /* Debug */,
+				58F01F4BB95117E6E211E8CF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		B8287841A15A1A2AA7E6FAFE /* Build configuration list for PBXNativeTarget "SwiftDataDemo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				6BF9D371C0BF3AFAA5B5CECB /* Debug */,
+				466B1EDB6737DBF4F48A1579 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCLocalSwiftPackageReference section */
+		DDA316616CC92CA3A68753FF /* XCLocalSwiftPackageReference "../.." */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = ../..;
+		};
+/* End XCLocalSwiftPackageReference section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		34C1B3565807B4CB990F9027 /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/supabase/supabase-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.4.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		3431FCE321F87BF67C4825B3 /* PowerSyncSwiftData */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PowerSyncSwiftData;
+		};
+		B14EC7634DC9EEA4890FC27A /* PowerSync */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PowerSync;
+		};
+		D619272DA8BA546403A7704C /* Supabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 34C1B3565807B4CB990F9027 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Supabase;
+		};
+		DEF1B36909AB3820D7C08E7B /* PowerSync */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PowerSync;
+		};
+		F3A854934D7B1FBB36362E20 /* PowerSyncSwiftData */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = PowerSyncSwiftData;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = E04EFBE8DD7279AFF99E51E2 /* Project object */;
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Demos/SwiftDataDemo/SwiftDataDemo.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Demos/SwiftDataDemo/SwiftDataDemo.xcodeproj/xcshareddata/xcschemes/SwiftDataDemo.xcscheme
+++ b/Demos/SwiftDataDemo/SwiftDataDemo.xcodeproj/xcshareddata/xcschemes/SwiftDataDemo.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AA59079BF0EC05F40196C49B"
+               BuildableName = "SwiftDataDemo.app"
+               BlueprintName = "SwiftDataDemo"
+               ReferencedContainer = "container:SwiftDataDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA59079BF0EC05F40196C49B"
+            BuildableName = "SwiftDataDemo.app"
+            BlueprintName = "SwiftDataDemo"
+            ReferencedContainer = "container:SwiftDataDemo.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA59079BF0EC05F40196C49B"
+            BuildableName = "SwiftDataDemo.app"
+            BlueprintName = "SwiftDataDemo"
+            ReferencedContainer = "container:SwiftDataDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AA59079BF0EC05F40196C49B"
+            BuildableName = "SwiftDataDemo.app"
+            BlueprintName = "SwiftDataDemo"
+            ReferencedContainer = "container:SwiftDataDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Demos/SwiftDataDemo/SwiftDataDemo.xcodeproj/xcshareddata/xcschemes/SwiftDataDemoWidget.xcscheme
+++ b/Demos/SwiftDataDemo/SwiftDataDemo.xcodeproj/xcshareddata/xcschemes/SwiftDataDemoWidget.xcscheme
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1430"
+   wasCreatedForAppExtension = "YES"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C470005A8E09D7879B2A72A2"
+               BuildableName = "SwiftDataDemoWidget.appex"
+               BlueprintName = "SwiftDataDemoWidget"
+               ReferencedContainer = "container:SwiftDataDemo.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C470005A8E09D7879B2A72A2"
+            BuildableName = "SwiftDataDemoWidget.appex"
+            BlueprintName = "SwiftDataDemoWidget"
+            ReferencedContainer = "container:SwiftDataDemo.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = ""
+      selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C470005A8E09D7879B2A72A2"
+            BuildableName = "SwiftDataDemoWidget.appex"
+            BlueprintName = "SwiftDataDemoWidget"
+            ReferencedContainer = "container:SwiftDataDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C470005A8E09D7879B2A72A2"
+            BuildableName = "SwiftDataDemoWidget.appex"
+            BlueprintName = "SwiftDataDemoWidget"
+            ReferencedContainer = "container:SwiftDataDemo.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Demos/SwiftDataDemo/SwiftDataDemo/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/Assets.xcassets/Contents.json
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/Components/TodoListRow.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/Components/TodoListRow.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct TodoListRow: View {
+    let list: TodoList
+
+    private var pendingCount: Int {
+        // The to-many relationship is resolved through the inverse `list_id` column.
+        list.todos.filter { !$0.completed }.count
+    }
+
+    var body: some View {
+        HStack {
+            Text(list.name)
+            Spacer()
+            if pendingCount > 0 {
+                Text("\(pendingCount)")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+            Image(systemName: "chevron.right")
+                .font(.footnote)
+                .foregroundStyle(.tertiary)
+        }
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/Components/TodoRow.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/Components/TodoRow.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct TodoRow: View {
+    let todo: Todo
+    let onToggle: () -> Void
+
+    var body: some View {
+        HStack {
+            Button(action: onToggle) {
+                Image(systemName: todo.completed ? "checkmark.circle.fill" : "circle")
+                    .foregroundStyle(todo.completed ? .green : .secondary)
+            }
+            .buttonStyle(.plain)
+
+            Text(todo.descriptionText)
+                .strikethrough(todo.completed)
+                .foregroundStyle(todo.completed ? .secondary : .primary)
+        }
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/Constants.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/Constants.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum Constants {
+    static let redirectToURL = URL(string: "co.powersync.swiftdatademo://")!
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/ErrorText.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/ErrorText.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct ErrorText: View {
+    let error: Error
+
+    init(_ error: Error) {
+        self.error = error
+    }
+
+    var body: some View {
+        Text(error.localizedDescription)
+            .foregroundColor(.red)
+            .font(.footnote)
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/Info.plist
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+	<key>UILaunchScreen</key>
+	<dict/>
+</dict>
+</plist>

--- a/Demos/SwiftDataDemo/SwiftDataDemo/Navigation.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/Navigation.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+enum Route: Hashable {
+    case signIn
+    case signUp
+    case todos(listId: String, listName: String)
+}
+
+@Observable
+class NavigationModel {
+    var path = NavigationPath()
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/PowerSync/SupabaseConnector.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/PowerSync/SupabaseConnector.swift
@@ -1,0 +1,129 @@
+import Auth
+import PowerSync
+import Supabase
+import SwiftUI
+
+private enum PostgresFatalCodes {
+    /// Postgres Response codes that we cannot recover from by retrying.
+    static let fatalResponseCodes: [String] = [
+        // Class 22 — Data Exception
+        // Examples include data type mismatch.
+        "22...",
+        // Class 23 — Integrity Constraint Violation.
+        // Examples include NOT NULL, FOREIGN KEY and UNIQUE violations.
+        "23...",
+        // INSUFFICIENT PRIVILEGE - typically a row-level security violation
+        "42501",
+    ]
+
+    static func isFatalError(_ code: String) -> Bool {
+        return fatalResponseCodes.contains { pattern in
+            code.range(of: pattern, options: [.regularExpression]) != nil
+        }
+    }
+
+    static func extractErrorCode(from error: any Error) -> String? {
+        // Look for code: Optional("XXXXX") pattern
+        let errorString = String(describing: error)
+        if let range = errorString.range(of: "code: Optional\\(\"([^\"]+)\"\\)", options: .regularExpression),
+           let codeRange = errorString[range].range(of: "\"([^\"]+)\"", options: .regularExpression)
+        {
+            // Extract just the code from within the quotes
+            let code = errorString[codeRange].dropFirst().dropLast()
+            return String(code)
+        }
+        return nil
+    }
+}
+
+/// Uploads the PowerSync CRUD queue to Supabase and provides PowerSync credentials from
+/// the Supabase session. Adapted from the PowerSyncExample demo.
+@Observable
+@MainActor // _session is mutable, limiting to the MainActor satisfies Sendable constraints
+final class SupabaseConnector: PowerSyncBackendConnectorProtocol {
+    let powerSyncEndpoint: String = Secrets.powerSyncEndpoint
+    let client: SupabaseClient = .init(
+        supabaseURL: Secrets.supabaseURL,
+        supabaseKey: Secrets.supabaseAnonKey
+    )
+    private(set) var session: Session?
+
+    @ObservationIgnored
+    private var observeAuthStateChangesTask: Task<Void, Error>?
+
+    init() {
+        session = client.auth.currentSession
+        observeAuthStateChangesTask = Task { [weak self] in
+            guard let self = self else { return }
+
+            for await (event, session) in self.client.auth.authStateChanges {
+                guard [.initialSession, .signedIn, .signedOut].contains(event) else { throw AuthError.sessionMissing }
+
+                self.session = session
+            }
+        }
+    }
+
+    func fetchCredentials() async throws -> PowerSyncCredentials? {
+        session = try await client.auth.session
+
+        if session == nil {
+            throw AuthError.sessionMissing
+        }
+
+        let token = session!.accessToken
+
+        return PowerSyncCredentials(endpoint: powerSyncEndpoint, token: token)
+    }
+
+    func uploadData(database: PowerSyncDatabaseProtocol) async throws {
+        guard let transaction = try await database.getNextCrudTransaction() else { return }
+
+        var lastEntry: CrudEntry?
+        do {
+            for entry in transaction.crud {
+                lastEntry = entry
+                let tableName = entry.table
+
+                let table = client.from(tableName)
+
+                switch entry.op {
+                case .put:
+                    var data = entry.opData ?? [:]
+                    data["id"] = entry.id
+                    try await table.upsert(data).execute()
+                case .patch:
+                    guard let opData = entry.opData else { continue }
+                    try await table.update(opData).eq("id", value: entry.id).execute()
+                case .delete:
+                    try await table.delete().eq("id", value: entry.id).execute()
+                }
+            }
+
+            try await transaction.complete()
+
+        } catch {
+            if let errorCode = PostgresFatalCodes.extractErrorCode(from: error),
+               PostgresFatalCodes.isFatalError(errorCode)
+            {
+                /// Instead of blocking the queue with these errors,
+                /// discard the (rest of the) transaction.
+                ///
+                /// Note that these errors typically indicate a bug in the application.
+                /// If protecting against data loss is important, save the failing records
+                /// elsewhere instead of discarding, and/or notify the user.
+                print("Data upload error: \(error)")
+                print("Discarding entry: \(lastEntry!)")
+                try await transaction.complete()
+                return
+            }
+
+            print("Data upload error - retrying last entry: \(lastEntry!), \(error)")
+            throw error
+        }
+    }
+
+    deinit {
+        observeAuthStateChangesTask?.cancel()
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/PowerSync/SystemManager.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/PowerSync/SystemManager.swift
@@ -1,0 +1,76 @@
+import Foundation
+import PowerSync
+import PowerSyncSwiftData
+import SwiftData
+
+private let logTag = "SystemManager"
+
+/// Bootstraps the PowerSync-backed SwiftData stack:
+///
+/// 1. Opens the `PowerSyncDatabase` over the shared App Group file (the widget reads the
+///    same file).
+/// 2. Builds a `ModelContainer` whose only store is a `PowerSyncDataStore`, so every
+///    `@Query` / `ModelContext` operation goes through PowerSync.
+/// 3. Starts a `PowerSyncChangeObserver` so rows downloaded by sync are re-injected into
+///    SwiftData and `@Query` views update live.
+/// 4. Connects PowerSync to the backend through the Supabase connector.
+///
+/// We use the MainActor SupabaseConnector synchronously here, this requires specifying
+/// that SystemManager runs on the MainActor. We don't actually block the MainActor with
+/// anything.
+@Observable
+@MainActor
+final class SystemManager {
+    let connector = SupabaseConnector()
+    let db: any PowerSyncDatabaseProtocol
+    let container: ModelContainer
+
+    @ObservationIgnored
+    private let observer: PowerSyncChangeObserver
+    @ObservationIgnored
+    private var observing = false
+
+    init() {
+        do {
+            let database = try SharedDatabase.openDatabase()
+            let configuration = PowerSyncDataStoreConfiguration(
+                name: "powersync",
+                database: database
+            )
+            let container = try ModelContainer(
+                for: SwiftData.Schema(SharedDatabase.models),
+                configurations: [configuration]
+            )
+            db = database
+            self.container = container
+            observer = PowerSyncChangeObserver(
+                container: container,
+                configuration: configuration
+            )
+        } catch {
+            fatalError("Failed to bootstrap the PowerSync SwiftData stack: \(error)")
+        }
+    }
+
+    /// Starts the change observer (once) and connects to the PowerSync service.
+    func start() async {
+        do {
+            if !observing {
+                try await observer.start(observing: SharedDatabase.models)
+                observing = true
+            }
+            if db.currentStatus.connected == false {
+                try await db.connect(connector: connector)
+            }
+        } catch {
+            db.logger.error("Failed to start sync: \(error)", tag: logTag)
+        }
+    }
+
+    /// Disconnects, clears the local database and signs out of Supabase. The change
+    /// observer notices the cleared tables and removes the models from SwiftData.
+    func signOut() async throws {
+        try await db.disconnectAndClear()
+        try await connector.client.auth.signOut()
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/RootView.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/RootView.swift
@@ -1,0 +1,31 @@
+import Auth
+import SwiftUI
+
+struct RootView: View {
+    @Environment(SystemManager.self) private var system
+
+    @State private var navigationModel = NavigationModel()
+
+    var body: some View {
+        NavigationStack(path: $navigationModel.path) {
+            Group {
+                if system.connector.session != nil {
+                    ListsScreen()
+                } else {
+                    SignInScreen()
+                }
+            }
+            .navigationDestination(for: Route.self) { route in
+                switch route {
+                case .signIn:
+                    SignInScreen()
+                case .signUp:
+                    SignUpScreen()
+                case let .todos(listId, listName):
+                    TodosScreen(listId: listId, listName: listName)
+                }
+            }
+        }
+        .environment(navigationModel)
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/Screens/ListsScreen.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/Screens/ListsScreen.swift
@@ -1,0 +1,134 @@
+import PowerSync
+import SwiftData
+import SwiftUI
+
+/// All todo lists, fetched with a plain `@Query`. The query goes through the
+/// `PowerSyncDataStore`; reactivity to sync downloads is provided by the
+/// `PowerSyncChangeObserver` started in `SystemManager.start()`.
+///
+/// Like PowerSyncExample's list view, the UI is gated on the first sync: until
+/// `SyncStatusData.hasSynced` the screen shows download progress instead of an
+/// empty state.
+struct ListsScreen: View {
+    @Environment(SystemManager.self) private var system
+    @Environment(NavigationModel.self) private var navigationModel
+    @Environment(\.modelContext) private var modelContext
+
+    @Query(sort: \TodoList.name) private var lists: [TodoList]
+
+    @State private var showAddList = false
+    @State private var newListName = ""
+    @State private var error: Error?
+    @State private var status: SyncStatusData?
+
+    var body: some View {
+        if status?.hasSynced != true {
+            VStack {
+                if let status {
+                    Text("Busy with initial sync...")
+
+                    if let progress = status.downloadProgress {
+                        ProgressView(value: progress.fraction)
+
+                        if progress.downloadedOperations == progress.totalOperations {
+                            Text("Applying server-side changes...")
+                        } else {
+                            Text("Downloaded \(progress.downloadedOperations) out of \(progress.totalOperations)")
+                        }
+                    }
+                } else {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle())
+                }
+            }
+        }
+
+        List {
+            if let error {
+                ErrorText(error)
+            }
+
+            ForEach(lists) { list in
+                Button {
+                    navigationModel.path.append(Route.todos(listId: list.id, listName: list.name))
+                } label: {
+                    TodoListRow(list: list)
+                }
+                .foregroundStyle(.primary)
+            }
+            .onDelete(perform: deleteLists)
+        }
+        .overlay {
+            if lists.isEmpty, status?.hasSynced == true {
+                ContentUnavailableView(
+                    "No lists yet",
+                    systemImage: "checklist",
+                    description: Text("Tap + to create your first list.")
+                )
+            }
+        }
+        .navigationTitle("Lists")
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Sign out") {
+                    Task {
+                        try? await system.signOut()
+                        navigationModel.path = NavigationPath()
+                    }
+                }
+            }
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showAddList = true
+                } label: {
+                    Label("Add list", systemImage: "plus")
+                }
+            }
+        }
+        .alert("Add list", isPresented: $showAddList) {
+            TextField("Name", text: $newListName)
+            Button("Add") {
+                addList()
+            }
+            Button("Cancel", role: .cancel) {
+                newListName = ""
+            }
+        }
+        .task {
+            await system.start()
+        }
+        .task {
+            status = system.db.currentStatus
+            for await current in system.db.currentStatus.asFlow() {
+                status = current
+            }
+        }
+        .navigationBarBackButtonHidden(true)
+    }
+
+    private func addList() {
+        let name = newListName.trimmingCharacters(in: .whitespacesAndNewlines)
+        newListName = ""
+        guard !name.isEmpty else { return }
+        do {
+            error = nil
+            modelContext.insert(TodoList(name: name))
+            try modelContext.save()
+        } catch {
+            self.error = error
+        }
+    }
+
+    private func deleteLists(at offsets: IndexSet) {
+        // The cascade delete rule removes the list's todos as well.
+        do {
+            error = nil
+            for index in offsets {
+                modelContext.delete(lists[index])
+            }
+            try modelContext.save()
+        } catch {
+            self.error = error
+        }
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/Screens/SignInScreen.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/Screens/SignInScreen.swift
@@ -1,0 +1,72 @@
+import SwiftUI
+
+private enum ActionState<Success, Failure: Error> {
+    case idle
+    case inFlight
+    case result(Result<Success, Failure>)
+}
+
+struct SignInScreen: View {
+    @Environment(SystemManager.self) private var system
+    @Environment(NavigationModel.self) private var navigationModel
+
+    @State private var email = ""
+    @State private var password = ""
+    @State private var actionState = ActionState<Void, Error>.idle
+
+    var body: some View {
+        Form {
+            Section {
+                TextField("Email", text: $email)
+                    .textContentType(.emailAddress)
+                    .autocorrectionDisabled()
+                    .keyboardType(.emailAddress)
+                    .textInputAutocapitalization(.never)
+
+                SecureField("Password", text: $password)
+                    .textContentType(.password)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+            }
+
+            Section {
+                Button("Sign in") {
+                    Task {
+                        await signInButtonTapped()
+                    }
+                }
+            }
+
+            switch actionState {
+            case .idle:
+                EmptyView()
+            case .inFlight:
+                ProgressView()
+            case let .result(.failure(error)):
+                ErrorText(error)
+            case .result(.success):
+                Text("Sign in successful!")
+            }
+
+            Section {
+                Button("Don't have an account? Sign up") {
+                    navigationModel.path.append(Route.signUp)
+                }
+            }
+        }
+        .navigationTitle("Sign in")
+    }
+
+    private func signInButtonTapped() async {
+        do {
+            actionState = .inFlight
+            try await system.connector.client.auth.signIn(email: email, password: password)
+            actionState = .result(.success(()))
+            navigationModel.path = NavigationPath()
+        } catch {
+            withAnimation {
+                actionState = .result(.failure(error))
+            }
+        }
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/Screens/SignUpScreen.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/Screens/SignUpScreen.swift
@@ -1,0 +1,70 @@
+import SwiftUI
+
+private enum ActionState<Success, Failure: Error> {
+    case idle
+    case inFlight
+    case result(Result<Success, Failure>)
+}
+
+struct SignUpScreen: View {
+    @Environment(SystemManager.self) private var system
+    @Environment(NavigationModel.self) private var navigationModel
+
+    @State private var email = ""
+    @State private var password = ""
+    @State private var actionState = ActionState<Void, Error>.idle
+
+    var body: some View {
+        Form {
+            Section {
+                TextField("Email", text: $email)
+                    .textContentType(.emailAddress)
+                    .autocorrectionDisabled()
+                    .keyboardType(.emailAddress)
+                    .textInputAutocapitalization(.never)
+
+                SecureField("Password", text: $password)
+                    .textContentType(.password)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+            }
+
+            Section {
+                Button("Sign up") {
+                    Task {
+                        await signUpButtonTapped()
+                    }
+                }
+            }
+
+            switch actionState {
+            case .idle:
+                EmptyView()
+            case .inFlight:
+                ProgressView()
+            case let .result(.failure(error)):
+                ErrorText(error)
+            case .result(.success):
+                Text("Sign up successful!")
+            }
+        }
+        .navigationTitle("Sign up")
+    }
+
+    private func signUpButtonTapped() async {
+        do {
+            actionState = .inFlight
+            try await system.connector.client.auth.signUp(
+                email: email,
+                password: password,
+                redirectTo: Constants.redirectToURL
+            )
+            actionState = .result(.success(()))
+            navigationModel.path = NavigationPath()
+        } catch {
+            withAnimation {
+                actionState = .result(.failure(error))
+            }
+        }
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/Screens/TodosScreen.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/Screens/TodosScreen.swift
@@ -1,0 +1,109 @@
+import SwiftData
+import SwiftUI
+
+/// The todos of a single list, fetched with a `@Query` filtered on the to-one
+/// relationship's id and sorted by description.
+struct TodosScreen: View {
+    let listId: String
+    let listName: String
+
+    @Environment(\.modelContext) private var modelContext
+
+    @Query private var todos: [Todo]
+
+    @State private var showAddTodo = false
+    @State private var newTodoDescription = ""
+    @State private var error: Error?
+
+    init(listId: String, listName: String) {
+        self.listId = listId
+        self.listName = listName
+        _todos = Query(
+            filter: #Predicate<Todo> { $0.list?.id == listId },
+            sort: \Todo.descriptionText
+        )
+    }
+
+    var body: some View {
+        List {
+            if let error {
+                ErrorText(error)
+            }
+
+            ForEach(todos) { todo in
+                TodoRow(todo: todo) {
+                    toggle(todo)
+                }
+            }
+            .onDelete(perform: deleteTodos)
+        }
+        .overlay {
+            if todos.isEmpty {
+                ContentUnavailableView(
+                    "No todos yet",
+                    systemImage: "checkmark.circle",
+                    description: Text("Tap + to add a todo to this list.")
+                )
+            }
+        }
+        .navigationTitle(listName)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    showAddTodo = true
+                } label: {
+                    Label("Add todo", systemImage: "plus")
+                }
+            }
+        }
+        .alert("Add todo", isPresented: $showAddTodo) {
+            TextField("Description", text: $newTodoDescription)
+            Button("Add") {
+                addTodo()
+            }
+            Button("Cancel", role: .cancel) {
+                newTodoDescription = ""
+            }
+        }
+    }
+
+    private func addTodo() {
+        let descriptionText = newTodoDescription.trimmingCharacters(in: .whitespacesAndNewlines)
+        newTodoDescription = ""
+        guard !descriptionText.isEmpty else { return }
+        do {
+            error = nil
+            // Fetch the list in this context to set the to-one relationship.
+            let descriptor = FetchDescriptor<TodoList>(
+                predicate: #Predicate { $0.id == listId }
+            )
+            guard let list = try modelContext.fetch(descriptor).first else { return }
+            modelContext.insert(Todo(descriptionText: descriptionText, list: list))
+            try modelContext.save()
+        } catch {
+            self.error = error
+        }
+    }
+
+    private func toggle(_ todo: Todo) {
+        do {
+            error = nil
+            todo.completed.toggle()
+            try modelContext.save()
+        } catch {
+            self.error = error
+        }
+    }
+
+    private func deleteTodos(at offsets: IndexSet) {
+        do {
+            error = nil
+            for index in offsets {
+                modelContext.delete(todos[index])
+            }
+            try modelContext.save()
+        } catch {
+            self.error = error
+        }
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/Secrets.template.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/Secrets.template.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension Secrets {
+    static var powerSyncEndpoint: String {
+        return "http://localhost:8080"
+    }
+
+    static var supabaseURL: URL {
+        return URL(string: "http://localhost:54321")!
+    }
+
+    static var supabaseAnonKey: String {
+        // The default for local Supabase development
+        return "sb_publishable_ACJWlzQHlZjBrEguHvfOxg_3BJgxAaH"
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/SwiftDataDemo.entitlements
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/SwiftDataDemo.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.co.powersync.swiftdatademo</string>
+	</array>
+</dict>
+</plist>

--- a/Demos/SwiftDataDemo/SwiftDataDemo/SwiftDataDemoApp.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/SwiftDataDemoApp.swift
@@ -1,0 +1,17 @@
+import SwiftData
+import SwiftUI
+
+@main
+struct SwiftDataDemoApp: App {
+    @State private var system = SystemManager()
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+                .environment(system)
+        }
+        // Every @Query and @Environment(\.modelContext) in the app reads and writes
+        // through the PowerSync-backed container.
+        .modelContainer(system.container)
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemo/_Secrets.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemo/_Secrets.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// A protocol which specifies the base structure for secrets
+protocol SecretsProvider {
+    static var powerSyncEndpoint: String { get }
+    static var supabaseURL: URL { get }
+    static var supabaseAnonKey: String { get }
+}
+
+// Default conforming type. The actual values live in `Secrets.swift`, which is gitignored;
+// copy `Secrets.template.swift` to `Secrets.swift` and fill in your project's credentials.
+enum Secrets: SecretsProvider {}

--- a/Demos/SwiftDataDemo/SwiftDataDemoWidget/CompleteTodoIntent.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemoWidget/CompleteTodoIntent.swift
@@ -1,0 +1,47 @@
+import AppIntents
+import Foundation
+import PowerSync
+import PowerSyncSwiftData
+import SwiftData
+
+/// Marks a todo as completed — **from the widget's own process**.
+///
+/// Interactive widget buttons run their App Intent in the widget extension by default;
+/// this intent opens its own database over the shared App Group file and writes through
+/// a regular `ModelContext`. The write persists immediately, lands in the shared upload
+/// queue (the app's sync client uploads it), and the cross-process change signal updates
+/// the app's `@Query` views live if the app is running.
+struct CompleteTodoIntent: AppIntent {
+    static let title: LocalizedStringResource = "Complete Todo"
+    static let description = IntentDescription("Marks a todo as completed.")
+
+    @Parameter(title: "Todo ID")
+    var todoId: String
+
+    init() {}
+
+    init(todoId: String) {
+        self.todoId = todoId
+    }
+
+    func perform() async throws -> some IntentResult {
+        let database = try SharedDatabase.openDatabase()
+        defer { Task { try? await database.close() } }
+
+        let container = try ModelContainer(
+            for: SwiftData.Schema(SharedDatabase.models),
+            configurations: [PowerSyncDataStoreConfiguration(
+                name: "powersync-widget-intent",
+                database: database
+            )]
+        )
+        let context = ModelContext(container)
+        let id = todoId
+        let descriptor = FetchDescriptor<Todo>(predicate: #Predicate { $0.id == id })
+        if let todo = try context.fetch(descriptor).first {
+            todo.completed = true
+            try context.save()
+        }
+        return .result()
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemoWidget/Info.plist
+++ b/Demos/SwiftDataDemo/SwiftDataDemoWidget/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>SwiftDataDemo Widget</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/Demos/SwiftDataDemo/SwiftDataDemoWidget/PendingTodosProvider.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemoWidget/PendingTodosProvider.swift
@@ -1,0 +1,101 @@
+import Foundation
+import PowerSync
+import PowerSyncSwiftData
+import SwiftData
+import WidgetKit
+
+/// A value snapshot of a pending todo. Timeline entries must not hold `@Model` instances
+/// (they outlive the `ModelContainer` the models were fetched from), so the provider copies
+/// the fetched values into this plain struct.
+struct PendingTodoItem: Identifiable {
+    let id: String
+    let descriptionText: String
+}
+
+struct PendingTodosEntry: TimelineEntry {
+    let date: Date
+    let todos: [PendingTodoItem]
+    let pendingCount: Int
+
+    static let placeholder = PendingTodosEntry(
+        date: .now,
+        todos: [
+            PendingTodoItem(id: "1", descriptionText: "Buy groceries"),
+            PendingTodoItem(id: "2", descriptionText: "Water the plants"),
+        ],
+        pendingCount: 2
+    )
+}
+
+/// Reads the first pending todos straight from the synced PowerSync database.
+///
+/// The provider opens its OWN `PowerSyncDatabase` over the SAME file in the App Group
+/// container the app syncs into. It never calls `connect()` (the app owns the sync
+/// connection) and the store is configured with `readOnly: true`, so any accidental write
+/// is refused: reads stay short and the extension cannot be suspended mid-write
+/// (`0xDEAD10CC`). The database is closed as soon as the fetch completes.
+struct PendingTodosProvider: TimelineProvider {
+    func placeholder(in _: Context) -> PendingTodosEntry {
+        .placeholder
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (PendingTodosEntry) -> Void) {
+        if context.isPreview {
+            completion(.placeholder)
+            return
+        }
+        Task {
+            completion(await loadEntry())
+        }
+    }
+
+    func getTimeline(in _: Context, completion: @escaping (Timeline<PendingTodosEntry>) -> Void) {
+        Task {
+            let entry = await loadEntry()
+            // Ask the system to refresh in 15 minutes; the system also reloads timelines
+            // on its own schedule (and whenever the app calls into WidgetCenter).
+            let timeline = Timeline(
+                entries: [entry],
+                policy: .after(.now.addingTimeInterval(15 * 60))
+            )
+            completion(timeline)
+        }
+    }
+
+    private func loadEntry() async -> PendingTodosEntry {
+        do {
+            let database = try SharedDatabase.openDatabase()
+            defer {
+                Task {
+                    try? await database.close()
+                }
+            }
+
+            let configuration = PowerSyncDataStoreConfiguration(
+                name: "powersync-widget",
+                database: database,
+                readOnly: true
+            )
+            let container = try ModelContainer(
+                for: SwiftData.Schema(SharedDatabase.models),
+                configurations: [configuration]
+            )
+            let context = ModelContext(container)
+
+            var descriptor = FetchDescriptor<Todo>(
+                predicate: #Predicate { !$0.completed },
+                sortBy: [SortDescriptor(\.descriptionText)]
+            )
+            let pendingCount = try context.fetchCount(descriptor)
+            descriptor.fetchLimit = 5
+            let todos = try context.fetch(descriptor).map {
+                PendingTodoItem(id: $0.id, descriptionText: $0.descriptionText)
+            }
+
+            return PendingTodosEntry(date: .now, todos: todos, pendingCount: pendingCount)
+        } catch {
+            // The database may not exist yet (the app has never run or never synced).
+            return PendingTodosEntry(date: .now, todos: [], pendingCount: 0)
+        }
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemoWidget/PendingTodosWidget.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemoWidget/PendingTodosWidget.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+import WidgetKit
+
+/// Widget showing the first pending todos synced by PowerSync. Each row has an
+/// interactive button that completes the todo by WRITING from the widget's process
+/// through the shared PowerSync database (see `CompleteTodoIntent`).
+struct PendingTodosWidget: Widget {
+    let kind = "PendingTodosWidget"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: PendingTodosProvider()) { entry in
+            PendingTodosView(entry: entry)
+                .containerBackground(.fill.tertiary, for: .widget)
+        }
+        .configurationDisplayName("Pending Todos")
+        .description("Shows your pending todos, synced by PowerSync.")
+        .supportedFamilies([.systemSmall, .systemMedium, .systemLarge])
+    }
+}
+
+struct PendingTodosView: View {
+    let entry: PendingTodosEntry
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("Pending")
+                    .font(.headline)
+                Spacer()
+                Text("\(entry.pendingCount)")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
+
+            if entry.todos.isEmpty {
+                Spacer()
+                Text("All done!")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                Spacer()
+            } else {
+                ForEach(entry.todos) { todo in
+                    HStack(spacing: 4) {
+                        Button(intent: CompleteTodoIntent(todoId: todo.id)) {
+                            Image(systemName: "circle")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                        Text(todo.descriptionText)
+                            .font(.caption)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+        }
+    }
+}

--- a/Demos/SwiftDataDemo/SwiftDataDemoWidget/SwiftDataDemoWidget.entitlements
+++ b/Demos/SwiftDataDemo/SwiftDataDemoWidget/SwiftDataDemoWidget.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.co.powersync.swiftdatademo</string>
+	</array>
+</dict>
+</plist>

--- a/Demos/SwiftDataDemo/SwiftDataDemoWidget/SwiftDataDemoWidgetBundle.swift
+++ b/Demos/SwiftDataDemo/SwiftDataDemoWidget/SwiftDataDemoWidgetBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct SwiftDataDemoWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        PendingTodosWidget()
+    }
+}

--- a/Demos/SwiftDataDemo/project.yml
+++ b/Demos/SwiftDataDemo/project.yml
@@ -1,0 +1,99 @@
+name: SwiftDataDemo
+options:
+  bundleIdPrefix: co.powersync
+  deploymentTarget:
+    iOS: "18.0"
+  createIntermediateGroups: true
+
+packages:
+  PowerSync:
+    path: ../..
+  Supabase:
+    url: https://github.com/supabase/supabase-swift
+    majorVersion: 2.4.0
+
+settings:
+  base:
+    SWIFT_VERSION: "5.0"
+    IPHONEOS_DEPLOYMENT_TARGET: "18.0"
+    CODE_SIGN_STYLE: Automatic
+    CURRENT_PROJECT_VERSION: 1
+    MARKETING_VERSION: "1.0"
+
+targets:
+  SwiftDataDemo:
+    type: application
+    platform: iOS
+    sources:
+      - path: SwiftDataDemo
+        excludes:
+          - Secrets.template.swift
+      - path: SwiftDataDemo/Secrets.template.swift
+        buildPhase: none
+      - path: Shared
+    dependencies:
+      - target: SwiftDataDemoWidget
+      - package: PowerSync
+        product: PowerSync
+      - package: PowerSync
+        product: PowerSyncSwiftData
+      - package: Supabase
+        product: Supabase
+    info:
+      path: SwiftDataDemo/Info.plist
+      properties:
+        UILaunchScreen: {}
+        ITSAppUsesNonExemptEncryption: false
+    entitlements:
+      path: SwiftDataDemo/SwiftDataDemo.entitlements
+      properties:
+        com.apple.security.application-groups:
+          - group.co.powersync.swiftdatademo
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: co.powersync.swiftdatademo
+        ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+        ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
+        ENABLE_PREVIEWS: YES
+
+  SwiftDataDemoWidget:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: SwiftDataDemoWidget
+      - path: Shared
+    dependencies:
+      - package: PowerSync
+        product: PowerSync
+      - package: PowerSync
+        product: PowerSyncSwiftData
+    info:
+      path: SwiftDataDemoWidget/Info.plist
+      properties:
+        CFBundleDisplayName: SwiftDataDemo Widget
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.widgetkit-extension
+    entitlements:
+      path: SwiftDataDemoWidget/SwiftDataDemoWidget.entitlements
+      properties:
+        com.apple.security.application-groups:
+          - group.co.powersync.swiftdatademo
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: co.powersync.swiftdatademo.widget
+
+schemes:
+  SwiftDataDemo:
+    build:
+      targets:
+        SwiftDataDemo: all
+    run:
+      config: Debug
+    archive:
+      config: Release
+  SwiftDataDemoWidget:
+    build:
+      targets:
+        SwiftDataDemoWidget: all
+    run:
+      config: Debug

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1c0c1364861f126b24bd7d7575874e6eba634ec76c5297ec1a23f7229298f40b",
+  "originHash" : "29e17e534d864270de2d807e86a5011c49dfaf677a61fe08c11bd9b3f2355b1b",
   "pins" : [
     {
       "identity" : "csqlite",
@@ -44,6 +44,15 @@
       "state" : {
         "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,7 @@
 // swift-tools-version: 6.1
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
+import CompilerPluginSupport
 import PackageDescription
 
 let packageName = "PowerSync"
@@ -57,13 +58,22 @@ let package = Package(
         .library(
             name: "PowerSyncGRDB",
             targets: ["PowerSyncGRDB"]
+        ),
+        .library(
+            name: "PowerSyncSwiftData",
+            targets: ["PowerSyncSwiftData"]
+        ),
+        .library(
+            name: "PowerSyncSwiftDataMacros",
+            targets: ["PowerSyncSwiftDataMacros"]
         )
     ],
     dependencies: conditionalDependencies + [
         .package(url: "https://github.com/groue/GRDB.swift.git", from: "7.11.0"),
         .package(url: "https://github.com/powersync-ja/CSQLite.git", exact: "3.51.2"),
         .package(url: "https://github.com/apple/swift-async-algorithms.git", from: "1.1.0"),
-        .package(url: "https://github.com/apple/swift-collections.git", from: "1.4.0")
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.4.0"),
+        .package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package, defining a module or a test suite.
@@ -91,6 +101,23 @@ let package = Package(
                 .product(name: "GRDB", package: "GRDB.swift")
             ]
         ),
+        .target(
+            name: "PowerSyncSwiftData",
+            dependencies: [
+                .target(name: "PowerSync")
+            ]
+        ),
+        .macro(
+            name: "PowerSyncSwiftDataMacrosPlugin",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+            ]
+        ),
+        .target(
+            name: "PowerSyncSwiftDataMacros",
+            dependencies: ["PowerSyncSwiftDataMacrosPlugin"]
+        ),
         .testTarget(
             name: "PowerSyncTests",
             dependencies: ["PowerSync"]
@@ -98,6 +125,10 @@ let package = Package(
         .testTarget(
             name: "PowerSyncGRDBTests",
             dependencies: ["PowerSync", "PowerSyncGRDB"]
+        ),
+        .testTarget(
+            name: "PowerSyncSwiftDataTests",
+            dependencies: ["PowerSync", "PowerSyncSwiftData", "PowerSyncSwiftDataMacros"]
         )
     ] + conditionalTargets
 )

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The SDK provides two main products:
 - **PowerSync**: Core SDK with SQLite support for data synchronization.
 - **PowerSyncDynamic**: Forced dynamically linked version of `PowerSync` - useful for XCode previews.
 - **PowerSyncGRDB [ALPHA]**: GRDB integration allowing PowerSync to work with GRDB databases. This product is currently in an alpha release.
+- **PowerSyncSwiftData [ALPHA]**: A SwiftData custom `DataStore` backed by PowerSync, letting apps use `@Model`/`@Query`/`ModelContext` with PowerSync storage and sync. Requires iOS 18 / macOS 15. This product is currently in an alpha release; see [its README](./Sources/PowerSyncSwiftData/README.md).
+- **PowerSyncSwiftDataMacros [ALPHA]**: Optional companion to `PowerSyncSwiftData`: the `@PowerSyncModel` macro exposes a model's key paths through public Foundation API, removing the integration's reflection fallback for that model.
 
 ## Demo Apps / Example Projects
 
@@ -25,6 +27,8 @@ The easiest way to test the PowerSync Swift SDK is to run our demo application.
 - [Demos/GRDBDemo](./Demos/GRDBDemo/README.md): A simple to-do list application demonstrating the use of the PowerSync Swift SDK using a Supabase connector and GRDB connections.
 
 - [Demos/SwiftEncryptionDemo](./Demos/SwiftEncryptionDemo/README.md): A simple app opening an encrypted local PowerSync database.
+
+- [Demos/SwiftDataDemo](./Demos/SwiftDataDemo/README.md): A to-do list application built with SwiftData (`@Model`/`@Query`) stored and synced by PowerSync through `PowerSyncSwiftData`, including a read-only widget sharing the database via an App Group.
 
 ## Installation
 
@@ -118,6 +122,42 @@ Feel free to use the `DatabasePool` for view logic and the `PowerSyncDatabase` f
 - Updating the PowerSync schema, with `updateSchema`, is not currently fully supported with GRDB connections.
 - This integration currently requires statically linking PowerSync and GRDB.
 - This implementation requires defining the PowerSync Schema and GRDB data types. This results in some duplication.
+
+### SwiftData Integration
+
+If your app uses SwiftData, the `PowerSyncSwiftData` product provides a custom `DataStore` so `@Model`, `@Query` and `ModelContext` work directly on top of PowerSync: local writes are captured into PowerSync's upload queue, and downloaded changes update the UI live.
+
+**⚠️ Note:** The SwiftData integration is currently in **alpha** release and the API may change significantly. It requires iOS 18 / macOS 15 / watchOS 11 / tvOS 18.
+
+```swift
+import PowerSync
+import PowerSyncSwiftData
+import SwiftData
+
+@Model
+final class Note {
+    var id: String   // maps to PowerSync's id column
+    var title: String
+    var done: Bool
+    init(id: String, title: String, done: Bool) { ... }
+}
+
+// The PowerSync schema is derived from the models - declare them once.
+let database = PowerSyncDatabase(schema: try PowerSyncSchema(for: [Note.self]))
+try await database.connect(connector: MyConnector())
+
+let configuration = PowerSyncDataStoreConfiguration(name: "powersync", database: database)
+let container = try ModelContainer(
+    for: SwiftData.Schema([Note.self]),
+    configurations: [configuration]
+)
+
+// Re-injects sync downloads into SwiftData so @Query updates live.
+let observer = PowerSyncChangeObserver(container: container, configuration: configuration)
+try await observer.start(observing: [Note.self])
+```
+
+See the [module README](./Sources/PowerSyncSwiftData/README.md) for the supported attribute types, predicate translation, relationships, the read-only mode for widgets/extensions, and current limitations.
 
 ## Attachments
 

--- a/Sources/PowerSyncSwiftData/AsyncBridge.swift
+++ b/Sources/PowerSyncSwiftData/AsyncBridge.swift
@@ -1,0 +1,64 @@
+import Dispatch
+import Synchronization
+
+/// Bridges the synchronous, throwing world of `DataStore` callbacks to the async PowerSync API.
+///
+/// `SwiftData.DataStore` requires synchronous `fetch`/`save` implementations while every
+/// PowerSync database operation is `async`. The bridge runs the async body and blocks the
+/// calling thread until it completes.
+///
+/// Safety contract:
+/// - The async body must never await work isolated to the blocked caller (for example, a
+///   `@MainActor` function when the caller is the main thread). PowerSync operations run on
+///   GCD queues and never hop back to the caller, so they satisfy this.
+/// - SwiftData may invoke the store *from* a cooperative-pool thread (any `ModelContext`
+///   used inside a task), so the bridge must not require a cooperative-pool thread to make
+///   progress. The body therefore runs with a dedicated `TaskExecutor` backed by a private
+///   GCD queue: neither the body nor its continuations ever wait for the cooperative pool,
+///   which keeps the bridge deadlock-free even when every pool thread is blocked inside it.
+///   This is validated by the pool-saturation stress test.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+enum AsyncBridge {
+    /// Runs every bridged body and its continuations on GCD worker threads, which the system
+    /// can grow when they block, unlike the fixed-width cooperative pool.
+    private final class BridgeExecutor: TaskExecutor {
+        private let queue = DispatchQueue(
+            label: "com.powersync.swiftdata.async-bridge",
+            qos: .userInitiated,
+            attributes: .concurrent
+        )
+
+        func enqueue(_ job: consuming ExecutorJob) {
+            let unownedJob = UnownedJob(job)
+            let unownedExecutor = asUnownedTaskExecutor()
+            queue.async {
+                unownedJob.runSynchronously(on: unownedExecutor)
+            }
+        }
+    }
+
+    private static let executor = BridgeExecutor()
+
+    /// Runs `body` and blocks the current thread until it finishes, returning its result.
+    static func blocking<T: Sendable>(
+        _ body: @escaping @Sendable () async throws -> T
+    ) throws -> T {
+        let semaphore = DispatchSemaphore(value: 0)
+        let result = Mutex<Result<T, any Error>?>(nil)
+        Task(executorPreference: executor, priority: .userInitiated) {
+            let outcome: Result<T, any Error>
+            do {
+                outcome = try await .success(body())
+            } catch {
+                outcome = .failure(error)
+            }
+            result.withLock { $0 = outcome }
+            semaphore.signal()
+        }
+        semaphore.wait()
+        guard let outcome = result.withLock({ $0 }) else {
+            preconditionFailure("AsyncBridge task signalled without storing a result")
+        }
+        return try outcome.get()
+    }
+}

--- a/Sources/PowerSyncSwiftData/ModelPropertyReflection.swift
+++ b/Sources/PowerSyncSwiftData/ModelPropertyReflection.swift
@@ -1,0 +1,150 @@
+import Foundation
+import SwiftData
+import Synchronization
+
+/// Recovers the typed `AnyKeyPath` for each stored property of a `@Model`.
+///
+/// Sources, in order of preference:
+/// 1. **Public**: if the model conforms to Foundation's `PredicateCodableKeyPathProviding`
+///    with property names as keys, those key paths are used directly — no reflection.
+/// 2. **Reflection**: `PersistentModel.schemaMetadata` (the array the `@Model` macro
+///    generates) read with `Mirror` using the child labels `name`/`keypath`.
+///    `Schema.Attribute` exposes no key path publicly (unlike `Schema.Relationship`), so
+///    this is the default source for attributes.
+///
+/// The reflection coupling is defended in depth: drift-guard tests pin the labels, and
+/// ``validateCoverage(of:entity:)`` runs at first use in production so an SDK change
+/// surfaces as a descriptive startup error instead of silent data loss.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+enum ModelPropertyReflection {
+    /// A stored property reflected from `schemaMetadata` (or provided publicly).
+    /// `AnyKeyPath` is immutable and safe to share across threads.
+    struct Property: @unchecked Sendable {
+        let name: String
+        let keyPath: AnyKeyPath
+    }
+
+    private static let cache = Mutex<[ObjectIdentifier: [Property]]>([:])
+
+    /// Test-only: simulates an SDK that stopped exposing mirrored key paths for the given
+    /// type names, so the runtime failure paths can be exercised.
+    private static let suppressedMirrorTypes = Mutex<Set<String>>([])
+
+    static func _testSuppressMirrorKeyPaths<M: PersistentModel>(for modelType: M.Type, _ suppressed: Bool) {
+        let name = String(describing: modelType)
+        suppressedMirrorTypes.withLock { storage in
+            if suppressed {
+                storage.insert(name)
+            } else {
+                storage.remove(name)
+            }
+        }
+        cache.withLock { $0[ObjectIdentifier(modelType)] = nil }
+    }
+
+    static func properties(for modelType: any PersistentModel.Type) -> [Property] {
+        let key = ObjectIdentifier(modelType)
+        if let cached = cache.withLock({ $0[key] }) {
+            return cached
+        }
+
+        let mirrorSuppressed = suppressedMirrorTypes.withLock {
+            $0.contains(String(describing: modelType))
+        }
+        let provided = providedKeyPaths(of: modelType)
+
+        var properties: [Property] = []
+        for propertyMetadata in modelType.schemaMetadata {
+            var name: String?
+            var keyPath: AnyKeyPath?
+            for child in Mirror(reflecting: propertyMetadata).children {
+                switch child.label {
+                case "name":
+                    name = child.value as? String
+                case "keypath":
+                    keyPath = child.value as? AnyKeyPath
+                default:
+                    break
+                }
+            }
+            guard let name else {
+                continue
+            }
+            // `Schema.Index` and `Schema.Unique` metadata entries carry placeholder key
+            // paths and are not stored properties.
+            if name.hasPrefix("SwiftData.Schema.") {
+                continue
+            }
+            if mirrorSuppressed {
+                keyPath = nil
+            }
+            // A publicly provided key path takes precedence over the reflected one.
+            guard let resolved = provided[name] ?? keyPath else {
+                continue
+            }
+            properties.append(Property(name: name, keyPath: resolved))
+        }
+        if !mirrorSuppressed {
+            cache.withLock { $0[key] = properties }
+        }
+        return properties
+    }
+
+    /// Throws when reflection (plus public providers) does not cover every stored
+    /// attribute of the entity — the descriptive runtime tripwire for SDK drift.
+    static func validateCoverage(of modelType: any PersistentModel.Type, entity: EntityMapping) throws {
+        let reflected = Set(properties(for: modelType).map(\.name))
+        var missing: [String] = []
+        if !reflected.contains(entity.idPropertyName) {
+            missing.append(entity.idPropertyName)
+        }
+        for property in entity.properties where !reflected.contains(property.name) {
+            missing.append(property.name)
+        }
+        guard missing.isEmpty else {
+            throw PowerSyncSwiftDataError.sdkDriftDetected(
+                detail: "schemaMetadata reflection lost the key paths of \(entity.entityName): "
+                    + missing.joined(separator: ", ")
+                    + ". Conforming \(entity.entityName) to PredicateCodableKeyPathProviding "
+                    + "(keys = property names) restores them through public API."
+            )
+        }
+    }
+
+    private static func providedKeyPaths(of modelType: any PersistentModel.Type) -> [String: AnyKeyPath] {
+        guard let providing = modelType as? any PredicateCodableKeyPathProviding.Type else {
+            return [:]
+        }
+        func open<P: PredicateCodableKeyPathProviding>(_: P.Type) -> [String: AnyKeyPath] {
+            P.predicateCodableKeyPaths.mapValues { $0 as AnyKeyPath }
+        }
+        return open(providing)
+    }
+}
+
+/// Tracks entities whose snapshots could not be extracted (no id value despite a known
+/// mapping): the symptom of broken key-path reflection during `init(from:)`, which cannot
+/// throw. ``PowerSyncDataStore/save(_:)`` consults this before writing, so drift fails the
+/// save descriptively instead of persisting empty rows.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+enum ReflectionHealth {
+    private static let flagged = Mutex<Set<String>>([])
+
+    static func flagExtractionFailure(entityName: String) {
+        flagged.withLock { _ = $0.insert(entityName) }
+    }
+
+    static func assertHealthy(entityName: String) throws {
+        let isFlagged = flagged.withLock { $0.contains(entityName) }
+        if isFlagged {
+            throw PowerSyncSwiftDataError.sdkDriftDetected(
+                detail: "snapshot extraction produced no values for \(entityName); "
+                    + "key-path reflection appears broken (see PowerSyncSwiftData README)"
+            )
+        }
+    }
+
+    static func _testReset() {
+        flagged.withLock { $0.removeAll() }
+    }
+}

--- a/Sources/PowerSyncSwiftData/PersistentIdentifier+PrimaryKey.swift
+++ b/Sources/PowerSyncSwiftData/PersistentIdentifier+PrimaryKey.swift
@@ -1,0 +1,59 @@
+import Foundation
+import SwiftData
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PersistentIdentifier {
+    /// Extracts the primary key backing this identifier.
+    ///
+    /// `PersistentIdentifier` is opaque, but it is `Codable`; encoding it produces the
+    /// private envelope `{"implementation": {"primaryKey": ...}}`. Identifiers minted by
+    /// ``PowerSyncDataStore`` always carry the PowerSync `id` string. The format is pinned
+    /// by an SDK-drift guard test.
+    func powerSyncPrimaryKey() throws -> String {
+        let data = try JSONEncoder().encode(self)
+        let envelope = try JSONDecoder().decode(Envelope.self, from: data)
+        return envelope.implementation.primaryKey.stringValue
+    }
+
+    private struct Envelope: Decodable {
+        let implementation: Implementation
+    }
+
+    private struct Implementation: Decodable {
+        let primaryKey: PrimaryKey
+    }
+
+    private enum PrimaryKey: Decodable {
+        case string(String)
+        case int(Int64)
+        case uint(UInt64)
+        case double(Double)
+
+        init(from decoder: any Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let value = try? container.decode(String.self) {
+                self = .string(value)
+            } else if let value = try? container.decode(Int64.self) {
+                self = .int(value)
+            } else if let value = try? container.decode(UInt64.self) {
+                self = .uint(value)
+            } else if let value = try? container.decode(Double.self) {
+                self = .double(value)
+            } else {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Unsupported primary key representation"
+                )
+            }
+        }
+
+        var stringValue: String {
+            switch self {
+            case let .string(value): return value
+            case let .int(value): return String(value)
+            case let .uint(value): return String(value)
+            case let .double(value): return String(value)
+            }
+        }
+    }
+}

--- a/Sources/PowerSyncSwiftData/PowerSyncChangeObserver.swift
+++ b/Sources/PowerSyncSwiftData/PowerSyncChangeObserver.swift
@@ -1,0 +1,448 @@
+import Foundation
+import PowerSync
+import SwiftData
+
+/// Re-injects PowerSync changes (sync downloads) into SwiftData so the UI updates live.
+///
+/// The observer watches each observed entity's PowerSync table. When rows change without
+/// going through SwiftData (a sync download), it reconciles them into a private background
+/// `ModelContext` whose `author` is the configuration's ``PowerSyncDataStoreConfiguration/remoteAuthor``
+/// and saves. That save is echo-suppressed by ``PowerSyncDataStore/save(_:)`` (no write
+/// goes back to PowerSync) but SwiftData still broadcasts `ModelContext.didSave`, which is
+/// what `@Query` and other contexts react to.
+///
+/// Robustness:
+/// - ``start(observing:)`` returns once every entity's initial state has been observed and
+///   **throws** if any watch fails before that (a missing table must not hang the app).
+/// - After priming, a failed watch stream is restarted with exponential backoff, so
+///   transient errors cannot silently kill live updates.
+/// - Emissions are coalesced per entity: if changes arrive faster than reconciliation, only
+///   the latest table state is processed (no unbounded buffering of full-table emissions).
+///
+/// Local saves also wake the watcher (the table changed), but reconciliation diffs row
+/// values against the registered models and finds nothing to change, and the echo-suppressed
+/// save executes no SQL, so no loops can form.
+///
+/// The observer keeps the models of observed entities registered in its context to diff
+/// incoming rows against the last known state. Memory cost is proportional to the number
+/// of rows of the observed entities.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+public actor PowerSyncChangeObserver {
+    private let container: ModelContainer
+    private let configuration: PowerSyncDataStoreConfiguration
+    private nonisolated let logger: any LoggerProtocol
+
+    private struct PendingEmission {
+        let type: any PersistentModel.Type
+        let entity: EntityMapping
+        let rows: [[String: any DataStoreSnapshotValue]]
+    }
+
+    private var watchTasks: [Task<Void, Never>] = []
+    private var context: ModelContext?
+    private var modelsByEntityAndId: [String: [String: any PersistentModel]] = [:]
+    private var primedEntities: Set<String> = []
+    private var primingErrors: [String: any Error] = [:]
+    private var pendingEmissions: [String: PendingEmission] = [:]
+    private var drainingEntities: Set<String> = []
+    /// Incremented on every stop/reset; tasks from older generations become inert.
+    private var generation = 0
+
+    public init(container: ModelContainer, configuration: PowerSyncDataStoreConfiguration) {
+        self.container = container
+        self.configuration = configuration
+        self.logger = configuration.database.logger
+    }
+
+    deinit {
+        for task in watchTasks {
+            task.cancel()
+        }
+    }
+
+    /// Starts watching the PowerSync tables of the given model types. Returns once the
+    /// initial state of every entity has been observed; throws if any watch fails before
+    /// then, leaving the observer ready to be started again.
+    public func start(observing types: [any PersistentModel.Type]) async throws {
+        guard watchTasks.isEmpty else {
+            return
+        }
+        guard let schema = configuration.schema else {
+            throw PowerSyncSwiftDataError.missingSchema
+        }
+        let mapper: SchemaMapper
+        do {
+            mapper = try SchemaMapper(
+                schema: schema,
+                tableNameForEntity: configuration.tableNameForEntity,
+                columnNameForProperty: configuration.columnNameForProperty
+            )
+        } catch {
+            throw error
+        }
+
+        func entityName<M: PersistentModel>(of _: M.Type) -> String {
+            SwiftData.Schema.entityName(for: M.self)
+        }
+
+        let currentGeneration = generation
+        var entityNames: [String] = []
+        do {
+            for type in types {
+                let name = entityName(of: type)
+                entityNames.append(name)
+                let entity = try mapper.entity(named: name)
+                watchTasks.append(makeWatchTask(type: type, entity: entity, generation: currentGeneration))
+            }
+        } catch {
+            cancelAndReset()
+            throw error
+        }
+
+        // The first emission of each watch carries the current table state and primes the
+        // registry; wait for all of them, surfacing the first failure instead of hanging.
+        while true {
+            if let failure = primingErrors.values.first {
+                cancelAndReset()
+                throw failure
+            }
+            if entityNames.allSatisfy({ primedEntities.contains($0) }) {
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+
+    /// Stops watching. The observer can be started again.
+    public func stop() {
+        cancelAndReset()
+    }
+
+    private func cancelAndReset() {
+        generation += 1
+        for task in watchTasks {
+            task.cancel()
+        }
+        watchTasks = []
+        primedEntities = []
+        primingErrors = [:]
+        pendingEmissions = [:]
+        drainingEntities = []
+        modelsByEntityAndId = [:]
+        context = nil
+    }
+
+    // MARK: watching
+
+    private func makeWatchTask(
+        type: any PersistentModel.Type,
+        entity: EntityMapping,
+        generation: Int
+    ) -> Task<Void, Never> {
+        let database = configuration.database
+        let sql = entity.selectSQL(where: nil, orderBy: nil, limit: nil, offset: nil)
+        return Task { [weak self, logger] in
+            var backoff: Duration = .milliseconds(250)
+            while !Task.isCancelled {
+                do {
+                    let stream = try database.watch(sql: sql, parameters: []) { cursor in
+                        try entity.row(from: cursor)
+                    }
+                    for try await rows in stream {
+                        guard let self else { return }
+                        await self.receive(rows: rows, type: type, entity: entity, generation: generation)
+                        backoff = .milliseconds(250)
+                    }
+                    // The stream ended (database closed): nothing left to watch.
+                    return
+                } catch is CancellationError {
+                    return
+                } catch {
+                    guard let self else { return }
+                    guard await self.noteWatchFailure(error, entityName: entity.entityName, generation: generation) else {
+                        return
+                    }
+                    logger.error(
+                        "watch for \(entity.tableName) failed; retrying in \(backoff): \(error)",
+                        tag: "PowerSyncSwiftData"
+                    )
+                    try? await Task.sleep(for: backoff)
+                    backoff = min(backoff * 2, .seconds(30))
+                }
+            }
+        }
+    }
+
+    /// Returns whether the watch task should retry. Failures before priming are stored for
+    /// ``start(observing:)`` to throw; failures after priming are transient and retried.
+    private func noteWatchFailure(_ error: any Error, entityName: String, generation: Int) -> Bool {
+        guard generation == self.generation else {
+            return false
+        }
+        if primedEntities.contains(entityName) {
+            return true
+        }
+        primingErrors[entityName] = error
+        return false
+    }
+
+    /// Stores the emission (replacing any unprocessed one for the entity) and kicks off a
+    /// drain if none is running: bursts coalesce to the latest table state.
+    private func receive(
+        rows: [[String: any DataStoreSnapshotValue]],
+        type: any PersistentModel.Type,
+        entity: EntityMapping,
+        generation: Int
+    ) {
+        guard generation == self.generation else {
+            return
+        }
+        pendingEmissions[entity.entityName] = PendingEmission(type: type, entity: entity, rows: rows)
+        guard !drainingEntities.contains(entity.entityName) else {
+            return
+        }
+        drainingEntities.insert(entity.entityName)
+        Task { [weak self] in
+            await self?.drain(entityName: entity.entityName, generation: generation)
+        }
+    }
+
+    private func drain(entityName: String, generation: Int) {
+        defer { drainingEntities.remove(entityName) }
+        while generation == self.generation, let emission = pendingEmissions.removeValue(forKey: entityName) {
+            reconcile(emission)
+        }
+    }
+
+    // MARK: reconciliation
+
+    private nonisolated func logError(_ message: String) {
+        logger.error(message, tag: "PowerSyncSwiftData")
+    }
+
+    private func ensureContext() -> ModelContext {
+        if let context {
+            return context
+        }
+        let created = ModelContext(container)
+        created.author = configuration.remoteAuthor
+        created.autosaveEnabled = false
+        context = created
+        return created
+    }
+
+    private func reconcile(_ emission: PendingEmission) {
+        func open<M: PersistentModel>(_: M.Type) throws {
+            try reconcileTyped(M.self, entity: emission.entity, rows: emission.rows)
+        }
+        do {
+            try open(emission.type)
+            primedEntities.insert(emission.entity.entityName)
+        } catch {
+            if primedEntities.contains(emission.entity.entityName) {
+                logError("reconciliation for \(emission.entity.entityName) failed: \(error)")
+            } else {
+                // A failed priming must not mark the entity primed (a later emission would
+                // diff against an empty registry and duplicate every row); it surfaces
+                // through start() instead.
+                primingErrors[emission.entity.entityName] = error
+            }
+        }
+    }
+
+    private func reconcileTyped<M: PersistentModel>(
+        _: M.Type,
+        entity: EntityMapping,
+        rows: [[String: any DataStoreSnapshotValue]]
+    ) throws {
+        let context = ensureContext()
+        let properties = ModelPropertyReflection.properties(for: M.self)
+        var registry = modelsByEntityAndId[entity.entityName] ?? [:]
+        defer { modelsByEntityAndId[entity.entityName] = registry }
+
+        var rowsById: [String: [String: any DataStoreSnapshotValue]] = [:]
+        for row in rows {
+            if let id = row[entity.idPropertyName] as? String {
+                rowsById[id] = row
+            }
+        }
+
+        guard primedEntities.contains(entity.entityName) else {
+            // First emission: register the current state without broadcasting anything.
+            for model in try context.fetch(FetchDescriptor<M>()) {
+                if let id = Self.idValue(of: model, entity: entity, properties: properties) {
+                    registry[id] = model
+                }
+            }
+            return
+        }
+
+        let knownIds = Set(registry.keys)
+        let currentIds = Set(rowsById.keys)
+
+        for id in knownIds.subtracting(currentIds) {
+            if let model = registry.removeValue(forKey: id) as? M {
+                context.delete(model)
+            }
+        }
+
+        for id in currentIds.subtracting(knownIds) {
+            guard let row = rowsById[id] else { continue }
+            // Populate the backing data BEFORE creating the model: the @Model property
+            // setters (and key-path writes) run the getter first, which traps on
+            // uninitialized storage.
+            var backingData: any BackingData<M> = M.createBackingData()
+            Self.populate(&backingData, from: row, entity: entity, properties: properties)
+            let model = M(backingData: backingData)
+            context.insert(model)
+            registry[id] = model
+        }
+
+        for id in currentIds.intersection(knownIds) {
+            guard let model = registry[id] as? M, let row = rowsById[id] else { continue }
+            Self.apply(row, to: model, entity: entity, properties: properties, diffing: true)
+        }
+
+        if context.hasChanges {
+            try context.save()
+        }
+    }
+
+    private static func idValue<M: PersistentModel>(
+        of model: M,
+        entity: EntityMapping,
+        properties: [ModelPropertyReflection.Property]
+    ) -> String? {
+        guard let property = properties.first(where: { $0.name == entity.idPropertyName }) else {
+            return nil
+        }
+        return model[keyPath: property.keyPath] as? String
+    }
+
+    private static func columnKind(
+        of property: ModelPropertyReflection.Property,
+        entity: EntityMapping
+    ) -> ValueCoercion.Kind? {
+        if property.name == entity.idPropertyName {
+            return .string
+        }
+        return entity.propertiesByName[property.name]?.kind
+    }
+
+    /// Writes row values onto a registered model through its property setters (so SwiftData
+    /// tracks the changes), skipping values whose column representation already matches.
+    private static func apply<M: PersistentModel>(
+        _ row: [String: any DataStoreSnapshotValue],
+        to model: M,
+        entity: EntityMapping,
+        properties: [ModelPropertyReflection.Property],
+        diffing: Bool
+    ) {
+        for property in properties {
+            guard let kind = columnKind(of: property, entity: entity) else {
+                continue
+            }
+            let newValue = row[property.name]
+            if diffing {
+                let currentValue = ValueCoercion.flattenOptional(model[keyPath: property.keyPath] as Any)
+                if ValueCoercion.representationsEqual(currentValue, newValue, kind: kind) {
+                    continue
+                }
+            }
+            assign(newValue, to: model, keyPath: property.keyPath, kind: kind)
+        }
+    }
+
+    /// Writes row values into fresh backing data (used before the model exists).
+    private static func populate<B: BackingData>(
+        _ backingData: inout B,
+        from row: [String: any DataStoreSnapshotValue],
+        entity: EntityMapping,
+        properties: [ModelPropertyReflection.Property]
+    ) {
+        for property in properties {
+            guard let kind = columnKind(of: property, entity: entity) else {
+                continue
+            }
+            setBackingValue(row[property.name], on: &backingData, keyPath: property.keyPath, kind: kind)
+        }
+    }
+
+    private static func setBackingValue<B: BackingData>(
+        _ value: (any DataStoreSnapshotValue)?,
+        on backingData: inout B,
+        keyPath: AnyKeyPath,
+        kind: ValueCoercion.Kind
+    ) {
+        func set<V: Decodable & Encodable & Sendable>(_: V.Type) {
+            if let typed = keyPath as? KeyPath<B.Model, V> {
+                if let concrete = value as? V {
+                    backingData.setValue(forKey: typed, to: concrete)
+                }
+                return
+            }
+            if let typed = keyPath as? KeyPath<B.Model, V?> {
+                backingData.setValue(forKey: typed, to: value as? V)
+            }
+        }
+        func setAny(_ type: any (Decodable & Encodable & Sendable).Type) {
+            func go<V: Decodable & Encodable & Sendable>(_: V.Type) {
+                set(V.self)
+            }
+            go(type)
+        }
+        switch kind {
+        case .string: set(String.self)
+        case .bool: set(Bool.self)
+        case .int: set(Int.self)
+        case .int64: set(Int64.self)
+        case .int32: set(Int32.self)
+        case .double: set(Double.self)
+        case .float: set(Float.self)
+        case .date: set(Date.self)
+        case .uuid: set(UUID.self)
+        case .data: set(Data.self)
+        case let .rawRepresentable(type, _): setAny(type)
+        case let .codable(type): setAny(type)
+        }
+    }
+
+    private static func assign<M: PersistentModel>(
+        _ value: (any DataStoreSnapshotValue)?,
+        to model: M,
+        keyPath: AnyKeyPath,
+        kind: ValueCoercion.Kind
+    ) {
+        func set<V>(_: V.Type) {
+            if let writable = keyPath as? ReferenceWritableKeyPath<M, V> {
+                if let typed = value as? V {
+                    model[keyPath: writable] = typed
+                }
+                return
+            }
+            if let writable = keyPath as? ReferenceWritableKeyPath<M, V?> {
+                model[keyPath: writable] = value as? V
+            }
+        }
+        func setAny(_ type: any (Decodable & Encodable & Sendable).Type) {
+            func go<V: Decodable & Encodable & Sendable>(_: V.Type) {
+                set(V.self)
+            }
+            go(type)
+        }
+        switch kind {
+        case .string: set(String.self)
+        case .bool: set(Bool.self)
+        case .int: set(Int.self)
+        case .int64: set(Int64.self)
+        case .int32: set(Int32.self)
+        case .double: set(Double.self)
+        case .float: set(Float.self)
+        case .date: set(Date.self)
+        case .uuid: set(UUID.self)
+        case .data: set(Data.self)
+        case let .rawRepresentable(type, _): setAny(type)
+        case let .codable(type): setAny(type)
+        }
+    }
+}

--- a/Sources/PowerSyncSwiftData/PowerSyncDataStore.swift
+++ b/Sources/PowerSyncSwiftData/PowerSyncDataStore.swift
@@ -1,0 +1,502 @@
+import Foundation
+import PowerSync
+import SwiftData
+import Synchronization
+
+extension Array {
+    func chunked(into size: Int) -> [[Element]] {
+        stride(from: 0, to: count, by: size).map {
+            Array(self[$0 ..< Swift.min($0 + size, count)])
+        }
+    }
+}
+
+/// A SwiftData `DataStore` backed by a PowerSync database.
+///
+/// SwiftData operations (`@Query`, `ModelContext.fetch`, `ModelContext.save`) are translated
+/// to PowerSync queries and writes. Writes go through PowerSync views, so they are captured
+/// in the `ps_crud` upload queue and synchronized by the app's backend connector. PowerSync
+/// owns the only SQLite connection; the store never opens a second one.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+public final class PowerSyncDataStore: DataStore, DataStoreBatching {
+    public typealias Configuration = PowerSyncDataStoreConfiguration
+    public typealias Snapshot = PowerSyncSnapshot
+
+    public let configuration: PowerSyncDataStoreConfiguration
+    public let identifier: String
+
+    let database: any PowerSyncDatabaseProtocol
+    private let cachedMapper = Mutex<SchemaMapper?>(nil)
+    /// Per-entity translators (their key-path tables are built once, not per fetch).
+    private let translators = Mutex<[String: PredicateTranslator]>([:])
+    /// Model types whose key-path coverage has been validated against the mapping.
+    private let validatedModels = Mutex<Set<ObjectIdentifier>>([])
+
+    public var schema: SwiftData.Schema {
+        configuration.schema ?? SwiftData.Schema()
+    }
+
+    public init(
+        _ configuration: PowerSyncDataStoreConfiguration,
+        migrationPlan: (any SchemaMigrationPlan.Type)?
+    ) throws {
+        guard migrationPlan == nil else {
+            throw PowerSyncSwiftDataError.migrationPlansUnsupported
+        }
+        self.configuration = configuration
+        self.identifier = configuration.name
+        self.database = configuration.database
+        if configuration.schema != nil {
+            _ = try mapper()
+        }
+        // Self-check the identifier's private Codable envelope once per store. With the
+        // mint cache in front it is only a fallback, but drift deserves a loud signal.
+        if let probe = try? PersistentIdentifier.identifier(
+            for: identifier,
+            entityName: "_powersync_probe",
+            primaryKey: "probe"
+        ), (try? probe.powerSyncPrimaryKey()) != "probe" {
+            configuration.database.logger.error(
+                "PersistentIdentifier's Codable envelope changed in this SDK; identifier "
+                    + "resolution now relies on the in-process mint cache only. "
+                    + "Report this to powersync-swift.",
+                tag: "PowerSyncSwiftData"
+            )
+        }
+    }
+
+    /// `ModelContainer` injects the schema into the configuration, so the mapper is built on
+    /// first use and cached. Building it also registers the entity mappings for
+    /// ``PowerSyncSnapshot`` initializers that receive no store reference.
+    private func mapper() throws -> SchemaMapper {
+        if let mapper = cachedMapper.withLock({ $0 }) {
+            return mapper
+        }
+        guard let schema = configuration.schema else {
+            throw PowerSyncSwiftDataError.missingSchema
+        }
+        let mapper = try SchemaMapper(
+            schema: schema,
+            tableNameForEntity: configuration.tableNameForEntity,
+            columnNameForProperty: configuration.columnNameForProperty
+        )
+        try validateMapping(mapper)
+        try SnapshotEntityRegistry.register(mapper)
+        return cachedMapper.withLock { storage in
+            if let existing = storage {
+                return existing
+            }
+            storage = mapper
+            return mapper
+        }
+    }
+
+    /// Verifies every mapped table and column against the actual database, so mapping
+    /// mistakes fail container creation with a precise error instead of surfacing as
+    /// cryptic SQL failures (or observer hangs) on first use.
+    private func validateMapping(_ mapper: SchemaMapper) throws {
+        let database = self.database
+        for entity in mapper.entitiesByName.values {
+            let table = entity.tableName
+            let existingColumns = try AsyncBridge.blocking {
+                try await database.getAll(
+                    sql: "SELECT name FROM pragma_table_xinfo(?)",
+                    parameters: [table]
+                ) { try $0.getString(name: "name") }
+            }
+            guard !existingColumns.isEmpty else {
+                throw PowerSyncSwiftDataError.tableMissing(entity: entity.entityName, table: table)
+            }
+            let required = ["id"]
+                + entity.properties.filter(\.isStored).map(\.columnName)
+                + entity.toOne.map(\.columnName)
+            let missing = required.filter { !existingColumns.contains($0) }
+            guard missing.isEmpty else {
+                throw PowerSyncSwiftDataError.columnsMissing(
+                    entity: entity.entityName,
+                    table: table,
+                    columns: missing
+                )
+            }
+        }
+    }
+
+    /// Translates the descriptor's predicate and sort. Untranslatable nodes surface as
+    /// `DataStoreError.preferInMemoryFilter`/`.preferInMemorySort`, telling SwiftData to
+    /// filter or sort in memory.
+    private func translate<T: PersistentModel>(
+        _ descriptor: FetchDescriptor<T>,
+        entity: EntityMapping
+    ) throws -> (whereClause: String?, bindings: [Sendable?], orderBy: String?) {
+        let translator = translators.withLock { cache -> PredicateTranslator in
+            if let cached = cache[entity.entityName] {
+                return cached
+            }
+            let created = PredicateTranslator(entity: entity, modelType: T.self)
+            cache[entity.entityName] = created
+            return created
+        }
+        var whereClause: String?
+        var bindings: [Sendable?] = []
+        if let predicate = descriptor.predicate {
+            let translated = try translator.translateWhere(predicate)
+            whereClause = translated.clause
+            bindings = translated.bindings
+        }
+        let orderBy = try translator.translateOrderBy(descriptor.sortBy)
+        return (whereClause, bindings, orderBy)
+    }
+
+    /// One-time (per model type) runtime check that key-path resolution covers every
+    /// mapped attribute, so SDK drift fails the first fetch descriptively.
+    private func ensureReflectionCoverage<T: PersistentModel>(_: T.Type, entity: EntityMapping) throws {
+        let key = ObjectIdentifier(T.self)
+        let alreadyValidated = validatedModels.withLock { $0.contains(key) }
+        guard !alreadyValidated else { return }
+        try ModelPropertyReflection.validateCoverage(of: T.self, entity: entity)
+        validatedModels.withLock { _ = $0.insert(key) }
+    }
+
+    public func fetch<T: PersistentModel>(
+        _ request: DataStoreFetchRequest<T>
+    ) throws -> DataStoreFetchResult<T, PowerSyncSnapshot> {
+        let descriptor = request.descriptor
+        let entity = try mapper().entity(named: SwiftData.Schema.entityName(for: T.self))
+        try ensureReflectionCoverage(T.self, entity: entity)
+        let (whereClause, bindings, orderBy) = try translate(descriptor, entity: entity)
+        let sql = entity.selectSQL(
+            where: whereClause,
+            orderBy: orderBy,
+            limit: descriptor.fetchLimit,
+            offset: descriptor.fetchOffset
+        )
+        let database = self.database
+        var rows = try AsyncBridge.blocking {
+            try await database.getAll(sql: sql, parameters: bindings) { cursor in
+                // Everything is read inside the mapper; the cursor never escapes.
+                try entity.row(from: cursor)
+            }
+        }
+        try populateToMany(entity: entity, rows: &rows)
+        let storeIdentifier = identifier
+        let keyTransform = configuration._testFetchKeyTransform
+        let snapshots = try rows.map { row in
+            try PowerSyncSnapshot(
+                row: row,
+                entity: entity,
+                storeIdentifier: storeIdentifier,
+                keyTransform: keyTransform
+            )
+        }
+        return DataStoreFetchResult(
+            descriptor: descriptor,
+            fetchedSnapshots: snapshots,
+            relatedSnapshots: [:]
+        )
+    }
+
+    /// Resolves the entity's to-many relationships for the fetched rows with one batched
+    /// query per relationship over the destination's inverse foreign-key column.
+    private func populateToMany(
+        entity: EntityMapping,
+        rows: inout [[String: any DataStoreSnapshotValue]]
+    ) throws {
+        guard !entity.toMany.isEmpty, !rows.isEmpty else {
+            return
+        }
+        let parentIds = rows.compactMap { $0[entity.idPropertyName] as? String }
+        let database = self.database
+        let storeIdentifier = identifier
+        for relationship in entity.toMany {
+            var childrenByParent: [String: [PersistentIdentifier]] = [:]
+            for chunk in parentIds.chunked(into: 500) {
+                let sql = entity.childrenSQL(for: relationship, parentCount: chunk.count)
+                let inverseColumn = relationship.inverseColumnName
+                let pairs = try AsyncBridge.blocking {
+                    try await database.getAll(sql: sql, parameters: chunk) { cursor in
+                        (try cursor.getString(name: "id"), try cursor.getString(name: inverseColumn))
+                    }
+                }
+                for (childId, parentId) in pairs {
+                    let identifier = try PrimaryKeyResolver.mint(
+                        store: storeIdentifier,
+                        entityName: relationship.destinationEntityName,
+                        primaryKey: childId
+                    )
+                    childrenByParent[parentId, default: []].append(identifier)
+                }
+            }
+            for index in rows.indices {
+                guard let parentId = rows[index][entity.idPropertyName] as? String else { continue }
+                rows[index][relationship.name] = childrenByParent[parentId] ?? []
+            }
+        }
+    }
+
+    /// Deletes every row matching the request's predicate with a single SQL DELETE,
+    /// captured by PowerSync's triggers for upload.
+    public func delete<T: PersistentModel>(
+        _ request: DataStoreBatchDeleteRequest<T>
+    ) throws {
+        guard !configuration.readOnly else {
+            throw DataStoreError.unsupportedFeature
+        }
+        guard request.editingState.author != configuration.remoteAuthor else {
+            return
+        }
+        let entity = try mapper().entity(named: SwiftData.Schema.entityName(for: T.self))
+        var whereClause: String?
+        var bindings: [Sendable?] = []
+        if let predicate = request.predicate {
+            let translator = PredicateTranslator(entity: entity, modelType: T.self)
+            let translated = try translator.translateWhere(predicate)
+            whereClause = translated.clause
+            bindings = translated.bindings
+        }
+        var sql = "DELETE FROM \(sqlQuote(entity.tableName))"
+        if let whereClause {
+            sql += " WHERE \(whereClause)"
+        }
+        let database = self.database
+        let statement = SQLStatement(sql: sql, parameters: bindings)
+        try AsyncBridge.blocking {
+            try await database.writeTransaction { transaction in
+                _ = try transaction.execute(sql: statement.sql, parameters: statement.parameters)
+            }
+        }
+    }
+
+    /// Erasing the store is intentionally unsupported. Resetting local PowerSync data is
+    /// `PowerSyncDatabaseProtocol.disconnectAndClear()`'s job; routing it through the
+    /// store would capture a DELETE for every row into the upload queue and destroy
+    /// server-side data.
+    public func erase() throws {
+        throw DataStoreError.unsupportedFeature
+    }
+
+    /// Returns fresh snapshots for the requested identifiers, straight from the database.
+    /// SwiftData uses this to restore model state, e.g. on `ModelContext.rollback()`.
+    public func cachedSnapshots(
+        for persistentIdentifiers: [PersistentIdentifier],
+        editingState: EditingState
+    ) throws -> [PersistentIdentifier: PowerSyncSnapshot] {
+        let mapper = try mapper()
+        let database = self.database
+        let storeIdentifier = identifier
+        var snapshots: [PersistentIdentifier: PowerSyncSnapshot] = [:]
+        let byEntity = Dictionary(grouping: persistentIdentifiers, by: \.entityName)
+        for (entityName, identifiers) in byEntity {
+            let entity = try mapper.entity(named: entityName)
+            let primaryKeys = try identifiers.map { try PrimaryKeyResolver.primaryKey(of: $0) }
+            for chunk in primaryKeys.chunked(into: 500) {
+                let placeholders = Array(repeating: "?", count: chunk.count).joined(separator: ", ")
+                let sql = entity.selectSQL(
+                    where: "\(sqlQuote("id")) IN (\(placeholders))",
+                    orderBy: nil,
+                    limit: nil,
+                    offset: nil
+                )
+                var rows = try AsyncBridge.blocking {
+                    try await database.getAll(sql: sql, parameters: chunk) { cursor in
+                        try entity.row(from: cursor)
+                    }
+                }
+                try populateToMany(entity: entity, rows: &rows)
+                for row in rows {
+                    let snapshot = try PowerSyncSnapshot(
+                        row: row,
+                        entity: entity,
+                        storeIdentifier: storeIdentifier,
+                        keyTransform: nil
+                    )
+                    snapshots[snapshot.persistentIdentifier] = snapshot
+                }
+            }
+        }
+        return snapshots
+    }
+
+    public func fetchCount<T: PersistentModel>(
+        _ request: DataStoreFetchRequest<T>
+    ) throws -> Int {
+        let descriptor = request.descriptor
+        let entity = try mapper().entity(named: SwiftData.Schema.entityName(for: T.self))
+        let (whereClause, bindings, _) = try translate(descriptor, entity: entity)
+        let sql = entity.countSQL(where: whereClause)
+        let database = self.database
+        var count = try AsyncBridge.blocking {
+            try await database.get(sql: sql, parameters: bindings) { cursor in
+                try cursor.getInt(index: 0)
+            }
+        }
+        // Count what the fetch would return: discount the offset, then cap at the limit.
+        if let offset = descriptor.fetchOffset {
+            count = max(0, count - offset)
+        }
+        if let limit = descriptor.fetchLimit {
+            count = min(count, limit)
+        }
+        return count
+    }
+
+    public func fetchIdentifiers<T: PersistentModel>(
+        _ request: DataStoreFetchRequest<T>
+    ) throws -> [PersistentIdentifier] {
+        let descriptor = request.descriptor
+        let entityName = SwiftData.Schema.entityName(for: T.self)
+        let entity = try mapper().entity(named: entityName)
+        let (whereClause, bindings, orderBy) = try translate(descriptor, entity: entity)
+        let sql = entity.identifiersSQL(
+            where: whereClause,
+            orderBy: orderBy,
+            limit: descriptor.fetchLimit,
+            offset: descriptor.fetchOffset
+        )
+        let database = self.database
+        let primaryKeys = try AsyncBridge.blocking {
+            try await database.getAll(sql: sql, parameters: bindings) { cursor in
+                try cursor.getString(name: "id")
+            }
+        }
+        let storeIdentifier = identifier
+        return try primaryKeys.map { primaryKey in
+            try PrimaryKeyResolver.mint(
+                store: storeIdentifier,
+                entityName: entityName,
+                primaryKey: primaryKey
+            )
+        }
+    }
+
+    public func save(
+        _ request: DataStoreSaveChangesRequest<PowerSyncSnapshot>
+    ) throws -> DataStoreSaveChangesResult<PowerSyncSnapshot> {
+        guard !configuration.readOnly else {
+            throw DataStoreError.unsupportedFeature
+        }
+        let mapper = try mapper()
+
+        // Echo suppression: saves authored by the change observer re-inject data that came
+        // FROM PowerSync, so nothing is written back. Inserted snapshots still need their
+        // permanent identifiers minted so SwiftData can register the models.
+        if request.editingState.author == configuration.remoteAuthor {
+            var remappedIdentifiers: [PersistentIdentifier: PersistentIdentifier] = [:]
+            var snapshotsToReregister: [PersistentIdentifier: PowerSyncSnapshot] = [:]
+            for snapshot in request.inserted {
+                let entity = try mapper.entity(named: snapshot.entityName)
+                guard let primaryKey = snapshot.primaryKey ?? (snapshot.values[entity.idPropertyName] as? String),
+                      !primaryKey.isEmpty
+                else {
+                    throw PowerSyncSwiftDataError.missingPrimaryKey(entity: snapshot.entityName)
+                }
+                let permanentIdentifier = try PrimaryKeyResolver.mint(
+                    store: identifier,
+                    entityName: snapshot.entityName,
+                    primaryKey: primaryKey
+                )
+                remappedIdentifiers[snapshot.persistentIdentifier] = permanentIdentifier
+                snapshotsToReregister[permanentIdentifier] = snapshot
+                    .settingPrimaryKey(primaryKey, idPropertyName: entity.idPropertyName)
+                    .copy(persistentIdentifier: permanentIdentifier, remappedIdentifiers: nil)
+            }
+            return DataStoreSaveChangesResult(
+                for: identifier,
+                remappedIdentifiers: remappedIdentifiers,
+                snapshotsToReregister: snapshotsToReregister
+            )
+        }
+
+        var remappedIdentifiers: [PersistentIdentifier: PersistentIdentifier] = [:]
+        var snapshotsToReregister: [PersistentIdentifier: PowerSyncSnapshot] = [:]
+        var insertStatements: [SQLStatement] = []
+        var updateStatements: [SQLStatement] = []
+        var deleteStatements: [SQLStatement] = []
+
+        // First pass: mint a permanent identifier for every inserted snapshot. Snapshots
+        // may reference each other (a child inserted together with its parent, including
+        // cycles), so the full map must exist before any statement is built. PowerSync
+        // tables are views over JSON without enforced foreign keys, so insert order never
+        // matters.
+        var insertedKeys: [(snapshot: PowerSyncSnapshot, entity: EntityMapping, primaryKey: String)] = []
+        for snapshot in request.inserted {
+            try ReflectionHealth.assertHealthy(entityName: snapshot.entityName)
+            let entity = try mapper.entity(named: snapshot.entityName)
+            let modelId = snapshot.primaryKey ?? (snapshot.values[entity.idPropertyName] as? String)
+            let primaryKey: String
+            if let modelId, !modelId.isEmpty {
+                primaryKey = modelId
+            } else {
+                primaryKey = UUID().uuidString.lowercased()
+            }
+            let permanentIdentifier = try PrimaryKeyResolver.mint(
+                store: identifier,
+                entityName: snapshot.entityName,
+                primaryKey: primaryKey
+            )
+            remappedIdentifiers[snapshot.persistentIdentifier] = permanentIdentifier
+            insertedKeys.append((snapshot, entity, primaryKey))
+        }
+
+        // Second pass: build statements with relationship references rewritten through the
+        // complete remapping.
+        for (snapshot, entity, primaryKey) in insertedKeys {
+            let permanentIdentifier = remappedIdentifiers[snapshot.persistentIdentifier]!
+            let saved = snapshot
+                .settingPrimaryKey(primaryKey, idPropertyName: entity.idPropertyName)
+                .copy(persistentIdentifier: permanentIdentifier, remappedIdentifiers: remappedIdentifiers)
+            insertStatements.append(try entity.insertStatement(for: saved, primaryKey: primaryKey))
+            snapshotsToReregister[permanentIdentifier] = saved
+        }
+
+        for snapshot in request.updated {
+            let entity = try mapper.entity(named: snapshot.entityName)
+            // The row is addressed by the identifier SwiftData registered, never by the id
+            // property: a mutated id would silently target nothing.
+            let primaryKey = try PrimaryKeyResolver.primaryKey(of: snapshot.persistentIdentifier)
+            if let modelId = snapshot.values[entity.idPropertyName] as? String, modelId != primaryKey {
+                throw PowerSyncSwiftDataError.idMutationUnsupported(entity: snapshot.entityName)
+            }
+            // Updated snapshots can reference models inserted in this same save.
+            let resolved = snapshot.copy(
+                persistentIdentifier: snapshot.persistentIdentifier,
+                remappedIdentifiers: remappedIdentifiers
+            )
+            if let statement = try entity.updateStatement(for: resolved, primaryKey: primaryKey) {
+                updateStatements.append(statement)
+            }
+        }
+
+        for snapshot in request.deleted {
+            let entity = try mapper.entity(named: snapshot.entityName)
+            // Deletes also address the registered identifier (a mutated id must not stop
+            // the row from being removed).
+            let primaryKey = try PrimaryKeyResolver.primaryKey(of: snapshot.persistentIdentifier)
+            deleteStatements.append(entity.deleteStatement(primaryKey: primaryKey))
+        }
+
+        // Deletes run first so a delete+insert pair sharing an id (the "replace" pattern)
+        // does not trip the primary key constraint; inserted rows are never deleted by the
+        // same request because SwiftData never reports a snapshot as both.
+        let statements = deleteStatements + insertStatements + updateStatements
+
+        if !statements.isEmpty {
+            let database = self.database
+            let pending = statements
+            // One write transaction per save request: the batch is atomic, and PowerSync's
+            // triggers capture every statement into the ps_crud upload queue.
+            try AsyncBridge.blocking {
+                try await database.writeTransaction { transaction in
+                    for statement in pending {
+                        _ = try transaction.execute(sql: statement.sql, parameters: statement.parameters)
+                    }
+                }
+            }
+        }
+
+        return DataStoreSaveChangesResult(
+            for: identifier,
+            remappedIdentifiers: remappedIdentifiers,
+            snapshotsToReregister: snapshotsToReregister
+        )
+    }
+}

--- a/Sources/PowerSyncSwiftData/PowerSyncDataStoreConfiguration.swift
+++ b/Sources/PowerSyncSwiftData/PowerSyncDataStoreConfiguration.swift
@@ -1,0 +1,103 @@
+import PowerSync
+import SwiftData
+
+/// Configures a ``PowerSyncDataStore`` for use with a SwiftData `ModelContainer`.
+///
+/// The application owns the `PowerSyncDatabase` (and its sync connection); this configuration
+/// merely points the store at it:
+///
+/// ```swift
+/// let database = PowerSyncDatabase(schema: appSchema)
+/// let configuration = PowerSyncDataStoreConfiguration(
+///     name: "powersync",
+///     database: database
+/// )
+/// let container = try ModelContainer(
+///     for: SwiftData.Schema([Note.self]),
+///     configurations: [configuration]
+/// )
+/// ```
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+public final class PowerSyncDataStoreConfiguration: DataStoreConfiguration {
+    public typealias Store = PowerSyncDataStore
+
+    /// Identifies the store. Persistent identifiers minted by the store embed this name.
+    public let name: String
+
+    /// The SwiftData schema. `ModelContainer` injects this before creating the store.
+    public var schema: SwiftData.Schema?
+
+    /// The PowerSync database backing the store. PowerSync owns the SQLite connection and
+    /// the upload queue; the store never opens a second connection.
+    public let database: any PowerSyncDatabaseProtocol
+
+    /// Maps a SwiftData entity name to the PowerSync table (view) name.
+    /// Defaults to ``defaultTableName(forEntityName:)``.
+    public let tableNameForEntity: @Sendable (String) -> String
+
+    /// Maps `(entityName, propertyName)` to a PowerSync column name, or `nil` to keep the
+    /// default (the property name; to-one relationships append `_id` to the result).
+    /// Lets camelCase Swift properties map to snake_case backend columns.
+    public let columnNameForProperty: @Sendable (String, String) -> String?
+
+    /// The `ModelContext.author` used by ``PowerSyncChangeObserver`` when re-injecting
+    /// changes that arrived from PowerSync. Saves authored this way are echo-suppressed:
+    /// the store does not write them back to the database.
+    public let remoteAuthor: String
+
+    /// When `true`, the store refuses every write with `DataStoreError.unsupportedFeature`.
+    /// Optional hardening for display-only widgets and extensions; writes from extension
+    /// processes are otherwise fully supported (persisted, queued for upload, and signaled
+    /// to the app's live queries).
+    public let readOnly: Bool
+
+    /// Test-only hook: remaps snapshot value keys when building snapshots from fetched rows.
+    /// Used to prove that SwiftData materializes models by property *name*.
+    var _testFetchKeyTransform: (@Sendable (String) -> String)?
+
+    public init(
+        name: String,
+        database: any PowerSyncDatabaseProtocol,
+        schema: SwiftData.Schema? = nil,
+        tableNameForEntity: @escaping @Sendable (String) -> String = PowerSyncDataStoreConfiguration.defaultTableName(forEntityName:),
+        columnNameForProperty: @escaping @Sendable (String, String) -> String? = { _, _ in nil },
+        remoteAuthor: String = "powersync-remote",
+        readOnly: Bool = false
+    ) {
+        self.name = name
+        self.database = database
+        self.schema = schema
+        self.tableNameForEntity = tableNameForEntity
+        self.columnNameForProperty = columnNameForProperty
+        self.remoteAuthor = remoteAuthor
+        self.readOnly = readOnly
+    }
+
+    /// Converts an entity name to `snake_case`, the conventional PowerSync table naming.
+    /// `Note` becomes `note`; `TodoItem` becomes `todo_item`.
+    public static func defaultTableName(forEntityName entityName: String) -> String {
+        var result = ""
+        var previousWasLowercase = false
+        for character in entityName {
+            if character.isUppercase {
+                if previousWasLowercase {
+                    result.append("_")
+                }
+                result.append(contentsOf: character.lowercased())
+                previousWasLowercase = false
+            } else {
+                result.append(character)
+                previousWasLowercase = character.isLowercase
+            }
+        }
+        return result
+    }
+
+    public static func == (lhs: PowerSyncDataStoreConfiguration, rhs: PowerSyncDataStoreConfiguration) -> Bool {
+        lhs.name == rhs.name
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(name)
+    }
+}

--- a/Sources/PowerSyncSwiftData/PowerSyncSchemaBuilder.swift
+++ b/Sources/PowerSyncSwiftData/PowerSyncSchemaBuilder.swift
@@ -1,0 +1,56 @@
+import PowerSync
+import SwiftData
+
+/// Derives the PowerSync schema from SwiftData models, so the application declares its
+/// `@Model`s once instead of duplicating tables and columns:
+///
+/// ```swift
+/// let database = PowerSyncDatabase(
+///     schema: try PowerSyncSchema(for: [Note.self, Playlist.self, Song.self])
+/// )
+/// ```
+///
+/// Attribute columns use the store's coercion mapping (`Date` -> `real`, `Data`/`UUID` and
+/// codable values -> `text`, ...). To-one relationships become `{name}_id` text columns
+/// with an index (used by the inverse to-many resolution). The implicit PowerSync `id`
+/// column is never declared.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+public func PowerSyncSchema(
+    for models: [any PersistentModel.Type],
+    tableNameForEntity: @escaping @Sendable (String) -> String = PowerSyncDataStoreConfiguration.defaultTableName(forEntityName:),
+    columnNameForProperty: @escaping @Sendable (String, String) -> String? = { _, _ in nil }
+) throws -> PowerSync.Schema {
+    return try PowerSyncSchema(
+        for: SwiftData.Schema(models),
+        tableNameForEntity: tableNameForEntity,
+        columnNameForProperty: columnNameForProperty
+    )
+}
+
+/// Derives the PowerSync schema from an existing SwiftData schema.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+public func PowerSyncSchema(
+    for schema: SwiftData.Schema,
+    tableNameForEntity: @escaping @Sendable (String) -> String = PowerSyncDataStoreConfiguration.defaultTableName(forEntityName:),
+    columnNameForProperty: @escaping @Sendable (String, String) -> String? = { _, _ in nil }
+) throws -> PowerSync.Schema {
+    let mapper = try SchemaMapper(
+        schema: schema,
+        tableNameForEntity: tableNameForEntity,
+        columnNameForProperty: columnNameForProperty
+    )
+    let tables = mapper.entitiesByName.values
+        .sorted { $0.tableName < $1.tableName }
+        .map { entity -> Table in
+            var columns = entity.properties.filter(\.isStored).map { property in
+                Column(name: property.columnName, type: ValueCoercion.columnType(for: property.kind))
+            }
+            var indexes: [Index] = []
+            for relationship in entity.toOne {
+                columns.append(.text(relationship.columnName))
+                indexes.append(.ascending(name: relationship.columnName, column: relationship.columnName))
+            }
+            return Table(name: entity.tableName, columns: columns, indexes: indexes)
+        }
+    return PowerSync.Schema(tables: tables)
+}

--- a/Sources/PowerSyncSwiftData/PowerSyncSnapshot.swift
+++ b/Sources/PowerSyncSwiftData/PowerSyncSnapshot.swift
@@ -1,0 +1,345 @@
+import Foundation
+import SwiftData
+
+/// A generic `DataStoreSnapshot` backed by a dictionary of values keyed by *property name*.
+///
+/// SwiftData materializes models from snapshots by property name (validated by the phase 1
+/// misaligned-name test), so the keys in ``values`` must mirror the `@Model` property names
+/// exactly. Values are stored in their natural Swift types (`String`, `Bool`, `Int`, ...);
+/// coercion to and from PowerSync's SQLite column types happens at the store boundary.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+public struct PowerSyncSnapshot: DataStoreSnapshot {
+    public let persistentIdentifier: PersistentIdentifier
+
+    /// The SwiftData entity name this snapshot belongs to.
+    let entityName: String
+
+    /// The PowerSync `id` column value, when known. Snapshots created from freshly inserted
+    /// models carry a temporary identifier; ``PowerSyncDataStore/save(_:)`` mints the
+    /// primary key (reusing the model's `id` property when set).
+    let primaryKey: String?
+
+    /// Property values keyed by `@Model` property name.
+    let values: [String: any DataStoreSnapshotValue]
+
+    init(
+        persistentIdentifier: PersistentIdentifier,
+        entityName: String,
+        primaryKey: String?,
+        values: [String: any DataStoreSnapshotValue]
+    ) {
+        self.persistentIdentifier = persistentIdentifier
+        self.entityName = entityName
+        self.primaryKey = primaryKey
+        self.values = values
+    }
+
+    // MARK: model -> snapshot (invoked by SwiftData during save)
+
+    public init(
+        from backingData: any BackingData,
+        relatedBackingDatas: inout [PersistentIdentifier: any BackingData]
+    ) {
+        guard let persistentIdentifier = backingData.persistentModelID else {
+            preconditionFailure("BackingData has no persistent identifier")
+        }
+        self.persistentIdentifier = persistentIdentifier
+        let entityName = persistentIdentifier.entityName
+        self.entityName = entityName
+        let entity = SnapshotEntityRegistry.entity(named: entityName)
+        let values = Self.extractValues(from: backingData, entity: entity)
+        self.values = values
+        self.primaryKey = values[entity?.idPropertyName ?? "id"] as? String
+        if let entity, values[entity.idPropertyName] == nil {
+            // The id is a non-optional String every backing data carries; extracting
+            // nothing means key-path resolution is broken. This initializer cannot throw,
+            // so the failure is flagged for save() to surface.
+            ReflectionHealth.flagExtractionFailure(entityName: entityName)
+        }
+    }
+
+    /// Walks the model's stored properties and pulls each value out of the backing data.
+    ///
+    /// The `AnyKeyPath` from ``ModelPropertyReflection`` is dispatched against the two typed
+    /// forms (`KeyPath<Model, V>` and `KeyPath<Model, V?>`) per value kind; `BackingData`
+    /// only answers `getValue(forKey:)` for typed key paths.
+    private static func extractValues(
+        from backingData: any BackingData,
+        entity: EntityMapping?
+    ) -> [String: any DataStoreSnapshotValue] {
+        func open<B: BackingData>(_ backingData: B) -> [String: any DataStoreSnapshotValue] {
+            let idPropertyName = entity?.idPropertyName ?? "id"
+            var values: [String: any DataStoreSnapshotValue] = [:]
+            for property in ModelPropertyReflection.properties(for: B.Model.self) {
+                let kind: ValueCoercion.Kind?
+                if property.name == idPropertyName {
+                    kind = .string
+                } else {
+                    kind = entity?.propertiesByName[property.name]?.kind
+                }
+                guard let kind else {
+                    continue
+                }
+                func extract<V: Decodable & Encodable & Sendable>(_: V.Type) -> V? {
+                    switch property.keyPath {
+                    case let keyPath as KeyPath<B.Model, V>:
+                        return backingData.getValue(forKey: keyPath)
+                    case let keyPath as KeyPath<B.Model, V?>:
+                        return backingData.getValue(forKey: keyPath)
+                    default:
+                        return nil
+                    }
+                }
+                func extractAny(
+                    _ type: any (Decodable & Encodable & Sendable).Type
+                ) -> (any DataStoreSnapshotValue)? {
+                    func go<V: Decodable & Encodable & Sendable>(_: V.Type) -> (any DataStoreSnapshotValue)? {
+                        extract(V.self).map { $0 as any DataStoreSnapshotValue }
+                    }
+                    return go(type)
+                }
+                let value: (any DataStoreSnapshotValue)?
+                switch kind {
+                case .string: value = extract(String.self)
+                case .bool: value = extract(Bool.self)
+                case .int: value = extract(Int.self)
+                case .int64: value = extract(Int64.self)
+                case .int32: value = extract(Int32.self)
+                case .double: value = extract(Double.self)
+                case .float: value = extract(Float.self)
+                case .date: value = extract(Date.self)
+                case .uuid: value = extract(UUID.self)
+                case .data: value = extract(Data.self)
+                case let .rawRepresentable(type, _): value = extractAny(type)
+                case let .codable(type): value = extractAny(type)
+                }
+                if let value {
+                    values[property.name] = value
+                }
+            }
+            if let entity {
+                for relationship in entity.toOne {
+                    let keyPath = relationship.keyPath
+                        ?? ModelPropertyReflection.properties(for: B.Model.self)
+                        .first(where: { $0.name == relationship.name })?.keyPath
+                    guard let keyPath else { continue }
+                    func related<R: PersistentModel>(_: R.Type) -> PersistentIdentifier? {
+                        switch keyPath {
+                        case let keyPath as KeyPath<B.Model, R>:
+                            return backingData.getValue(forKey: keyPath).persistentModelID
+                        case let keyPath as KeyPath<B.Model, R?>:
+                            return backingData.getValue(forKey: keyPath)?.persistentModelID
+                        default:
+                            return nil
+                        }
+                    }
+                    if let identifier = related(relationship.destinationType) {
+                        values[relationship.name] = identifier
+                    }
+                }
+                for relationship in entity.toMany {
+                    let keyPath = relationship.keyPath
+                        ?? ModelPropertyReflection.properties(for: B.Model.self)
+                        .first(where: { $0.name == relationship.name })?.keyPath
+                    guard let keyPath else { continue }
+                    func related<R: PersistentModel>(_: R.Type) -> [PersistentIdentifier]? {
+                        switch keyPath {
+                        case let keyPath as KeyPath<B.Model, [R]>:
+                            return backingData.getValue(forKey: keyPath).map(\.persistentModelID)
+                        case let keyPath as KeyPath<B.Model, [R]?>:
+                            return backingData.getValue(forKey: keyPath)?.map(\.persistentModelID)
+                        default:
+                            return nil
+                        }
+                    }
+                    if let identifiers = related(relationship.elementType) {
+                        values[relationship.name] = identifiers
+                    }
+                }
+            }
+            return values
+        }
+        return open(backingData)
+    }
+
+    // MARK: row -> snapshot (built by the store during fetch)
+
+    init(
+        row: [String: any DataStoreSnapshotValue],
+        entity: EntityMapping,
+        storeIdentifier: String,
+        keyTransform: (@Sendable (String) -> String)?
+    ) throws {
+        guard let primaryKey = row[entity.idPropertyName] as? String else {
+            throw PowerSyncSwiftDataError.missingPrimaryKey(entity: entity.entityName)
+        }
+        self.persistentIdentifier = try PrimaryKeyResolver.mint(
+            store: storeIdentifier,
+            entityName: entity.entityName,
+            primaryKey: primaryKey
+        )
+        self.entityName = entity.entityName
+        self.primaryKey = primaryKey
+        var values = row
+        // To-one columns arrive as raw id strings; turn them into identifiers of the
+        // destination entity.
+        for relationship in entity.toOne {
+            if let foreignKey = values[relationship.name] as? String {
+                values[relationship.name] = try PrimaryKeyResolver.mint(
+                    store: storeIdentifier,
+                    entityName: relationship.destinationEntityName,
+                    primaryKey: foreignKey
+                )
+            }
+        }
+        if let keyTransform {
+            self.values = Dictionary(uniqueKeysWithValues: values.map { (keyTransform($0.key), $0.value) })
+        } else {
+            self.values = values
+        }
+    }
+
+    // MARK: copies
+
+    public func copy(
+        persistentIdentifier: PersistentIdentifier,
+        remappedIdentifiers: [PersistentIdentifier: PersistentIdentifier]?
+    ) -> PowerSyncSnapshot {
+        // Attribute values are identifier-independent; relationship values (identifiers and
+        // identifier arrays) are rewritten so references to models inserted in the same
+        // save end up pointing at their permanent identifiers.
+        var values = values
+        if let remappedIdentifiers, !remappedIdentifiers.isEmpty {
+            for (name, value) in values {
+                if let identifier = value as? PersistentIdentifier {
+                    if let remapped = remappedIdentifiers[identifier] {
+                        values[name] = remapped
+                    }
+                } else if let identifiers = value as? [PersistentIdentifier] {
+                    values[name] = identifiers.map { remappedIdentifiers[$0] ?? $0 }
+                }
+            }
+        }
+        return PowerSyncSnapshot(
+            persistentIdentifier: persistentIdentifier,
+            entityName: entityName,
+            primaryKey: primaryKey,
+            values: values
+        )
+    }
+
+    /// Returns a copy carrying the minted primary key, both as ``primaryKey`` and as the
+    /// model's id property value so the materialized model sees it.
+    func settingPrimaryKey(_ primaryKey: String, idPropertyName: String) -> PowerSyncSnapshot {
+        var values = values
+        values[idPropertyName] = primaryKey
+        return PowerSyncSnapshot(
+            persistentIdentifier: persistentIdentifier,
+            entityName: entityName,
+            primaryKey: primaryKey,
+            values: values
+        )
+    }
+
+    // MARK: Codable
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: DataStoreSnapshotCodingKey.self)
+        let persistentIdentifier = try container.decode(PersistentIdentifier.self, forKey: .persistentIdentifier)
+        self.persistentIdentifier = persistentIdentifier
+        let entityName = persistentIdentifier.entityName
+        self.entityName = entityName
+        let entity = SnapshotEntityRegistry.entity(named: entityName)
+        let idPropertyName = entity?.idPropertyName ?? "id"
+        var values: [String: any DataStoreSnapshotValue] = [:]
+        for key in container.allKeys {
+            guard case let .modeledProperty(name) = key else {
+                continue
+            }
+            if let entity {
+                if entity.toOneByName[name] != nil {
+                    if let identifier = try container.decodeIfPresent(PersistentIdentifier.self, forKey: key) {
+                        values[name] = identifier
+                    }
+                    continue
+                }
+                if entity.toManyByName[name] != nil {
+                    if let identifiers = try container.decodeIfPresent([PersistentIdentifier].self, forKey: key) {
+                        values[name] = identifiers
+                    }
+                    continue
+                }
+            }
+            let kind: ValueCoercion.Kind?
+            if name == idPropertyName {
+                kind = .string
+            } else {
+                kind = entity?.propertiesByName[name]?.kind
+            }
+            if let value = try Self.decodeValue(kind, from: container, forKey: key) {
+                values[name] = value
+            }
+        }
+        self.values = values
+        self.primaryKey = values[idPropertyName] as? String
+    }
+
+    private static func decodeValue(
+        _ kind: ValueCoercion.Kind?,
+        from container: KeyedDecodingContainer<DataStoreSnapshotCodingKey>,
+        forKey key: DataStoreSnapshotCodingKey
+    ) throws -> (any DataStoreSnapshotValue)? {
+        func decodeAny(
+            _ type: any (Decodable & Encodable & Sendable).Type
+        ) throws -> (any DataStoreSnapshotValue)? {
+            func go<V: Decodable & Encodable & Sendable>(_: V.Type) throws -> (any DataStoreSnapshotValue)? {
+                try container.decodeIfPresent(V.self, forKey: key).map { $0 as any DataStoreSnapshotValue }
+            }
+            return try go(type)
+        }
+
+        switch kind {
+        case .string: return try container.decodeIfPresent(String.self, forKey: key)
+        case .bool: return try container.decodeIfPresent(Bool.self, forKey: key)
+        case .int: return try container.decodeIfPresent(Int.self, forKey: key)
+        case .int64: return try container.decodeIfPresent(Int64.self, forKey: key)
+        case .int32: return try container.decodeIfPresent(Int32.self, forKey: key)
+        case .double: return try container.decodeIfPresent(Double.self, forKey: key)
+        case .float: return try container.decodeIfPresent(Float.self, forKey: key)
+        case .date: return try container.decodeIfPresent(Date.self, forKey: key)
+        case .uuid: return try container.decodeIfPresent(UUID.self, forKey: key)
+        case .data: return try container.decodeIfPresent(Data.self, forKey: key)
+        case let .rawRepresentable(type, _): return try decodeAny(type)
+        case let .codable(type): return try decodeAny(type)
+        case nil:
+            // Unknown property (no registered entity): try the supported scalars in order.
+            if let value = try? container.decodeIfPresent(String.self, forKey: key) { return value }
+            if let value = try? container.decodeIfPresent(Bool.self, forKey: key) { return value }
+            if let value = try? container.decodeIfPresent(Int64.self, forKey: key) { return value }
+            if let value = try? container.decodeIfPresent(Double.self, forKey: key) { return value }
+            return nil
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: DataStoreSnapshotCodingKey.self)
+        try container.encode(persistentIdentifier, forKey: .persistentIdentifier)
+        for (name, value) in values {
+            try container.encode(value, forKey: .modeledProperty(name))
+        }
+        // SwiftData's model decoder looks every property up by name, so emit explicit nulls
+        // for known properties with no value (optional attributes and to-one relationships
+        // that are nil).
+        if let entity = SnapshotEntityRegistry.entity(named: entityName) {
+            for property in entity.properties where values[property.name] == nil {
+                try container.encodeNil(forKey: .modeledProperty(property.name))
+            }
+            for relationship in entity.toOne where values[relationship.name] == nil {
+                try container.encodeNil(forKey: .modeledProperty(relationship.name))
+            }
+            for relationship in entity.toMany where values[relationship.name] == nil {
+                try container.encodeNil(forKey: .modeledProperty(relationship.name))
+            }
+        }
+    }
+}

--- a/Sources/PowerSyncSwiftData/PowerSyncSwiftDataError.swift
+++ b/Sources/PowerSyncSwiftData/PowerSyncSwiftDataError.swift
@@ -1,0 +1,83 @@
+/// Errors thrown by the PowerSync SwiftData integration.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+public enum PowerSyncSwiftDataError: Error, CustomStringConvertible {
+    /// The requested functionality has not been implemented yet.
+    case unimplemented(String)
+    /// No entity with the given name exists in the SwiftData schema handed to the store.
+    case entityNotFound(String)
+    /// The store configuration is missing a SwiftData schema.
+    ///
+    /// `ModelContainer` injects the schema into the configuration before creating the store.
+    /// This error indicates the configuration was used outside of a `ModelContainer`.
+    case missingSchema
+    /// A model property uses a value type that cannot be stored in a PowerSync column.
+    case unsupportedValueType(entity: String, property: String, type: String)
+    /// A snapshot did not contain the value required to derive the PowerSync `id` column.
+    case missingPrimaryKey(entity: String)
+    /// Synchronized models must expose a `String` property mapped to PowerSync's `id` column.
+    case modelRequiresStringId(entity: String)
+    /// A stored row has no value for a required property and the property declares no
+    /// default. Typically the row predates the property; give the property a default value.
+    case missingRequiredValue(entity: String, property: String)
+    /// SwiftData `SchemaMigrationPlan`s are not supported: schema evolution is driven by
+    /// the backend and PowerSync's views (see the module README's schema evolution notes).
+    case migrationPlansUnsupported
+    /// The id property of a saved model was mutated. Rows are addressed by their persistent
+    /// identifier; to change a row's id, delete the model and insert a new one.
+    case idMutationUnsupported(entity: String)
+    /// A stored integer does not fit the model property's integer type.
+    case valueOutOfRange(entity: String, property: String)
+    /// The PowerSync database has no table (view) for a mapped entity.
+    case tableMissing(entity: String, table: String)
+    /// The entity's table exists but lacks mapped columns.
+    case columnsMissing(entity: String, table: String, columns: [String])
+    /// Two entities map to the same PowerSync table.
+    case tableCollision(table: String, entities: [String])
+    /// Two stores in this process registered the same entity with different mappings.
+    case configurationConflict(entity: String)
+    /// Model inheritance hierarchies are not supported.
+    case inheritanceUnsupported(entity: String)
+    /// A private SwiftData surface the integration relies on changed shape in this SDK.
+    case sdkDriftDetected(detail: String)
+
+    public var description: String {
+        switch self {
+        case let .unimplemented(what):
+            return "Not implemented: \(what)"
+        case let .entityNotFound(name):
+            return "Entity \(name) was not found in the SwiftData schema"
+        case .missingSchema:
+            return "The configuration has no SwiftData schema. Use it through a ModelContainer."
+        case let .unsupportedValueType(entity, property, type):
+            return "Unsupported value type \(type) for \(entity).\(property)"
+        case let .missingPrimaryKey(entity):
+            return "Snapshot for \(entity) is missing a primary key value"
+        case let .modelRequiresStringId(entity):
+            return "\(entity) must declare a String `id` property mapped to PowerSync's id column"
+        case let .missingRequiredValue(entity, property):
+            return "A stored \(entity) row has no value for required property \(property); "
+                + "declare a default value for properties added after rows existed"
+        case .migrationPlansUnsupported:
+            return "SchemaMigrationPlans are not supported; schema evolution is backend-driven "
+                + "(see the PowerSyncSwiftData README)"
+        case let .idMutationUnsupported(entity):
+            return "The id of a saved \(entity) cannot change; delete the model and insert a new one"
+        case let .valueOutOfRange(entity, property):
+            return "A stored value for \(entity).\(property) does not fit the property's integer type"
+        case let .tableMissing(entity, table):
+            return "The PowerSync database has no table \(table) for entity \(entity); "
+                + "declare it in the PowerSync schema (PowerSyncSchema(for:) derives it)"
+        case let .columnsMissing(entity, table, columns):
+            return "Table \(table) for entity \(entity) lacks columns: \(columns.joined(separator: ", "))"
+        case let .tableCollision(table, entities):
+            return "Entities \(entities.joined(separator: ", ")) map to the same table \(table)"
+        case let .configurationConflict(entity):
+            return "Entity \(entity) is already registered by another store with a different mapping; "
+                + "entity names must map consistently within a process"
+        case let .inheritanceUnsupported(entity):
+            return "\(entity) uses model inheritance, which is not supported; flatten the hierarchy"
+        case let .sdkDriftDetected(detail):
+            return "SwiftData SDK drift detected: \(detail)"
+        }
+    }
+}

--- a/Sources/PowerSyncSwiftData/PredicateTranslator.swift
+++ b/Sources/PowerSyncSwiftData/PredicateTranslator.swift
@@ -1,0 +1,615 @@
+import Foundation
+import SwiftData
+
+/// Translates `FetchDescriptor` predicates and sort descriptors to PowerSync SQL.
+///
+/// Translation is structural: only expression nodes the translator understands (the
+/// retroactive ``SQLTranslatableExpression`` conformances below) produce SQL; any other
+/// node makes the whole predicate untranslatable and SwiftData is asked to filter or sort
+/// in memory via `DataStoreError.preferInMemoryFilter`/`.preferInMemorySort`.
+///
+/// Known semantic approximations (documented in the module README):
+/// - String sorts use `COLLATE NOCASE` (ASCII case-insensitive), an approximation of
+///   `SortDescriptor`'s default localized-standard comparator.
+/// - `starts(with:)`/`contains` translate to `LIKE`, which is ASCII case-insensitive in
+///   SQLite, whereas the Swift operators are case-sensitive. Locale-aware operators such as
+///   `localizedStandardContains` are NOT translated and fall back to in-memory filtering.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+struct PredicateTranslator: @unchecked Sendable {
+    let entity: EntityMapping
+    let modelType: any PersistentModel.Type
+    /// Computed once: key-path resolution is on the hot path of every fetch.
+    private let columns: [AnyKeyPath: SQLColumnReference]
+
+    init(entity: EntityMapping, modelType: any PersistentModel.Type) {
+        self.entity = entity
+        self.modelType = modelType
+        self.columns = Self.columnsByKeyPath(entity: entity, modelType: modelType)
+    }
+
+    /// Returns the SQL boolean clause (without the `WHERE` keyword) and its bindings.
+    /// - Throws: `DataStoreError.preferInMemoryFilter` for unsupported expression nodes.
+    func translateWhere<T>(_ predicate: Predicate<T>) throws -> (clause: String, bindings: [Sendable?]) {
+        let context = SQLTranslationContext(entity: entity, columnsByKeyPath: columns)
+        guard let expression = predicate.expression as? any SQLTranslatableExpression else {
+            throw DataStoreError.preferInMemoryFilter
+        }
+        let fragment = try expression.sqlFragment(in: context)
+        let (clause, bindings, _) = try fragment.booleanClause()
+        return (clause, bindings)
+    }
+
+    /// Returns the `ORDER BY` body (without the keywords), or `nil` when there is nothing
+    /// to sort by.
+    /// - Throws: `DataStoreError.preferInMemorySort` for unsupported sort descriptors.
+    func translateOrderBy<T>(_ sortBy: [SortDescriptor<T>]) throws -> String? {
+        guard !sortBy.isEmpty else {
+            return nil
+        }
+        var terms: [String] = []
+        for descriptor in sortBy {
+            guard let keyPath = descriptor.keyPath, let column = columns[keyPath] else {
+                throw DataStoreError.preferInMemorySort
+            }
+            var term = sqlQuote(column.column)
+            if case .string = column.kind {
+                term += " COLLATE NOCASE"
+            }
+            term += descriptor.order == .forward ? " ASC" : " DESC"
+            terms.append(term)
+        }
+        return terms.joined(separator: ", ")
+    }
+
+    static func columnsByKeyPath(
+        entity: EntityMapping,
+        modelType: any PersistentModel.Type
+    ) -> [AnyKeyPath: SQLColumnReference] {
+        var columns: [AnyKeyPath: SQLColumnReference] = [:]
+        for property in ModelPropertyReflection.properties(for: modelType) {
+            if property.name == entity.idPropertyName {
+                columns[property.keyPath] = SQLColumnReference(column: "id", kind: .string, isOptional: false)
+            } else if let mapping = entity.propertiesByName[property.name] {
+                columns[property.keyPath] = SQLColumnReference(
+                    column: mapping.columnName,
+                    kind: mapping.kind,
+                    isOptional: mapping.isOptional
+                )
+            } else if let relationship = entity.toOneByName[property.name] {
+                // Comparisons against the relationship bind the related row's id.
+                columns[property.keyPath] = SQLColumnReference(
+                    column: relationship.columnName,
+                    kind: .string,
+                    isOptional: relationship.isOptional,
+                    relationship: relationship
+                )
+            }
+        }
+        for relationship in entity.toOne {
+            if let keyPath = relationship.keyPath {
+                columns[keyPath] = SQLColumnReference(
+                    column: relationship.columnName,
+                    kind: .string,
+                    isOptional: relationship.isOptional,
+                    relationship: relationship
+                )
+            }
+        }
+        func addPersistentModelID<M: PersistentModel>(_: M.Type) {
+            columns[\M.persistentModelID] = SQLColumnReference(column: "id", kind: .string, isOptional: false)
+        }
+        addPersistentModelID(modelType)
+        return columns
+    }
+}
+
+// MARK: - Translation machinery
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+struct SQLColumnReference {
+    let column: String
+    let kind: ValueCoercion.Kind
+    let isOptional: Bool
+    /// Set when this column is a to-one foreign key, enabling chained traversals.
+    var relationship: RelationshipMapping? = nil
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+struct SQLTranslationContext {
+    let entity: EntityMapping
+    let columnsByKeyPath: [AnyKeyPath: SQLColumnReference]
+}
+
+/// What a sub-expression contributes to the SQL statement.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+enum SQLTranslationFragment {
+    /// The `$0` predicate input.
+    case variable
+    /// A reference to a column of the entity's table.
+    case column(SQLColumnReference)
+    /// A constant, with optionality flattened (`nil` = SQL NULL).
+    case constant(Any?)
+    /// An attribute reached through an optional to-one chain (`$0.playlist?.name`):
+    /// comparisons resolve through a subquery over the destination table.
+    case relatedColumn(foreignKey: SQLColumnReference, destinationTable: String, destination: SQLColumnReference)
+    /// A complete boolean SQL expression. `mayBeNull` tracks SQL three-valued logic:
+    /// clauses that can evaluate to NULL (comparisons over optional columns) must be
+    /// coalesced before negation so results match Swift's optional semantics.
+    case clause(String, bindings: [Sendable?], mayBeNull: Bool)
+
+    func booleanClause() throws -> (clause: String, bindings: [Sendable?], mayBeNull: Bool) {
+        switch self {
+        case let .clause(sql, bindings, mayBeNull):
+            return (sql, bindings, mayBeNull)
+        case let .column(reference):
+            // A bare boolean key path (`{ $0.done }`) is itself the predicate.
+            if case .bool = reference.kind {
+                return ("\(sqlQuote(reference.column)) = 1", [], reference.isOptional)
+            }
+            throw DataStoreError.preferInMemoryFilter
+        case .variable, .constant, .relatedColumn:
+            throw DataStoreError.preferInMemoryFilter
+        }
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+protocol SQLTranslatableExpression {
+    func sqlFragment(in context: SQLTranslationContext) throws -> SQLTranslationFragment
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+private enum SQLTranslation {
+    /// `Optional(Optional("x"))` becomes `"x"`; `Optional<T>.none` becomes `nil`.
+    static func flattenOptional(_ value: Any) -> Any? {
+        ValueCoercion.flattenOptional(value)
+    }
+
+    /// Converts a constant to a binding using the column's storage representation
+    /// (`Date` -> epoch, enums -> raw value, `Bool` -> 0/1, persistent identifiers and
+    /// models -> the related row's id, ...).
+    static func binding(for constant: Any, kind: ValueCoercion.Kind) throws -> Sendable? {
+        if let identifier = constant as? PersistentIdentifier {
+            guard let primaryKey = try? PrimaryKeyResolver.primaryKey(of: identifier) else {
+                throw DataStoreError.preferInMemoryFilter
+            }
+            return primaryKey
+        }
+        if let model = constant as? any PersistentModel {
+            return try binding(for: model.persistentModelID, kind: kind)
+        }
+        do {
+            return try ValueCoercion.parameter(from: constant, kind: kind, entity: "", property: "")
+        } catch {
+            throw DataStoreError.preferInMemoryFilter
+        }
+    }
+
+    /// Builds `lhs op rhs` where one side is a column and the other a constant (or both
+    /// are columns). `op` is used as written when the column is on the left; `flippedOp`
+    /// when the column is on the right.
+    static func comparison(
+        lhs: SQLTranslationFragment,
+        rhs: SQLTranslationFragment,
+        op: String,
+        flippedOp: String
+    ) throws -> SQLTranslationFragment {
+        switch (lhs, rhs) {
+        case let (.column(reference), .constant(value)):
+            guard let value else { throw DataStoreError.preferInMemoryFilter }
+            return .clause(
+                "\(sqlQuote(reference.column)) \(op) ?",
+                bindings: [try binding(for: value, kind: reference.kind)],
+                mayBeNull: reference.isOptional
+            )
+        case let (.constant(value), .column(reference)):
+            guard let value else { throw DataStoreError.preferInMemoryFilter }
+            return .clause(
+                "\(sqlQuote(reference.column)) \(flippedOp) ?",
+                bindings: [try binding(for: value, kind: reference.kind)],
+                mayBeNull: reference.isOptional
+            )
+        case let (.column(left), .column(right)):
+            return .clause(
+                "\(sqlQuote(left.column)) \(op) \(sqlQuote(right.column))",
+                bindings: [],
+                mayBeNull: left.isOptional || right.isOptional
+            )
+        default:
+            throw DataStoreError.preferInMemoryFilter
+        }
+    }
+
+    /// Equality with SQL NULL semantics: comparisons against `nil` become `IS [NOT] NULL`.
+    static func equality(
+        lhs: SQLTranslationFragment,
+        rhs: SQLTranslationFragment,
+        negated: Bool
+    ) throws -> SQLTranslationFragment {
+        let column: SQLColumnReference?
+        let constant: Any??
+        switch (lhs, rhs) {
+        case let (.column(reference), .constant(value)):
+            column = reference
+            constant = value
+        case let (.constant(value), .column(reference)):
+            column = reference
+            constant = value
+        default:
+            column = nil
+            constant = nil
+        }
+        switch (lhs, rhs) {
+        case let (.relatedColumn(foreignKey, table, destination), .constant(value)),
+             let (.constant(value), .relatedColumn(foreignKey, table, destination)):
+            // Swift optional-chain semantics: a nil relationship makes == false and
+            // != true, independent of the destination value.
+            guard let value else {
+                throw DataStoreError.preferInMemoryFilter
+            }
+            let fk = sqlQuote(foreignKey.column)
+            let subquery = "(SELECT \(sqlQuote("id")) FROM \(sqlQuote(table)) "
+                + "WHERE \(sqlQuote(destination.column)) = ?)"
+            let bound = try binding(for: value, kind: destination.kind)
+            if negated {
+                return .clause(
+                    "(\(fk) IS NULL OR \(fk) NOT IN \(subquery))",
+                    bindings: [bound],
+                    mayBeNull: false
+                )
+            }
+            return .clause("\(fk) IN \(subquery)", bindings: [bound], mayBeNull: false)
+        default:
+            break
+        }
+        if let column, let constant {
+            if constant == nil {
+                return .clause(
+                    "\(sqlQuote(column.column)) IS \(negated ? "NOT " : "")NULL",
+                    bindings: [],
+                    mayBeNull: false
+                )
+            }
+            if negated, column.isOptional, let constant {
+                // Swift: nil != "x" is true; SQL: NULL != 'x' is NULL (row excluded).
+                let quoted = sqlQuote(column.column)
+                return .clause(
+                    "(\(quoted) IS NULL OR \(quoted) != ?)",
+                    bindings: [try binding(for: constant, kind: column.kind)],
+                    mayBeNull: false
+                )
+            }
+            return try comparison(lhs: lhs, rhs: rhs, op: negated ? "!=" : "=", flippedOp: negated ? "!=" : "=")
+        }
+        return try comparison(lhs: lhs, rhs: rhs, op: negated ? "!=" : "=", flippedOp: negated ? "!=" : "=")
+    }
+
+    /// Constant elements of an `IN` list. Arrays and any other `Sequence` (such as `Set`,
+    /// common with persistent identifiers) are supported.
+    static func sequenceElements(of value: Any) -> [Any]? {
+        if let array = value as? [Any] {
+            return array
+        }
+        guard let sequence = value as? any Sequence else {
+            return nil
+        }
+        func open<S: Sequence>(_ sequence: S) -> [Any] {
+            sequence.map { $0 as Any }
+        }
+        return open(sequence)
+    }
+
+    static func escapeForLike(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "%", with: "\\%")
+            .replacingOccurrences(of: "_", with: "\\_")
+    }
+
+    static func like(
+        base: SQLTranslationFragment,
+        pattern: SQLTranslationFragment,
+        makePattern: (String) -> String
+    ) throws -> SQLTranslationFragment {
+        guard
+            case let .column(reference) = base,
+            case .string = reference.kind,
+            case let .constant(value) = pattern,
+            let text = value as? String
+        else {
+            throw DataStoreError.preferInMemoryFilter
+        }
+        return .clause(
+            "\(sqlQuote(reference.column)) LIKE ? ESCAPE '\\'",
+            bindings: [makePattern(escapeForLike(text))],
+            mayBeNull: reference.isOptional
+        )
+    }
+}
+
+/// Constant ranges usable in `RangeExpressionContains`.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+private protocol SQLRangeBounds {
+    var sqlLowerBound: Any { get }
+    var sqlUpperBound: Any { get }
+    var sqlIsClosed: Bool { get }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension ClosedRange: SQLRangeBounds {
+    var sqlLowerBound: Any { lowerBound }
+    var sqlUpperBound: Any { upperBound }
+    var sqlIsClosed: Bool { true }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension Range: SQLRangeBounds {
+    var sqlLowerBound: Any { lowerBound }
+    var sqlUpperBound: Any { upperBound }
+    var sqlIsClosed: Bool { false }
+}
+
+// MARK: - Supported expression nodes
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.Variable: SQLTranslatableExpression {
+    func sqlFragment(in _: SQLTranslationContext) throws -> SQLTranslationFragment {
+        .variable
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.KeyPath: SQLTranslatableExpression where Root: SQLTranslatableExpression {
+    func sqlFragment(in context: SQLTranslationContext) throws -> SQLTranslationFragment {
+        guard case .variable = try root.sqlFragment(in: context) else {
+            throw DataStoreError.preferInMemoryFilter
+        }
+        guard let reference = context.columnsByKeyPath[keyPath] else {
+            throw DataStoreError.preferInMemoryFilter
+        }
+        return .column(reference)
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.Value: SQLTranslatableExpression {
+    func sqlFragment(in _: SQLTranslationContext) throws -> SQLTranslationFragment {
+        .constant(SQLTranslation.flattenOptional(value))
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.NilLiteral: SQLTranslatableExpression {
+    func sqlFragment(in _: SQLTranslationContext) throws -> SQLTranslationFragment {
+        .constant(nil)
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.Equal: SQLTranslatableExpression
+    where LHS: SQLTranslatableExpression, RHS: SQLTranslatableExpression {
+    func sqlFragment(in context: SQLTranslationContext) throws -> SQLTranslationFragment {
+        try SQLTranslation.equality(
+            lhs: try lhs.sqlFragment(in: context),
+            rhs: try rhs.sqlFragment(in: context),
+            negated: false
+        )
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.NotEqual: SQLTranslatableExpression
+    where LHS: SQLTranslatableExpression, RHS: SQLTranslatableExpression {
+    func sqlFragment(in context: SQLTranslationContext) throws -> SQLTranslationFragment {
+        try SQLTranslation.equality(
+            lhs: try lhs.sqlFragment(in: context),
+            rhs: try rhs.sqlFragment(in: context),
+            negated: true
+        )
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.Comparison: SQLTranslatableExpression
+    where LHS: SQLTranslatableExpression, RHS: SQLTranslatableExpression {
+    func sqlFragment(in context: SQLTranslationContext) throws -> SQLTranslationFragment {
+        let operators: (op: String, flipped: String)
+        switch op {
+        case .lessThan: operators = ("<", ">")
+        case .lessThanOrEqual: operators = ("<=", ">=")
+        case .greaterThan: operators = (">", "<")
+        case .greaterThanOrEqual: operators = (">=", "<=")
+        @unknown default: throw DataStoreError.preferInMemoryFilter
+        }
+        return try SQLTranslation.comparison(
+            lhs: try lhs.sqlFragment(in: context),
+            rhs: try rhs.sqlFragment(in: context),
+            op: operators.op,
+            flippedOp: operators.flipped
+        )
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.Conjunction: SQLTranslatableExpression
+    where LHS: SQLTranslatableExpression, RHS: SQLTranslatableExpression {
+    func sqlFragment(in context: SQLTranslationContext) throws -> SQLTranslationFragment {
+        let left = try lhs.sqlFragment(in: context).booleanClause()
+        let right = try rhs.sqlFragment(in: context).booleanClause()
+        return .clause(
+            "(\(left.clause) AND \(right.clause))",
+            bindings: left.bindings + right.bindings,
+            mayBeNull: left.mayBeNull || right.mayBeNull
+        )
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.Disjunction: SQLTranslatableExpression
+    where LHS: SQLTranslatableExpression, RHS: SQLTranslatableExpression {
+    func sqlFragment(in context: SQLTranslationContext) throws -> SQLTranslationFragment {
+        let left = try lhs.sqlFragment(in: context).booleanClause()
+        let right = try rhs.sqlFragment(in: context).booleanClause()
+        return .clause(
+            "(\(left.clause) OR \(right.clause))",
+            bindings: left.bindings + right.bindings,
+            mayBeNull: left.mayBeNull || right.mayBeNull
+        )
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.OptionalFlatMap: SQLTranslatableExpression
+    where LHS: SQLTranslatableExpression, RHS: SQLTranslatableExpression {
+    /// `$0.playlist?.id` resolves to the foreign-key column itself; `$0.playlist?.attr`
+    /// resolves to a related column compared through a subquery. The transform's key paths
+    /// are rooted at the flat-map's own variable, so evaluating it with the destination
+    /// entity's key-path table merged in is all the machinery needed.
+    func sqlFragment(in context: SQLTranslationContext) throws -> SQLTranslationFragment {
+        let base = try wrapped.sqlFragment(in: context)
+        guard case let .column(foreignKey) = base, let relationship = foreignKey.relationship else {
+            throw DataStoreError.preferInMemoryFilter
+        }
+        guard let destinationEntity = SnapshotEntityRegistry.entity(named: relationship.destinationEntityName) else {
+            throw DataStoreError.preferInMemoryFilter
+        }
+        var merged = context.columnsByKeyPath
+        for (keyPath, reference) in PredicateTranslator.columnsByKeyPath(
+            entity: destinationEntity,
+            modelType: relationship.destinationType
+        ) {
+            merged[keyPath] = reference
+        }
+        let innerContext = SQLTranslationContext(entity: destinationEntity, columnsByKeyPath: merged)
+        let inner = try transform.sqlFragment(in: innerContext)
+        guard case let .column(destination) = inner else {
+            throw DataStoreError.preferInMemoryFilter
+        }
+        if destination.column == "id" {
+            // The destination id IS the foreign-key value: compare the FK directly.
+            return .column(foreignKey)
+        }
+        return .relatedColumn(
+            foreignKey: foreignKey,
+            destinationTable: destinationEntity.tableName,
+            destination: destination
+        )
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.Negation: SQLTranslatableExpression where Wrapped: SQLTranslatableExpression {
+    func sqlFragment(in context: SQLTranslationContext) throws -> SQLTranslationFragment {
+        let inner = try wrapped.sqlFragment(in: context).booleanClause()
+        if inner.mayBeNull {
+            // Swift: !(nil == "x") is true; SQL: NOT (NULL) is NULL (row excluded).
+            return .clause("NOT (COALESCE((\(inner.clause)), 0))", bindings: inner.bindings, mayBeNull: false)
+        }
+        return .clause("NOT (\(inner.clause))", bindings: inner.bindings, mayBeNull: false)
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.SequenceContains: SQLTranslatableExpression
+    where LHS: SQLTranslatableExpression, RHS: SQLTranslatableExpression {
+    func sqlFragment(in context: SQLTranslationContext) throws -> SQLTranslationFragment {
+        guard
+            case let .constant(value) = try sequence.sqlFragment(in: context),
+            let value,
+            let elements = SQLTranslation.sequenceElements(of: value),
+            case let .column(reference) = try element.sqlFragment(in: context)
+        else {
+            throw DataStoreError.preferInMemoryFilter
+        }
+        guard !elements.isEmpty else {
+            return .clause("1 = 0", bindings: [], mayBeNull: false)
+        }
+        let bindings = try elements.map { element -> Sendable? in
+            guard let flattened = SQLTranslation.flattenOptional(element) else {
+                throw DataStoreError.preferInMemoryFilter
+            }
+            return try SQLTranslation.binding(for: flattened, kind: reference.kind)
+        }
+        let placeholders = Array(repeating: "?", count: elements.count).joined(separator: ", ")
+        return .clause(
+            "\(sqlQuote(reference.column)) IN (\(placeholders))",
+            bindings: bindings,
+            mayBeNull: reference.isOptional
+        )
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.ClosedRange: SQLTranslatableExpression where LHS: SQLTranslatableExpression, RHS: SQLTranslatableExpression {
+    func sqlFragment(in context: SQLTranslationContext) throws -> SQLTranslationFragment {
+        guard
+            case let .constant(lowerValue) = try lower.sqlFragment(in: context),
+            case let .constant(upperValue) = try upper.sqlFragment(in: context),
+            let lowerValue,
+            let upperValue
+        else {
+            throw DataStoreError.preferInMemoryFilter
+        }
+        return .constant(SQLConstantRange(lower: lowerValue, upper: upperValue, isClosed: true))
+    }
+}
+
+/// Carrier for ranges built from expression nodes rather than captured constants.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+private struct SQLConstantRange: SQLRangeBounds {
+    let lower: Any
+    let upper: Any
+    let isClosed: Bool
+    var sqlLowerBound: Any { lower }
+    var sqlUpperBound: Any { upper }
+    var sqlIsClosed: Bool { isClosed }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.RangeExpressionContains: SQLTranslatableExpression
+    where RangeExpression: SQLTranslatableExpression, Element: SQLTranslatableExpression {
+    func sqlFragment(in context: SQLTranslationContext) throws -> SQLTranslationFragment {
+        guard
+            case let .constant(rangeValue) = try range.sqlFragment(in: context),
+            let bounds = rangeValue as? any SQLRangeBounds,
+            case let .column(reference) = try element.sqlFragment(in: context)
+        else {
+            throw DataStoreError.preferInMemoryFilter
+        }
+        let lower = try SQLTranslation.binding(for: bounds.sqlLowerBound, kind: reference.kind)
+        let upper = try SQLTranslation.binding(for: bounds.sqlUpperBound, kind: reference.kind)
+        let column = sqlQuote(reference.column)
+        if bounds.sqlIsClosed {
+            return .clause("\(column) BETWEEN ? AND ?", bindings: [lower, upper], mayBeNull: reference.isOptional)
+        }
+        return .clause(
+            "(\(column) >= ? AND \(column) < ?)",
+            bindings: [lower, upper],
+            mayBeNull: reference.isOptional
+        )
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.SequenceStartsWith: SQLTranslatableExpression
+    where Base: SQLTranslatableExpression, Prefix: SQLTranslatableExpression {
+    func sqlFragment(in context: SQLTranslationContext) throws -> SQLTranslationFragment {
+        try SQLTranslation.like(
+            base: try base.sqlFragment(in: context),
+            pattern: try prefix.sqlFragment(in: context),
+            makePattern: { "\($0)%" }
+        )
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension PredicateExpressions.CollectionContainsCollection: SQLTranslatableExpression
+    where Base: SQLTranslatableExpression, Other: SQLTranslatableExpression {
+    func sqlFragment(in context: SQLTranslationContext) throws -> SQLTranslationFragment {
+        try SQLTranslation.like(
+            base: try base.sqlFragment(in: context),
+            pattern: try other.sqlFragment(in: context),
+            makePattern: { "%\($0)%" }
+        )
+    }
+}

--- a/Sources/PowerSyncSwiftData/PrimaryKeyResolver.swift
+++ b/Sources/PowerSyncSwiftData/PrimaryKeyResolver.swift
@@ -1,0 +1,50 @@
+import SwiftData
+import Synchronization
+
+/// Mints persistent identifiers and resolves them back to PowerSync primary keys.
+///
+/// Every identifier that enters the system is minted here (fetch, save remapping,
+/// relationships, cached snapshots), and its primary key is remembered. Resolution is
+/// served from that in-process cache first, so the identifier's private Codable envelope
+/// (``PersistentIdentifier/powerSyncPrimaryKey()``) is only a fallback for identifiers
+/// minted before an eviction — the integration no longer depends on it on hot paths.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+enum PrimaryKeyResolver {
+    private static let cache = Mutex<[PersistentIdentifier: String]>([:])
+
+    /// Mints an identifier and remembers its primary key.
+    static func mint(
+        store: String,
+        entityName: String,
+        primaryKey: String
+    ) throws -> PersistentIdentifier {
+        let identifier = try PersistentIdentifier.identifier(
+            for: store,
+            entityName: entityName,
+            primaryKey: primaryKey
+        )
+        cache.withLock { storage in
+            // Crude bound: reset rather than grow without limit. Evicted identifiers
+            // still resolve through the envelope fallback.
+            if storage.count >= 200_000 {
+                storage.removeAll(keepingCapacity: true)
+            }
+            storage[identifier] = primaryKey
+        }
+        return identifier
+    }
+
+    /// Resolves an identifier's primary key: mint cache first, Codable envelope fallback.
+    static func primaryKey(of identifier: PersistentIdentifier) throws -> String {
+        if let cached = cache.withLock({ $0[identifier] }) {
+            return cached
+        }
+        let resolved = try identifier.powerSyncPrimaryKey()
+        cache.withLock { $0[identifier] = resolved }
+        return resolved
+    }
+
+    static var _testCacheCount: Int {
+        cache.withLock { $0.count }
+    }
+}

--- a/Sources/PowerSyncSwiftData/README.md
+++ b/Sources/PowerSyncSwiftData/README.md
@@ -1,0 +1,301 @@
+# PowerSyncSwiftData
+
+A SwiftData custom `DataStore` backed by PowerSync. Apps keep using `@Model`, `@Query` and
+`ModelContext` as usual; underneath, PowerSync owns the SQLite database, captures local
+writes into its upload queue (`ps_crud`), and downloaded changes update the UI live. The
+store is multi-process: widgets and App Intents read **and write** the shared database,
+and changes made anywhere — sync downloads, the app, an extension — update `@Query`
+views live.
+
+**Status: alpha.** Requires iOS 18 / macOS 15 / watchOS 11 / tvOS 18 (the first OS releases
+with custom SwiftData stores).
+
+## Quick start
+
+```swift
+import PowerSync
+import PowerSyncSwiftData
+import SwiftData
+
+@Model
+final class Note {
+    var id: String        // required: maps to PowerSync's implicit id column
+    var title: String
+    var done: Bool
+    init(id: String, title: String, done: Bool) {
+        self.id = id
+        self.title = title
+        self.done = done
+    }
+}
+
+// 1. The PowerSync schema is derived from the models - declare them once.
+let database = PowerSyncDatabase(schema: try PowerSyncSchema(for: [Note.self]))
+try await database.connect(connector: myConnector)
+
+// 2. Build the ModelContainer on the PowerSync-backed store.
+let configuration = PowerSyncDataStoreConfiguration(name: "powersync", database: database)
+let container = try ModelContainer(
+    for: SwiftData.Schema([Note.self]),
+    configurations: [configuration]
+)
+
+// 3. Start the change observer so sync downloads update @Query live.
+let observer = PowerSyncChangeObserver(container: container, configuration: configuration)
+try await observer.start(observing: [Note.self])
+```
+
+Everything else is ordinary SwiftData: `context.insert(note)`, `try context.save()`,
+`@Query var notes: [Note]`, `#Predicate`, `FetchDescriptor`, relationships, ...
+
+## Requirements on models
+
+- Every synced `@Model` must declare a `String` property named `id`; it maps to PowerSync's
+  implicit `id` column. When you insert a model with an empty `id`, the store mints a UUID
+  and writes it back into the model on save. The id of a saved model is immutable:
+  mutating it fails the save (delete and insert instead).
+- Model inheritance hierarchies are rejected; flatten them into separate models.
+- Table names default to `snake_case` of the entity name (`TodoItem` → `todo_item`);
+  override per store with `tableNameForEntity`.
+- Column names default to the property name; override per property with the
+  configuration's `columnNameForProperty` (also accepted by `PowerSyncSchema(for:)`), so
+  camelCase Swift properties can map to snake_case backend columns. To-one relationships
+  append `_id` to the override's result.
+
+## Hardening for production: `@PowerSyncModel` (optional)
+
+The optional `PowerSyncSwiftDataMacros` product ships an attached macro that generates a
+`PredicateCodableKeyPathProviding` conformance for a model — its stored-property key
+paths flow through **public Foundation API** instead of the reflection fallback the store
+otherwise uses (see *How it works*). The expansion enumerates stored properties at
+compile time, so adding a property never needs manual bookkeeping:
+
+```swift
+// Package.swift: add the product (it adds nothing to apps that skip it)
+.product(name: "PowerSyncSwiftDataMacros", package: "powersync-swift")
+```
+
+```swift
+import PowerSyncSwiftDataMacros
+
+@Model
+@PowerSyncModel   // applied ALONGSIDE @Model (macros cannot inject other macros)
+final class Note {
+    var id: String
+    var title: String
+}
+```
+
+Recommended for production apps: SwiftData ships with the OS, so the reflection fallback
+could in principle break when *users* update iOS — not when you compile. Conforming
+models close that vector for key paths (property names are still enumerated from
+`schemaMetadata`, guarded by a runtime coverage check that fails descriptively). Skipped
+`@Transient` and computed properties, replicated availability, and a full round trip with
+reflection suppressed are pinned by tests.
+
+## Supported attribute types
+
+| Swift | PowerSync column |
+|---|---|
+| `String` | `text` |
+| `Bool` | `integer` (0/1) |
+| `Int`, `Int64`, `Int32` | `integer` |
+| `Double`, `Float` | `real` |
+| `Date` | `real` (seconds since 1970) |
+| `UUID` | `text` (lowercase uuidString, matching backend rendering) |
+| `Data` | `text` (base64; PowerSync has no blob column type) |
+| `RawRepresentable` enums (String/Int/Int64/Int32/Double raw) | raw value's column |
+| other `Codable` values | `text` (JSON, ISO 8601 dates, sorted keys) |
+| `Optional` of any of the above | nullable column |
+
+`@Attribute(.ephemeral)` attributes are honored: no column, never persisted or uploaded,
+reset to their declared default on fetch. Transformable attributes
+(`@Attribute(.transformable(by:))`) are rejected with an error; store a `Codable` value
+instead.
+
+## Relationships
+
+- **To-one** is stored as a `{name}_id` `text` column holding the related row's id (indexed
+  by the derived schema).
+- **To-many** needs an inverse to-one on the destination and is resolved by querying it.
+- **Many-to-many without a join model is rejected**: PowerSync syncs tables, so the join
+  table must exist anyway. Declare the join as its own `@Model` with two to-one
+  relationships.
+- Models that reference each other can be inserted in the same save (including cycles);
+  identifier remapping rewrites the references. PowerSync tables don't enforce foreign
+  keys, so insert order never matters.
+
+## Fetching, predicates and sorting
+
+`#Predicate` trees are translated to SQL `WHERE` clauses: comparisons, `==`/`!=` (with
+`IS NULL` semantics), boolean key paths, `&&`/`||`/`!`, `contains` over constant
+collections (`IN`), ranges (`BETWEEN`), `starts(with:)` and `contains` on strings
+(`LIKE` with escaping), and constants of every supported attribute type, persistent
+identifiers and models (bound as the related row's id). Sort descriptors translate to
+`ORDER BY`; `fetchLimit`/`fetchOffset` to `LIMIT`/`OFFSET`; `fetchCount` runs
+`SELECT COUNT(*)` and `fetchIdentifiers` selects only ids.
+
+SQL three-valued logic does not leak into results: `!=` and `!(...)` over optional
+columns include NULL rows exactly like Swift's optional semantics (the translator emits
+NULL-safe forms).
+
+Optional-chained to-one traversals translate too: `$0.playlist?.id == x` compares the
+foreign-key column directly, and `$0.playlist?.name == x` resolves through an
+`IN (SELECT id ...)` subquery — both preserving Swift's optional-chain semantics (a nil
+relationship makes `==` false and `!=` true, NULL-safe in SQL).
+
+Anything the translator does not understand (locale-aware operators such as
+`localizedStandardContains`, arithmetic, explicit subqueries, ...) throws
+`DataStoreError.preferInMemoryFilter`/`.preferInMemorySort`. **SwiftData applies the
+in-memory fallback to `fetch()` only**: results stay correct (performance degrades with
+table size), but `fetchCount`, `fetchIdentifiers` and `delete(model:where:)` propagate the
+error — use `fetch(...).count` / `fetch` + per-model delete as the workaround for
+untranslatable predicates on those paths.
+
+Known semantic approximations:
+
+- String sorts use SQLite `COLLATE NOCASE` (ASCII case-insensitive), an approximation of
+  `SortDescriptor`'s localized-standard comparator (diacritics order differs).
+- `starts(with:)`/`contains` translate to `LIKE`, which is ASCII case-insensitive in
+  SQLite, while the Swift operators are case-sensitive.
+
+## Live updates (reactivity)
+
+`PowerSyncChangeObserver` watches the PowerSync tables of the observed entities. When rows
+change without going through this process's SwiftData — a sync download, or a write from
+**another process** (a widget button, an App Intent) — it reconciles them into a private
+background `ModelContext` and saves, which broadcasts `ModelContext.didSave` — the signal
+`@Query` and other contexts react to. Those saves carry the configuration's `remoteAuthor`
+and are echo-suppressed by the store: nothing is written back to PowerSync, so no loops can
+form. Cross-process wake-ups ride on a Darwin notification the PowerSync pool posts after
+every committed write (the same mechanism Core Data uses for remote changes).
+
+Current limitations of the observer:
+
+- Relationship changes arriving from sync (a changed `{name}_id` column) update the row but
+  are not yet diffed onto registered models; attribute changes are.
+- It keeps the models of observed entities registered in its context, so memory is
+  proportional to the observed tables' row counts.
+
+## Schema evolution (migrations)
+
+PowerSync tables are views over JSON and the local database is a **cache of synced data**,
+so schema evolution works differently from Core Data-style migrations — most changes are
+absorbed structurally and the backend drives the rest:
+
+- **Adding a model or property**: pass the new models to `PowerSyncSchema(for:)` and the
+  views regenerate when the database opens; no data migration runs. Old rows read `NULL`
+  for added columns: optional properties materialize as `nil`, and required properties use
+  their **declared default** (`var rating: Int = 5`). A required property with no default
+  and no stored value fails the fetch with a descriptive error instead of trapping — give
+  added required properties a default.
+- **Removing a model or property**: stale JSON keys and tables are simply ignored locally;
+  clean up server-side via sync rules when convenient.
+- **Renaming, changing types, splitting models**: coordinate on the backend and re-sync;
+  the server is the source of truth. `@Attribute(originalName:)` is not honored locally
+  (data under the old key reads as missing until re-synced).
+- **`SchemaMigrationPlan`/`VersionedSchema`** are rejected with an error: there is no
+  local-store migration step for them to run against.
+
+## Widgets, App Intents and app extensions
+
+Sharing works like standard SwiftData: put the database in an App Group container and
+have **each process create its own database and container** over the same file, compiling
+the same `@Model` types into every target. The `PowerSyncDatabase` factory accepts an
+absolute path:
+
+```swift
+let url = FileManager.default
+    .containerURL(forSecurityApplicationGroupIdentifier: "group.example.app")!
+    .appendingPathComponent("powersync.db")
+let database = PowerSyncDatabase(schema: schema, dbFilename: url.path)
+```
+
+**Reads and writes both work from extension processes** — interactive widget buttons and
+App Intents included, mirroring what Apple's own SwiftData samples do. Writes persist
+immediately, are captured into the shared upload queue, and a cross-process change signal
+wakes the app's `watch` queries: the change observer reconciles and `@Query` views update
+live. Concurrent opens are safe (the pool retries while another process holds the file)
+and concurrent writers serialize through SQLite's WAL.
+
+Rules and notes:
+
+- **Only the app calls `connect()`** — sync has a single owner. Extension writes upload
+  the next time the app's sync client runs (immediately, if the app is running: the
+  signal nudges it).
+- **App Intents in the app target** run in the app's process: full read-write against the
+  app's own container, nothing special needed. **Widget-button intents** run in the
+  widget extension's process: create the container there and write normally.
+- Keep extension saves small (each save is one short transaction, typically
+  milliseconds), so process suspension cannot catch a long write in flight.
+- `readOnly: true` remains available as hardening for display-only widgets: fetching
+  works and every write throws `DataStoreError.unsupportedFeature`.
+
+See `Demos/SwiftDataDemo` for a complete widget setup including an interactive button
+that writes from the widget process.
+
+## How it works (and what it relies on)
+
+- Container creation validates every mapped table and column against the actual database
+  (`pragma_table_xinfo`), rejects table-name collisions and model inheritance, and fails if
+  another store in the process registered the same entity with a different mapping —
+  configuration mistakes fail fast and descriptively instead of as SQL errors mid-fetch.
+- SwiftData materializes models from snapshots **by property name** through the snapshot's
+  `Codable` representation (`DataStoreSnapshotCodingKey.modeledProperty`). A mismatched
+  name traps inside SwiftData; the test suite pins this behavior with an exit test
+  (macOS, where Swift Testing exit tests are available).
+- `fetch`/`save` are synchronous while PowerSync is async; the store bridges with a
+  semaphore plus a dedicated `TaskExecutor` on a private GCD queue, so neither the bridged
+  work nor its continuations ever need a cooperative-pool thread. This is stress-tested
+  with the pool saturated by blocked callers. The bridged work never hops back to the
+  caller, so calling from the main thread (`mainContext`) is safe and behaves like the
+  default store's synchronous I/O.
+- Two private SwiftData surfaces are used, with defense in depth so SDK drift can never
+  corrupt data:
+  1. Attribute key paths come from reflecting `PersistentModel.schemaMetadata`
+     (`Schema.Attribute` exposes no key path, unlike `Schema.Relationship`). Coverage is
+     validated **at runtime on first use**: drift fails the first fetch/save with a
+     descriptive error instead of materializing or persisting garbage. Models can source
+     their **key paths** through Foundation's public `PredicateCodableKeyPathProviding`
+     (keys = property names), which takes precedence over reflection — generated
+     automatically by the `@PowerSyncModel` macro (see the hardening section above).
+  2. The PowerSync id of a `PersistentIdentifier` is served by an in-process mint cache
+     (every identifier the store creates remembers its id); the identifier's private
+     `Codable` envelope is only a fallback, self-checked once per store at startup.
+  Both surfaces are additionally pinned by drift-guard tests, including simulated-drift
+  tests that exercise the runtime failure paths.
+- Multi-process support rests on two PowerSync-core mechanisms (public, not SwiftData
+  internals): the connection pool retries opening while another process holds the file
+  (the WAL transition reports `SQLITE_BUSY` without consulting the busy handler), and a
+  Darwin notification posted after every committed write re-emits `tableUpdates` with a
+  marker that `watch` queries and the upload client treat as "unknown tables changed".
+- `SqlCursor` rows are fully read inside the mapper closure; cursors never escape.
+
+## Operational notes
+
+- Do not reuse the configuration's `remoteAuthor` (default `"powersync-remote"`) as your
+  own `ModelContext.author`: saves authored that way are echo-suppressed and never reach
+  PowerSync.
+- `PowerSyncDatabase.updateSchema(...)` with a live `ModelContainer` is not supported: the
+  store's mapping is built at container creation. Rebuild the container after schema
+  changes.
+- On first launch, `@Query` is empty until the first sync completes; gate your UI with
+  `database.waitForFirstSync()` (or `currentStatus`) as in any PowerSync app.
+- After `disconnectAndClear()`, registered models in live contexts still hold deleted
+  rows. With the change observer running it notices the cleared tables and deletes the
+  registered models (the demo relies on this); otherwise tear down or refresh contexts.
+- Widgets are snapshot-based and do not live-refresh: reload their timelines after
+  relevant app writes (`WidgetCenter.shared.reloadTimelines(ofKind:)`); the system reloads
+  a widget automatically after its own interactive intents run.
+
+## Not supported (yet)
+
+- `ModelContainer.erase()` — resetting local PowerSync data is `disconnectAndClear()`'s
+  job; erasing through the store would upload a DELETE for every row.
+- Model inheritance (rejected with a descriptive error).
+- Transformable attributes.
+- Composite unique constraints / `@Attribute(.unique)` upsert semantics.
+- `@Attribute(.externalStorage)` (values are stored inline).
+- Schema migrations beyond additive changes managed by PowerSync views.
+- Connecting to the PowerSync service from more than one process (sync has a single owner:
+  the app); extension reads and writes are fully supported.

--- a/Sources/PowerSyncSwiftData/SchemaMapper.swift
+++ b/Sources/PowerSyncSwiftData/SchemaMapper.swift
@@ -1,0 +1,484 @@
+import PowerSync
+import SwiftData
+import Synchronization
+
+/// Quotes a SQL identifier (table or column name).
+func sqlQuote(_ name: String) -> String {
+    "\"" + name.replacingOccurrences(of: "\"", with: "\"\"") + "\""
+}
+
+/// How a single `@Model` stored property maps to a PowerSync column.
+/// `defaultValue` is an immutable value captured from the schema, safe to share.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+struct PropertyMapping: @unchecked Sendable {
+    let name: String
+    let columnName: String
+    let kind: ValueCoercion.Kind
+    let isOptional: Bool
+    /// `false` for ephemeral (transient) attributes: no column, never persisted or
+    /// uploaded; materialization uses the declared default.
+    let isStored: Bool
+    /// The property's declared default, used when stored rows predate the property and
+    /// for ephemeral attributes.
+    let defaultValue: Any?
+}
+
+/// How a to-one relationship maps to a foreign-key column.
+/// `AnyKeyPath` is immutable and safe to share across threads.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+struct RelationshipMapping: @unchecked Sendable {
+    let name: String
+    let columnName: String
+    let destinationEntityName: String
+    let isOptional: Bool
+    let keyPath: AnyKeyPath?
+    let destinationType: any PersistentModel.Type
+}
+
+/// How a to-many relationship resolves through the destination's inverse to-one column.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+struct ToManyMapping: @unchecked Sendable {
+    let name: String
+    let destinationEntityName: String
+    let destinationTableName: String
+    /// The foreign-key column on the destination table pointing back at this entity.
+    let inverseColumnName: String
+    let keyPath: AnyKeyPath?
+    let elementType: any PersistentModel.Type
+}
+
+/// A SQL statement ready to run inside a PowerSync write transaction.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+struct SQLStatement: Sendable {
+    let sql: String
+    let parameters: [Sendable?]
+}
+
+/// How a SwiftData entity maps to a PowerSync table, including SQL generation for the
+/// operations the store performs.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+struct EntityMapping: @unchecked Sendable {
+    let entityName: String
+    let tableName: String
+    /// The `@Model` property holding the PowerSync `id` column value.
+    let idPropertyName: String
+    /// All stored attribute mappings, excluding the id property.
+    let properties: [PropertyMapping]
+    /// To-one relationships, stored as foreign-key columns on this table.
+    let toOne: [RelationshipMapping]
+    /// To-many relationships, resolved through the destination's inverse column.
+    let toMany: [ToManyMapping]
+
+    /// O(1) lookups for the hot materialization and translation paths.
+    let propertiesByName: [String: PropertyMapping]
+    let toOneByName: [String: RelationshipMapping]
+    let toManyByName: [String: ToManyMapping]
+
+    init(
+        entityName: String,
+        tableName: String,
+        idPropertyName: String,
+        properties: [PropertyMapping],
+        toOne: [RelationshipMapping],
+        toMany: [ToManyMapping]
+    ) {
+        self.entityName = entityName
+        self.tableName = tableName
+        self.idPropertyName = idPropertyName
+        self.properties = properties
+        self.toOne = toOne
+        self.toMany = toMany
+        self.propertiesByName = Dictionary(uniqueKeysWithValues: properties.map { ($0.name, $0) })
+        self.toOneByName = Dictionary(uniqueKeysWithValues: toOne.map { ($0.name, $0) })
+        self.toManyByName = Dictionary(uniqueKeysWithValues: toMany.map { ($0.name, $0) })
+    }
+
+    private static func quoted(_ name: String) -> String {
+        sqlQuote(name)
+    }
+
+    func selectSQL(where whereClause: String?, orderBy: String?, limit: Int?, offset: Int?) -> String {
+        var columns = [Self.quoted("id")]
+        columns.append(contentsOf: properties.filter(\.isStored).map { Self.quoted($0.columnName) })
+        columns.append(contentsOf: toOne.map { Self.quoted($0.columnName) })
+        return assembleSQL(
+            select: columns.joined(separator: ", "),
+            where: whereClause,
+            orderBy: orderBy,
+            limit: limit,
+            offset: offset
+        )
+    }
+
+    func countSQL(where whereClause: String?) -> String {
+        assembleSQL(select: "COUNT(*)", where: whereClause, orderBy: nil, limit: nil, offset: nil)
+    }
+
+    func identifiersSQL(where whereClause: String?, orderBy: String?, limit: Int?, offset: Int?) -> String {
+        assembleSQL(
+            select: Self.quoted("id"),
+            where: whereClause,
+            orderBy: orderBy,
+            limit: limit,
+            offset: offset
+        )
+    }
+
+    private func assembleSQL(
+        select: String,
+        where whereClause: String?,
+        orderBy: String?,
+        limit: Int?,
+        offset: Int?
+    ) -> String {
+        var sql = "SELECT \(select) FROM \(Self.quoted(tableName))"
+        if let whereClause {
+            sql += " WHERE \(whereClause)"
+        }
+        if let orderBy {
+            sql += " ORDER BY \(orderBy)"
+        }
+        if let limit {
+            sql += " LIMIT \(limit)"
+            if let offset {
+                sql += " OFFSET \(offset)"
+            }
+        } else if let offset {
+            sql += " LIMIT -1 OFFSET \(offset)"
+        }
+        return sql
+    }
+
+    /// Reads one row into snapshot values keyed by property name. To-one foreign keys are
+    /// read as raw id strings; ``PowerSyncSnapshot/init(row:entity:storeIdentifier:keyTransform:)``
+    /// turns them into persistent identifiers. Reads everything inside the cursor mapper;
+    /// the cursor must never escape this function.
+    func row(from cursor: any SqlCursor) throws -> [String: any DataStoreSnapshotValue] {
+        var row: [String: any DataStoreSnapshotValue] = [:]
+        row[idPropertyName] = try cursor.getString(name: "id")
+        for property in properties {
+            let value = property.isStored
+                ? try ValueCoercion.value(
+                    from: cursor,
+                    column: property.columnName,
+                    kind: property.kind,
+                    entity: entityName,
+                    property: property.name
+                )
+                : nil
+            if let value {
+                row[property.name] = value
+            } else if !property.isOptional {
+                // Stored row predates the property (or sync delivered NULL). Materializing
+                // a required property from nothing traps inside SwiftData, so fall back to
+                // the declared default or fail with a descriptive error.
+                guard
+                    let defaultValue = property.defaultValue,
+                    let value = ValueCoercion.snapshotValue(from: defaultValue, kind: property.kind)
+                else {
+                    throw PowerSyncSwiftDataError.missingRequiredValue(
+                        entity: entityName,
+                        property: property.name
+                    )
+                }
+                row[property.name] = value
+            }
+        }
+        for relationship in toOne {
+            if let foreignKey = try cursor.getStringOptional(name: relationship.columnName) {
+                row[relationship.name] = foreignKey
+            }
+        }
+        return row
+    }
+
+    /// Converts a to-one snapshot value (a related identifier, or a raw id string) to a
+    /// foreign-key parameter.
+    private func foreignKeyParameter(
+        _ value: (any DataStoreSnapshotValue)?,
+        relationship: RelationshipMapping
+    ) throws -> Sendable? {
+        guard let value else { return nil }
+        if let identifier = value as? PersistentIdentifier {
+            return try PrimaryKeyResolver.primaryKey(of: identifier)
+        }
+        if let raw = value as? String {
+            return raw
+        }
+        throw PowerSyncSwiftDataError.unsupportedValueType(
+            entity: entityName,
+            property: relationship.name,
+            type: String(describing: type(of: value))
+        )
+    }
+
+    func insertStatement(for snapshot: PowerSyncSnapshot, primaryKey: String) throws -> SQLStatement {
+        var columns = [Self.quoted("id")]
+        var parameters: [Sendable?] = [primaryKey]
+        for property in properties where property.isStored {
+            columns.append(Self.quoted(property.columnName))
+            parameters.append(try ValueCoercion.parameter(
+                from: snapshot.values[property.name],
+                kind: property.kind,
+                entity: entityName,
+                property: property.name
+            ))
+        }
+        for relationship in toOne {
+            columns.append(Self.quoted(relationship.columnName))
+            parameters.append(try foreignKeyParameter(snapshot.values[relationship.name], relationship: relationship))
+        }
+        let placeholders = Array(repeating: "?", count: columns.count).joined(separator: ", ")
+        return SQLStatement(
+            sql: "INSERT INTO \(Self.quoted(tableName)) (\(columns.joined(separator: ", "))) VALUES (\(placeholders))",
+            parameters: parameters
+        )
+    }
+
+    /// Returns `nil` when the entity has no columns besides the id.
+    func updateStatement(for snapshot: PowerSyncSnapshot, primaryKey: String) throws -> SQLStatement? {
+        guard !properties.isEmpty || !toOne.isEmpty else { return nil }
+        var assignments: [String] = []
+        var parameters: [Sendable?] = []
+        for property in properties where property.isStored {
+            assignments.append("\(Self.quoted(property.columnName)) = ?")
+            parameters.append(try ValueCoercion.parameter(
+                from: snapshot.values[property.name],
+                kind: property.kind,
+                entity: entityName,
+                property: property.name
+            ))
+        }
+        for relationship in toOne {
+            assignments.append("\(Self.quoted(relationship.columnName)) = ?")
+            parameters.append(try foreignKeyParameter(snapshot.values[relationship.name], relationship: relationship))
+        }
+        parameters.append(primaryKey)
+        return SQLStatement(
+            sql: "UPDATE \(Self.quoted(tableName)) SET \(assignments.joined(separator: ", ")) WHERE \(Self.quoted("id")) = ?",
+            parameters: parameters
+        )
+    }
+
+    func deleteStatement(primaryKey: String) -> SQLStatement {
+        SQLStatement(
+            sql: "DELETE FROM \(Self.quoted(tableName)) WHERE \(Self.quoted("id")) = ?",
+            parameters: [primaryKey]
+        )
+    }
+
+    /// Stable description of the mapping used to detect conflicting registrations of the
+    /// same entity name by different stores.
+    var shapeSignature: String {
+        let columns = properties
+            .map { "\($0.name)=\($0.columnName):\($0.kind):\($0.isOptional):\($0.isStored)" }
+            .sorted()
+        let relationships = toOne.map { "\($0.name)->\($0.columnName)@\($0.destinationEntityName)" }.sorted()
+        let inverses = toMany.map { "\($0.name)<-\($0.inverseColumnName)@\($0.destinationEntityName)" }.sorted()
+        return "\(tableName)|\(columns)|\(relationships)|\(inverses)"
+    }
+
+    /// `SELECT id, fk FROM destination WHERE fk IN (...)` for batched to-many resolution.
+    func childrenSQL(for toMany: ToManyMapping, parentCount: Int) -> String {
+        let placeholders = Array(repeating: "?", count: parentCount).joined(separator: ", ")
+        return "SELECT \(Self.quoted("id")), \(Self.quoted(toMany.inverseColumnName)) "
+            + "FROM \(Self.quoted(toMany.destinationTableName)) "
+            + "WHERE \(Self.quoted(toMany.inverseColumnName)) IN (\(placeholders))"
+    }
+}
+
+/// Builds and caches the entity/property mapping for a SwiftData schema.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+struct SchemaMapper: Sendable {
+    let entitiesByName: [String: EntityMapping]
+
+    init(
+        schema: SwiftData.Schema,
+        tableNameForEntity: @Sendable (String) -> String,
+        columnNameForProperty: @Sendable (String, String) -> String? = { _, _ in nil }
+    ) throws {
+        var result: [String: EntityMapping] = [:]
+        var entitiesByTable: [String: String] = [:]
+        for entity in schema.entities {
+            guard entity.superentityName == nil, entity.subentities.isEmpty else {
+                throw PowerSyncSwiftDataError.inheritanceUnsupported(entity: entity.name)
+            }
+            let tableName = tableNameForEntity(entity.name)
+            if let existing = entitiesByTable[tableName] {
+                throw PowerSyncSwiftDataError.tableCollision(table: tableName, entities: [existing, entity.name])
+            }
+            entitiesByTable[tableName] = entity.name
+            let idPropertyName = "id"
+            guard
+                let idAttribute = entity.storedPropertiesByName[idPropertyName] as? SwiftData.Schema.Attribute,
+                ValueCoercion.unwrapOptionalMetatype(idAttribute.valueType) == String.self
+            else {
+                throw PowerSyncSwiftDataError.modelRequiresStringId(entity: entity.name)
+            }
+            var properties: [PropertyMapping] = []
+            var toOne: [RelationshipMapping] = []
+            var toMany: [ToManyMapping] = []
+            for property in entity.storedProperties {
+                if property.name == idPropertyName {
+                    continue
+                }
+                if let attribute = property as? SwiftData.Schema.Attribute {
+                    if attribute.isTransformable {
+                        throw PowerSyncSwiftDataError.unimplemented(
+                            "transformable attributes (\(entity.name).\(property.name)); store a Codable value instead"
+                        )
+                    }
+                    let kind = try ValueCoercion.kind(of: attribute.valueType, entity: entity.name, property: attribute.name)
+                    // `Attribute.Option` is not Equatable, so `.ephemeral` is detected by
+                    // description; the end-to-end ephemeral test guards this against SDK
+                    // representation changes.
+                    let isEphemeral = attribute.options.contains {
+                        String(describing: $0).lowercased().contains("ephemeral")
+                    }
+                    properties.append(PropertyMapping(
+                        name: attribute.name,
+                        columnName: columnNameForProperty(entity.name, attribute.name) ?? attribute.name,
+                        kind: kind,
+                        isOptional: attribute.isOptional,
+                        isStored: !attribute.isTransient && !isEphemeral,
+                        defaultValue: attribute.defaultValue
+                    ))
+                    continue
+                }
+                guard let relationship = property as? SwiftData.Schema.Relationship else {
+                    throw PowerSyncSwiftDataError.unsupportedValueType(
+                        entity: entity.name,
+                        property: property.name,
+                        type: String(describing: type(of: property))
+                    )
+                }
+                if relationship.isToOneRelationship {
+                    guard let destinationType = ValueCoercion.unwrapOptionalMetatype(relationship.valueType)
+                        as? any PersistentModel.Type
+                    else {
+                        throw PowerSyncSwiftDataError.unsupportedValueType(
+                            entity: entity.name,
+                            property: relationship.name,
+                            type: String(describing: relationship.valueType)
+                        )
+                    }
+                    toOne.append(RelationshipMapping(
+                        name: relationship.name,
+                        columnName: (columnNameForProperty(entity.name, relationship.name) ?? relationship.name) + "_id",
+                        destinationEntityName: relationship.destination,
+                        isOptional: relationship.isOptional,
+                        keyPath: relationship.keypath,
+                        destinationType: destinationType
+                    ))
+                } else {
+                    // Resolved below, once every entity's to-one columns are known.
+                    let elementType = Self.collectionElementType(relationship.valueType)
+                    guard let elementType else {
+                        throw PowerSyncSwiftDataError.unsupportedValueType(
+                            entity: entity.name,
+                            property: relationship.name,
+                            type: String(describing: relationship.valueType)
+                        )
+                    }
+                    toMany.append(ToManyMapping(
+                        name: relationship.name,
+                        destinationEntityName: relationship.destination,
+                        destinationTableName: tableNameForEntity(relationship.destination),
+                        inverseColumnName: "",
+                        keyPath: relationship.keypath,
+                        elementType: elementType
+                    ))
+                }
+            }
+            result[entity.name] = EntityMapping(
+                entityName: entity.name,
+                tableName: tableName,
+                idPropertyName: idPropertyName,
+                properties: properties,
+                toOne: toOne,
+                toMany: toMany
+            )
+        }
+
+        // Second pass: resolve every to-many through the destination's inverse to-one
+        // column. A to-many whose inverse is also to-many is a many-to-many without a join
+        // model, which PowerSync cannot sync (the join table must exist as a synced table);
+        // model the join explicitly as its own @Model with two to-one relationships.
+        for (entityName, mapping) in result {
+            guard !mapping.toMany.isEmpty else { continue }
+            let resolved = try mapping.toMany.map { toMany -> ToManyMapping in
+                guard let destination = result[toMany.destinationEntityName] else {
+                    throw PowerSyncSwiftDataError.entityNotFound(toMany.destinationEntityName)
+                }
+                guard let inverse = destination.toOne.first(where: { $0.destinationEntityName == entityName }) else {
+                    throw PowerSyncSwiftDataError.unimplemented(
+                        "many-to-many between \(entityName) and \(toMany.destinationEntityName) without a join model. "
+                            + "Declare an explicit join @Model with to-one relationships to both sides; "
+                            + "PowerSync needs the join table as a synced table anyway."
+                    )
+                }
+                return ToManyMapping(
+                    name: toMany.name,
+                    destinationEntityName: toMany.destinationEntityName,
+                    destinationTableName: destination.tableName,
+                    inverseColumnName: inverse.columnName,
+                    keyPath: toMany.keyPath,
+                    elementType: toMany.elementType
+                )
+            }
+            result[entityName] = EntityMapping(
+                entityName: mapping.entityName,
+                tableName: mapping.tableName,
+                idPropertyName: mapping.idPropertyName,
+                properties: mapping.properties,
+                toOne: mapping.toOne,
+                toMany: resolved
+            )
+        }
+
+        entitiesByName = result
+    }
+
+    private static func collectionElementType(_ valueType: Any.Type) -> (any PersistentModel.Type)? {
+        guard let collection = ValueCoercion.unwrapOptionalMetatype(valueType) as? any RelationshipCollection.Type else {
+            return nil
+        }
+        func open<C: RelationshipCollection>(_: C.Type) -> any PersistentModel.Type {
+            C.PersistentElement.self
+        }
+        return open(collection)
+    }
+
+    func entity(named name: String) throws -> EntityMapping {
+        guard let entity = entitiesByName[name] else {
+            throw PowerSyncSwiftDataError.entityNotFound(name)
+        }
+        return entity
+    }
+}
+
+/// Process-wide lookup from entity name to mapping, used where SwiftData hands us no store
+/// reference: `PowerSyncSnapshot.init(from:relatedBackingDatas:)` and `Decodable`.
+///
+/// Stores register their mapper on creation. If two stores in one process map the same
+/// entity name differently, the last registration wins; entity names are expected to be
+/// unique per process.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+enum SnapshotEntityRegistry {
+    private static let entities = Mutex<[String: EntityMapping]>([:])
+
+    static func register(_ mapper: SchemaMapper) throws {
+        try entities.withLock { storage in
+            for (name, entity) in mapper.entitiesByName {
+                if let existing = storage[name], existing.shapeSignature != entity.shapeSignature {
+                    throw PowerSyncSwiftDataError.configurationConflict(entity: name)
+                }
+                storage[name] = entity
+            }
+        }
+    }
+
+    static func entity(named name: String) -> EntityMapping? {
+        entities.withLock { $0[name] }
+    }
+}

--- a/Sources/PowerSyncSwiftData/ValueCoercion.swift
+++ b/Sources/PowerSyncSwiftData/ValueCoercion.swift
@@ -1,0 +1,357 @@
+import Foundation
+import PowerSync
+import SwiftData
+
+private protocol OptionalTypeMarker {
+    static var wrappedType: Any.Type { get }
+}
+
+extension Optional: OptionalTypeMarker {
+    static var wrappedType: Any.Type { Wrapped.self }
+}
+
+/// Converts values between their Swift types (as stored in ``PowerSyncSnapshot``) and the
+/// SQLite representations PowerSync uses (`text`/`integer`/`real` columns).
+///
+/// Representation choices (PowerSync has no blob column type and `SqlCursor` exposes no
+/// blob getter, so binary types ride on `text`):
+/// - `Date` -> `real` (seconds since 1970)
+/// - `UUID` -> `text` (uuidString)
+/// - `Data` -> `text` (base64)
+/// - `RawRepresentable` enums -> their raw value's column type
+/// - other `Codable` values -> `text` (JSON, ISO 8601 dates, sorted keys)
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+enum ValueCoercion {
+    /// The column type backing a raw-representable enum.
+    enum RawKind: Sendable {
+        case string
+        case int
+        case int64
+        case int32
+        case double
+    }
+
+    /// How a model property's value type is stored in its PowerSync column.
+    enum Kind: Sendable {
+        case string
+        case bool
+        case int
+        case int64
+        case int32
+        case double
+        case float
+        case date
+        case uuid
+        case data
+        case rawRepresentable(type: any (RawRepresentable & Decodable & Encodable & Sendable).Type, rawKind: RawKind)
+        case codable(type: any (Decodable & Encodable & Sendable).Type)
+    }
+
+    /// `Optional<String>.self` becomes `String.self`; non-optional metatypes pass through.
+    /// Unwrapping before dispatching on the type is required for optional values to cast.
+    static func unwrapOptionalMetatype(_ type: Any.Type) -> Any.Type {
+        (type as? OptionalTypeMarker.Type)?.wrappedType ?? type
+    }
+
+    /// `Optional(Optional("x"))` becomes `"x"`; `Optional<T>.none` becomes `nil`.
+    static func flattenOptional(_ value: Any) -> Any? {
+        let mirror = Mirror(reflecting: value)
+        guard mirror.displayStyle == .optional else {
+            return value
+        }
+        guard let child = mirror.children.first else {
+            return nil
+        }
+        return flattenOptional(child.value)
+    }
+
+    /// Converts an untyped value (such as a schema default) into a snapshot value of the
+    /// property's kind. Returns `nil` when the value does not match the kind.
+    static func snapshotValue(from value: Any, kind: Kind) -> (any DataStoreSnapshotValue)? {
+        func openAny(_ type: any (Decodable & Encodable & Sendable).Type) -> (any DataStoreSnapshotValue)? {
+            func go<V: Decodable & Encodable & Sendable>(_: V.Type) -> (any DataStoreSnapshotValue)? {
+                (value as? V).map { $0 as any DataStoreSnapshotValue }
+            }
+            return go(type)
+        }
+        switch kind {
+        case .string: return value as? String
+        case .bool: return value as? Bool
+        case .int: return value as? Int
+        case .int64: return value as? Int64
+        case .int32: return value as? Int32
+        case .double: return value as? Double
+        case .float: return value as? Float
+        case .date: return value as? Date
+        case .uuid: return value as? UUID
+        case .data: return value as? Data
+        case let .rawRepresentable(type, _): return openAny(type)
+        case let .codable(type): return openAny(type)
+        }
+    }
+
+    /// Whether two values are equal under the column representation for `kind`.
+    /// Used to diff incoming PowerSync rows against registered model state.
+    static func representationsEqual(_ lhs: Any?, _ rhs: Any?, kind: Kind) -> Bool {
+        let left = try? parameter(from: lhs, kind: kind, entity: "", property: "")
+        let right = try? parameter(from: rhs, kind: kind, entity: "", property: "")
+        switch (left ?? nil, right ?? nil) {
+        case (nil, nil):
+            return true
+        case let (lhs as String, rhs as String):
+            return lhs == rhs
+        case let (lhs as Int64, rhs as Int64):
+            return lhs == rhs
+        case let (lhs as Double, rhs as Double):
+            return lhs == rhs
+        default:
+            return false
+        }
+    }
+
+    static func kind(of valueType: Any.Type, entity: String, property: String) throws -> Kind {
+        let unwrapped = unwrapOptionalMetatype(valueType)
+        if unwrapped == String.self { return .string }
+        if unwrapped == Bool.self { return .bool }
+        if unwrapped == Int.self { return .int }
+        if unwrapped == Int64.self { return .int64 }
+        if unwrapped == Int32.self { return .int32 }
+        if unwrapped == Double.self { return .double }
+        if unwrapped == Float.self { return .float }
+        if unwrapped == Date.self { return .date }
+        if unwrapped == UUID.self { return .uuid }
+        if unwrapped == Data.self { return .data }
+        if let rawType = unwrapped as? any (RawRepresentable & Decodable & Encodable & Sendable).Type {
+            return .rawRepresentable(
+                type: rawType,
+                rawKind: try rawKind(of: rawType, entity: entity, property: property)
+            )
+        }
+        if let codableType = unwrapped as? any (Decodable & Encodable & Sendable).Type {
+            return .codable(type: codableType)
+        }
+        throw PowerSyncSwiftDataError.unsupportedValueType(
+            entity: entity,
+            property: property,
+            type: String(describing: valueType)
+        )
+    }
+
+    private static func rawKind(
+        of type: any (RawRepresentable & Decodable & Encodable & Sendable).Type,
+        entity: String,
+        property: String
+    ) throws -> RawKind {
+        func rawValueType<T: RawRepresentable>(_: T.Type) -> Any.Type { T.RawValue.self }
+        let raw = rawValueType(type)
+        if raw == String.self { return .string }
+        if raw == Int.self { return .int }
+        if raw == Int64.self { return .int64 }
+        if raw == Int32.self { return .int32 }
+        if raw == Double.self { return .double }
+        throw PowerSyncSwiftDataError.unsupportedValueType(
+            entity: entity,
+            property: property,
+            type: "\(type) (raw value \(raw))"
+        )
+    }
+
+    /// The PowerSync column type for a property kind (used to derive PowerSync schemas).
+    static func columnType(for kind: Kind) -> ColumnData {
+        switch kind {
+        case .string, .uuid, .data, .codable:
+            return .text
+        case .bool, .int, .int64, .int32:
+            return .integer
+        case .double, .float, .date:
+            return .real
+        case let .rawRepresentable(_, rawKind):
+            switch rawKind {
+            case .string: return .text
+            case .int, .int64, .int32: return .integer
+            case .double: return .real
+            }
+        }
+    }
+
+    // MARK: cursor -> value
+
+    /// Reads a column from a PowerSync cursor as the Swift type backing `kind`.
+    /// Returns `nil` for SQL `NULL`.
+    static func value(
+        from cursor: any SqlCursor,
+        column: String,
+        kind: Kind,
+        entity: String,
+        property: String
+    ) throws -> (any DataStoreSnapshotValue)? {
+        func exactInt<I: FixedWidthInteger & Decodable & Encodable & Sendable>(
+            _: I.Type
+        ) throws -> I? {
+            guard let raw = try cursor.getInt64Optional(name: column) else { return nil }
+            guard let exact = I(exactly: raw) else {
+                throw PowerSyncSwiftDataError.valueOutOfRange(entity: entity, property: property)
+            }
+            return exact
+        }
+        switch kind {
+        case .string:
+            return try cursor.getStringOptional(name: column)
+        case .bool:
+            return try cursor.getBooleanOptional(name: column)
+        case .int:
+            return try exactInt(Int.self)
+        case .int64:
+            return try cursor.getInt64Optional(name: column)
+        case .int32:
+            return try exactInt(Int32.self)
+        case .double:
+            return try cursor.getDoubleOptional(name: column)
+        case .float:
+            return try cursor.getDoubleOptional(name: column).map { Float($0) }
+        case .date:
+            return try cursor.getDoubleOptional(name: column).map { Date(timeIntervalSince1970: $0) }
+        case .uuid:
+            return try cursor.getStringOptional(name: column).flatMap { UUID(uuidString: $0) }
+        case .data:
+            return try cursor.getStringOptional(name: column).flatMap { Data(base64Encoded: $0) }
+        case let .rawRepresentable(type, rawKind):
+            let raw: Any?
+            switch rawKind {
+            case .string: raw = try cursor.getStringOptional(name: column)
+            case .int: raw = try exactInt(Int.self)
+            case .int64: raw = try cursor.getInt64Optional(name: column)
+            case .int32: raw = try exactInt(Int32.self)
+            case .double: raw = try cursor.getDoubleOptional(name: column)
+            }
+            guard let raw else { return nil }
+            return constructRawRepresentable(type, rawValue: raw)
+        case let .codable(type):
+            guard let json = try cursor.getStringOptional(name: column) else { return nil }
+            return try decodeJSON(type, from: json)
+        }
+    }
+
+    private static func constructRawRepresentable(
+        _ type: any (RawRepresentable & Decodable & Encodable & Sendable).Type,
+        rawValue: Any
+    ) -> (any DataStoreSnapshotValue)? {
+        func open<T: RawRepresentable & Decodable & Encodable & Sendable>(
+            _: T.Type
+        ) -> (any DataStoreSnapshotValue)? {
+            guard let raw = rawValue as? T.RawValue else { return nil }
+            return T(rawValue: raw).map { $0 as any DataStoreSnapshotValue }
+        }
+        return open(type)
+    }
+
+    private static func decodeJSON(
+        _ type: any (Decodable & Encodable & Sendable).Type,
+        from json: String
+    ) throws -> any DataStoreSnapshotValue {
+        func open<T: Decodable & Encodable & Sendable>(_: T.Type) throws -> any DataStoreSnapshotValue {
+            try makeDecoder().decode(T.self, from: Data(json.utf8))
+        }
+        return try open(type)
+    }
+
+    // MARK: value -> SQL parameter
+
+    /// Converts a snapshot value (or predicate constant) to a SQL statement parameter for
+    /// its column kind. Booleans become `0`/`1` so the stored representation is
+    /// deterministic.
+    static func parameter(
+        from value: Any?,
+        kind: Kind,
+        entity: String,
+        property: String
+    ) throws -> Sendable? {
+        guard let value else { return nil }
+
+        func mismatch() -> PowerSyncSwiftDataError {
+            .unsupportedValueType(
+                entity: entity,
+                property: property,
+                type: String(describing: type(of: value))
+            )
+        }
+
+        switch kind {
+        case .string:
+            guard let v = value as? String else { throw mismatch() }
+            return v
+        case .bool:
+            guard let v = value as? Bool else { throw mismatch() }
+            return Int64(v ? 1 : 0)
+        case .int:
+            guard let v = value as? Int else { throw mismatch() }
+            return Int64(v)
+        case .int64:
+            guard let v = value as? Int64 else { throw mismatch() }
+            return v
+        case .int32:
+            guard let v = value as? Int32 else { throw mismatch() }
+            return Int64(v)
+        case .double:
+            guard let v = value as? Double else { throw mismatch() }
+            return v
+        case .float:
+            guard let v = value as? Float else { throw mismatch() }
+            return Double(v)
+        case .date:
+            guard let v = value as? Date else { throw mismatch() }
+            return v.timeIntervalSince1970
+        case .uuid:
+            guard let v = value as? UUID else { throw mismatch() }
+            // Lowercase: backends (Postgres) render uuids lowercase and SQLite text
+            // comparison is case-sensitive, so storage and bindings must agree.
+            return v.uuidString.lowercased()
+        case .data:
+            guard let v = value as? Data else { throw mismatch() }
+            return v.base64EncodedString()
+        case let .rawRepresentable(_, rawKind):
+            guard let representable = value as? any RawRepresentable else { throw mismatch() }
+            let raw = representable.rawValue
+            switch rawKind {
+            case .string:
+                guard let v = raw as? String else { throw mismatch() }
+                return v
+            case .int:
+                guard let v = raw as? Int else { throw mismatch() }
+                return Int64(v)
+            case .int64:
+                guard let v = raw as? Int64 else { throw mismatch() }
+                return v
+            case .int32:
+                guard let v = raw as? Int32 else { throw mismatch() }
+                return Int64(v)
+            case .double:
+                guard let v = raw as? Double else { throw mismatch() }
+                return v
+            }
+        case .codable:
+            guard let encodable = value as? any Encodable else { throw mismatch() }
+            func open<T: Encodable>(_ v: T) throws -> String {
+                String(decoding: try makeEncoder().encode(v), as: UTF8.self)
+            }
+            return try open(encodable)
+        }
+    }
+
+    // MARK: JSON strategies (stable on-disk format for codable attributes)
+
+    private static func makeEncoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.dataEncodingStrategy = .base64
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return encoder
+    }
+
+    private static func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        decoder.dataDecodingStrategy = .base64
+        return decoder
+    }
+}

--- a/Sources/PowerSyncSwiftDataMacros/PowerSyncModel.swift
+++ b/Sources/PowerSyncSwiftDataMacros/PowerSyncModel.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Generates a `PredicateCodableKeyPathProviding` conformance for a `@Model`, exposing its
+/// stored properties' key paths through **public Foundation API** so the PowerSync store
+/// never needs to reflect SwiftData internals for this model.
+///
+/// Apply it alongside `@Model`:
+///
+/// ```swift
+/// import PowerSyncSwiftDataMacros
+///
+/// @Model
+/// @PowerSyncModel
+/// final class Note {
+///     var id: String
+///     var title: String
+///     init(id: String, title: String) { ... }
+/// }
+/// ```
+///
+/// The expansion enumerates the type's stored properties at compile time (skipping
+/// `@Transient` and computed properties), so adding a property never requires manual
+/// bookkeeping. Publicly provided key paths take precedence over reflection in
+/// `PowerSyncSwiftData`, removing its dependency on the private `schemaMetadata` layout
+/// for conforming models.
+@attached(extension, conformances: PredicateCodableKeyPathProviding, names: named(predicateCodableKeyPaths))
+public macro PowerSyncModel() = #externalMacro(
+    module: "PowerSyncSwiftDataMacrosPlugin",
+    type: "PowerSyncModelMacro"
+)

--- a/Sources/PowerSyncSwiftDataMacrosPlugin/PowerSyncModelMacro.swift
+++ b/Sources/PowerSyncSwiftDataMacrosPlugin/PowerSyncModelMacro.swift
@@ -1,0 +1,81 @@
+import SwiftCompilerPlugin
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Expands `@PowerSyncModel` into a `PredicateCodableKeyPathProviding` extension whose
+/// dictionary maps every stored property name to its key path.
+public struct PowerSyncModelMacro: ExtensionMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        let typeName = type.trimmedDescription
+
+        var entries: [String] = []
+        for member in declaration.memberBlock.members {
+            guard let variable = member.decl.as(VariableDeclSyntax.self) else {
+                continue
+            }
+            if variable.modifiers.contains(where: {
+                $0.name.tokenKind == .keyword(.static) || $0.name.tokenKind == .keyword(.class)
+            }) {
+                continue
+            }
+            // SwiftData's @Transient properties are not persisted.
+            if variable.attributes.contains(where: {
+                $0.as(AttributeSyntax.self)?.attributeName.trimmedDescription == "Transient"
+            }) {
+                continue
+            }
+            for binding in variable.bindings {
+                guard let pattern = binding.pattern.as(IdentifierPatternSyntax.self) else {
+                    continue
+                }
+                if let accessorBlock = binding.accessorBlock {
+                    switch accessorBlock.accessors {
+                    case .getter:
+                        continue // computed
+                    case let .accessors(list):
+                        let isStored = list.allSatisfy {
+                            $0.accessorSpecifier.tokenKind == .keyword(.willSet)
+                                || $0.accessorSpecifier.tokenKind == .keyword(.didSet)
+                        }
+                        if !isStored {
+                            continue
+                        }
+                    }
+                }
+                let name = pattern.identifier.text
+                entries.append("\"\(name)\": \\\(typeName).\(name)")
+            }
+        }
+
+        // Replicate the model's availability on the generated extension.
+        let availability = declaration.attributes
+            .compactMap { $0.as(AttributeSyntax.self) }
+            .filter { $0.attributeName.trimmedDescription == "available" }
+            .map(\.trimmedDescription)
+        let availabilityPrefix = availability.isEmpty ? "" : availability.joined(separator: "\n") + "\n"
+
+        let dictionary = entries.isEmpty ? "[:]" : "[\(entries.joined(separator: ", "))]"
+        let extensionDecl: DeclSyntax = """
+        \(raw: availabilityPrefix)extension \(raw: typeName): PredicateCodableKeyPathProviding {
+            public static var predicateCodableKeyPaths: [String: any PartialKeyPath<\(raw: typeName)> & Sendable] {
+                \(raw: dictionary)
+            }
+        }
+        """
+        guard let result = extensionDecl.as(ExtensionDeclSyntax.self) else {
+            return []
+        }
+        return [result]
+    }
+}
+
+@main
+struct PowerSyncSwiftDataMacrosPluginMain: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [PowerSyncModelMacro.self]
+}

--- a/Tests/PowerSyncSwiftDataTests/AsyncBridgeTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/AsyncBridgeTests.swift
@@ -1,0 +1,68 @@
+import Dispatch
+import Foundation
+@testable import PowerSyncSwiftData
+import Synchronization
+import Testing
+
+/// Validates the synchronous-over-async bridge that `fetch`/`save` rely on: results and
+/// errors propagate, and the bridge cannot deadlock regardless of which thread SwiftData
+/// invokes the store from.
+@Suite("AsyncBridge")
+struct AsyncBridgeTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test(.timeLimit(.minutes(1)))
+    func returnsValuesAndPropagatesErrors() throws {
+        let value = try AsyncBridge.blocking { () async throws -> Int in
+            try await Task.sleep(nanoseconds: 1_000_000)
+            return 42
+        }
+        #expect(value == 42)
+
+        struct Boom: Error, Equatable {}
+        #expect(throws: Boom.self) {
+            try AsyncBridge.blocking { () async throws -> Void in
+                throw Boom()
+            }
+        }
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test(.timeLimit(.minutes(1)))
+    func doesNotDeadlockFromManyGCDThreads() {
+        // SwiftData calls fetch/save synchronously on whatever thread the app happens to
+        // use; simulate a burst of simultaneous callers on GCD worker threads.
+        let iterations = 64
+        let completed = Mutex(0)
+        DispatchQueue.concurrentPerform(iterations: iterations) { _ in
+            let value = try? AsyncBridge.blocking { () async throws -> Int in
+                try await Task.sleep(nanoseconds: 2_000_000)
+                return 1
+            }
+            completed.withLock { $0 += value ?? 0 }
+        }
+        #expect(completed.withLock { $0 } == iterations)
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test(.timeLimit(.minutes(1)))
+    func doesNotDeadlockWhenCooperativePoolIsSaturated() async {
+        // Worst case for a semaphore bridge: every cooperative-pool thread is blocked
+        // inside the bridge while the bridged work itself still needs somewhere to run.
+        // 4x the core count guarantees the pool is saturated with blocked callers, and the
+        // bridged body suspends twice so its continuations also need somewhere to resume.
+        let callers = max(8, ProcessInfo.processInfo.activeProcessorCount * 4)
+        let total = await withTaskGroup(of: Int.self, returning: Int.self) { group in
+            for _ in 0 ..< callers {
+                group.addTask {
+                    (try? AsyncBridge.blocking { () async throws -> Int in
+                        try await Task.sleep(nanoseconds: 2_000_000)
+                        try await Task.sleep(nanoseconds: 2_000_000)
+                        return 1
+                    }) ?? 0
+                }
+            }
+            return await group.reduce(0, +)
+        }
+        #expect(total == callers)
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/AttributeCoercionTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/AttributeCoercionTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// Round-trips every supported attribute type (spec type table): scalars, Date, Data,
+/// UUID, raw-representable enums, Codable values, and optionals flipping nil <-> value.
+@Suite("Attribute coercion")
+struct AttributeCoercionTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func allSupportedAttributeTypesRoundTrip() async throws {
+        let database = try await TestDatabases.makeTypeMixDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(name: "coercion-types", database: database)
+        let container = try ModelContainer(
+            for: SwiftData.Schema([TypeMix.self]),
+            configurations: [configuration]
+        )
+
+        let id = UUID().uuidString.lowercased()
+        let stamp = Date(timeIntervalSince1970: 1_760_000_000.25)
+        let payload = Data([0x01, 0x02, 0xFE, 0xFF])
+        let token = UUID()
+        let geo = Geo(lat: 43.263, lon: -2.935)
+
+        let context = ModelContext(container)
+        context.insert(TypeMix(
+            id: id,
+            text: "txt",
+            integer: -42,
+            integer64: 9_000_000_000,
+            integer32: 123_456,
+            flag: true,
+            fraction: 3.14159,
+            fraction32: 2.5,
+            stamp: stamp,
+            payload: payload,
+            token: token,
+            mood: .stormy,
+            level: .high,
+            geo: geo,
+            subtitle: "sub",
+            optionalNumber: nil,
+            optionalStamp: nil,
+            optionalPayload: nil
+        ))
+        try context.save()
+
+        let secondContext = ModelContext(container)
+        let fetched = try secondContext.fetch(FetchDescriptor<TypeMix>())
+        #expect(fetched.count == 1)
+        let m = try #require(fetched.first)
+        #expect(m.id == id)
+        #expect(m.text == "txt")
+        #expect(m.integer == -42)
+        #expect(m.integer64 == 9_000_000_000)
+        #expect(m.integer32 == 123_456)
+        #expect(m.flag == true)
+        #expect(m.fraction == 3.14159)
+        #expect(m.fraction32 == 2.5)
+        #expect(abs(m.stamp.timeIntervalSince(stamp)) < 0.001)
+        #expect(m.payload == payload)
+        #expect(m.token == token)
+        #expect(m.mood == .stormy)
+        #expect(m.level == .high)
+        #expect(m.geo == geo)
+        #expect(m.subtitle == "sub")
+        #expect(m.optionalNumber == nil)
+        #expect(m.optionalStamp == nil)
+        #expect(m.optionalPayload == nil)
+
+        // Flip the optionals through an update: set the nil ones, clear the set one.
+        m.subtitle = nil
+        m.optionalNumber = 7
+        m.optionalStamp = stamp
+        m.optionalPayload = payload
+        try secondContext.save()
+
+        let refetched = try ModelContext(container).fetch(FetchDescriptor<TypeMix>())
+        let m2 = try #require(refetched.first)
+        #expect(m2.subtitle == nil)
+        #expect(m2.optionalNumber == 7)
+        #expect(abs((m2.optionalStamp ?? .distantPast).timeIntervalSince(stamp)) < 0.001)
+        #expect(m2.optionalPayload == payload)
+
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/BatchDeleteTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/BatchDeleteTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// Batch deletes translate to a single SQL DELETE (captured by PowerSync's triggers), and
+/// erase() is intentionally unsupported: resetting local PowerSync data is
+/// `disconnectAndClear()`'s job, and uploading DELETEs for every row would destroy server
+/// data on what apps usually call during logout.
+@Suite("Batch delete and erase")
+struct BatchDeleteTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func batchDeleteWithPredicateRemovesMatchingRows() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(name: "batch-batch", database: database)
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [configuration]
+        )
+
+        let context = ModelContext(container)
+        for index in 0 ..< 6 {
+            context.insert(Note(id: "n\(index)", title: "t\(index)", done: index % 2 == 0, count: index))
+        }
+        try context.save()
+        try await #require(try await database.getNextCrudTransaction()).complete()
+
+        try context.delete(model: Note.self, where: #Predicate { $0.count >= 3 })
+        try context.save()
+
+        let reader = ModelContext(container)
+        let remaining = try reader.fetch(FetchDescriptor<Note>())
+        #expect(Set(remaining.map(\.id)) == ["n0", "n1", "n2"])
+
+        // The batch delete is captured for upload.
+        let transaction = try #require(try await database.getNextCrudTransaction())
+        let deletes = transaction.crud.filter { $0.op == .delete && $0.table == "note" }
+        #expect(Set(deletes.map(\.id)) == ["n3", "n4", "n5"])
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func eraseIsUnsupportedInFavorOfDisconnectAndClear() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(name: "batch-erase", database: database)
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [configuration]
+        )
+        _ = container
+
+        let store = try PowerSyncDataStore(configuration, migrationPlan: nil)
+        #expect(throws: DataStoreError.unsupportedFeature) {
+            try store.erase()
+        }
+
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/ChainedPredicateTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/ChainedPredicateTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// Optional-chained to-one predicates translate to SQL instead of falling back to
+/// in-memory filtering: `$0.playlist?.id == x` compares the foreign-key column directly,
+/// and `$0.playlist?.name == x` uses an `IN (SELECT id ...)` subquery — both with Swift's
+/// optional-chain semantics (a nil relationship makes `==` false and `!=` true).
+@Suite("Chained relationship predicates")
+struct ChainedPredicateTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    private static func songTranslator() throws -> PredicateTranslator {
+        let mapper = try SchemaMapper(
+            schema: SwiftData.Schema([Playlist.self, Song.self]),
+            tableNameForEntity: PowerSyncDataStoreConfiguration.defaultTableName(forEntityName:)
+        )
+        try SnapshotEntityRegistry.register(mapper)
+        return PredicateTranslator(entity: try mapper.entity(named: "Song"), modelType: Song.self)
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func chainedIdComparesTheForeignKeyDirectly() throws {
+        let translator = try Self.songTranslator()
+        let listId = "p1"
+        let translated = try translator.translateWhere(#Predicate<Song> { $0.playlist?.id == listId })
+        #expect(translated.clause == "\"playlist_id\" = ?")
+        #expect(translated.bindings.first as? String == "p1")
+
+        // Swift: nil-chain != x is TRUE, so the negation must be NULL-safe.
+        let negated = try translator.translateWhere(#Predicate<Song> { $0.playlist?.id != listId })
+        #expect(negated.clause == "(\"playlist_id\" IS NULL OR \"playlist_id\" != ?)")
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func chainedAttributeUsesASubquery() throws {
+        let translator = try Self.songTranslator()
+        let translated = try translator.translateWhere(#Predicate<Song> { $0.playlist?.name == "Road" })
+        #expect(translated.clause == "\"playlist_id\" IN (SELECT \"id\" FROM \"playlist\" WHERE \"name\" = ?)")
+
+        let negated = try translator.translateWhere(#Predicate<Song> { $0.playlist?.name != "Road" })
+        #expect(negated.clause
+            == "(\"playlist_id\" IS NULL OR \"playlist_id\" NOT IN (SELECT \"id\" FROM \"playlist\" WHERE \"name\" = ?))")
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func chainedPredicatesMatchSwiftSemanticsEndToEnd() async throws {
+        let database = try await TestDatabases.makeMusicDatabase()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Playlist.self, Song.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "chained", database: database)]
+        )
+
+        let context = ModelContext(container)
+        let road = Playlist(id: "p1", name: "Road")
+        let focus = Playlist(id: "p2", name: "Focus")
+        context.insert(road)
+        context.insert(focus)
+        context.insert(Song(id: "s1", title: "en road", playlist: road))
+        context.insert(Song(id: "s2", title: "en focus", playlist: focus))
+        context.insert(Song(id: "s3", title: "huérfana", playlist: nil))
+        try context.save()
+
+        let reader = ModelContext(container)
+
+        let inRoad = try reader.fetch(FetchDescriptor<Song>(
+            predicate: #Predicate { $0.playlist?.name == "Road" }
+        ))
+        #expect(Set(inRoad.map(\.id)) == ["s1"])
+
+        // Swift semantics: != is true for the other playlist AND for the nil chain.
+        let notRoad = try reader.fetch(FetchDescriptor<Song>(
+            predicate: #Predicate { $0.playlist?.name != "Road" }
+        ))
+        #expect(Set(notRoad.map(\.id)) == ["s2", "s3"])
+
+        let byId = try reader.fetch(FetchDescriptor<Song>(
+            predicate: #Predicate { $0.playlist?.id == "p2" }
+        ))
+        #expect(Set(byId.map(\.id)) == ["s2"])
+
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/ColumnOverrideTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/ColumnOverrideTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// Per-property column-name overrides: Swift models keep idiomatic camelCase property
+/// names while mapping to conventional snake_case Postgres columns, without renaming
+/// either side.
+@Suite("Column overrides")
+struct ColumnOverrideTests {
+    static let snakeCase: @Sendable (String, String) -> String? = { _, property in
+        var result = ""
+        for character in property {
+            if character.isUppercase {
+                result.append("_")
+                result.append(contentsOf: character.lowercased())
+            } else {
+                result.append(character)
+            }
+        }
+        return result == property ? nil : result
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func mapsPropertiesToOverriddenColumnsEndToEnd() async throws {
+        // Stamp model: `createdAt` property, `created_at` column.
+        let database = PowerSyncDatabase(
+            schema: try PowerSyncSchema(
+                for: [Stamp.self],
+                columnNameForProperty: Self.snakeCase
+            ),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+
+        // The derived schema uses the overridden column names.
+        let derived = try PowerSyncSchema(for: [Stamp.self], columnNameForProperty: Self.snakeCase)
+        let table = try #require(derived.tables.first { $0.name == "stamp" })
+        #expect(table.columns.contains { $0.name == "created_at" })
+        #expect(!table.columns.contains { $0.name == "createdAt" })
+
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Stamp.self]),
+            configurations: [PowerSyncDataStoreConfiguration(
+                name: "column-overrides",
+                database: database,
+                columnNameForProperty: Self.snakeCase
+            )]
+        )
+
+        let context = ModelContext(container)
+        let moment = Date(timeIntervalSince1970: 1_700_000_000)
+        context.insert(Stamp(id: "s1", createdAt: moment, displayName: "uno"))
+        try context.save()
+
+        // The upload queue carries the COLUMN names (what the backend expects).
+        let batch = try #require(try await database.getCrudBatch())
+        let opData = try #require(batch.crud.first?.opData)
+        #expect(opData.keys.contains("created_at"))
+        #expect(opData.keys.contains("display_name"))
+        #expect(!opData.keys.contains("createdAt"))
+
+        // Round trip and predicate translation work against the overridden columns.
+        let reader = ModelContext(container)
+        let cutoff = moment.addingTimeInterval(-1)
+        let fetched = try reader.fetch(FetchDescriptor<Stamp>(
+            predicate: #Predicate { $0.createdAt > cutoff },
+            sortBy: [SortDescriptor(\.displayName)]
+        ))
+        #expect(fetched.first?.displayName == "uno")
+        #expect(fetched.first?.createdAt == moment)
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func overriddenColumnsAreValidatedAgainstTheDatabase() async throws {
+        // A database whose table has the DEFAULT column names: container creation with the
+        // override must fail descriptively (the overridden column is missing).
+        let database = PowerSyncDatabase(
+            schema: try PowerSyncSchema(for: [Stamp.self]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+
+        do {
+            _ = try ModelContainer(
+                for: SwiftData.Schema([Stamp.self]),
+                configurations: [PowerSyncDataStoreConfiguration(
+                    name: "column-overrides-mismatch",
+                    database: database,
+                    columnNameForProperty: Self.snakeCase
+                )]
+            )
+            Issue.record("container creation should fail when overridden columns are missing")
+        } catch {
+            #expect(String(describing: error).contains("created_at"))
+        }
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/CoverageGapsTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/CoverageGapsTests.swift
@@ -1,0 +1,216 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// Closes the asserted-but-untested gaps found by the module audit: real reference cycles
+/// in one save, many-to-many through an explicit join model, the transformable rejection
+/// path, in-memory fallback behavior for count/identifiers/batch delete, and ModelContext
+/// lifecycle smoke coverage (rollback, enumerate, model(for:)).
+@Suite("Coverage gaps")
+struct CoverageGapsTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func referenceCycleInOneSaveRemapsBothDirections() async throws {
+        let database = PowerSyncDatabase(
+            schema: try PowerSyncSchema(for: [Twin.self]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Twin.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "cycle", database: database)]
+        )
+
+        // A true cycle: both models reference each other and BOTH carry empty ids, so
+        // both references point at temporary identifiers that must be remapped.
+        let context = ModelContext(container)
+        let castor = Twin(id: "", name: "Castor")
+        let pollux = Twin(id: "", name: "Pollux")
+        castor.partner = pollux
+        pollux.partner = castor
+        context.insert(castor)
+        context.insert(pollux)
+        try context.save()
+
+        let reader = ModelContext(container)
+        let twins = try reader.fetch(FetchDescriptor<Twin>())
+        #expect(twins.count == 2)
+        let byName = Dictionary(uniqueKeysWithValues: twins.map { ($0.name, $0) })
+        #expect(byName["Castor"]?.partner?.name == "Pollux")
+        #expect(byName["Pollux"]?.partner?.name == "Castor")
+        #expect(byName["Castor"]?.partner?.id == byName["Pollux"]?.id)
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func manyToManyThroughJoinModelRoundTrips() async throws {
+        let database = PowerSyncDatabase(
+            schema: try PowerSyncSchema(for: [Student.self, Course.self, Enrollment.self]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Student.self, Course.self, Enrollment.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "join-m2m", database: database)]
+        )
+
+        // Three entities inserted in the same save, joined through Enrollment.
+        let context = ModelContext(container)
+        let ada = Student(id: "s1", name: "Ada")
+        let alan = Student(id: "s2", name: "Alan")
+        let logic = Course(id: "c1", title: "Logic")
+        let crypto = Course(id: "c2", title: "Crypto")
+        context.insert(ada)
+        context.insert(alan)
+        context.insert(logic)
+        context.insert(crypto)
+        context.insert(Enrollment(id: "e1", student: ada, course: logic))
+        context.insert(Enrollment(id: "e2", student: ada, course: crypto))
+        context.insert(Enrollment(id: "e3", student: alan, course: crypto))
+        try context.save()
+
+        let reader = ModelContext(container)
+        let students = try reader.fetch(FetchDescriptor<Student>(sortBy: [SortDescriptor(\.name)]))
+        let adaCourses = Set(students[0].enrollments.compactMap(\.course?.title))
+        #expect(adaCourses == ["Logic", "Crypto"])
+        let cryptoStudents = try reader.fetch(
+            FetchDescriptor<Course>(predicate: #Predicate { $0.id == "c2" })
+        ).first?.enrollments.compactMap(\.student?.name)
+        #expect(Set(cryptoStudents ?? []) == ["Ada", "Alan"])
+
+        // Unenrolling deletes only the join row.
+        let enrollment = try #require(try reader.fetch(
+            FetchDescriptor<Enrollment>(predicate: #Predicate { $0.id == "e2" })
+        ).first)
+        reader.delete(enrollment)
+        try reader.save()
+
+        let verifier = ModelContext(container)
+        let adaAfter = try #require(try verifier.fetch(
+            FetchDescriptor<Student>(predicate: #Predicate { $0.id == "s1" })
+        ).first)
+        #expect(adaAfter.enrollments.compactMap(\.course?.title) == ["Logic"])
+        #expect(try verifier.fetchCount(FetchDescriptor<Course>()) == 2)
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func transformableAttributesAreRejectedDescriptively() throws {
+        let entity = SwiftData.Schema.Entity("Sketch")
+        entity.storedProperties = [
+            SwiftData.Schema.Attribute(name: "id", valueType: String.self),
+            SwiftData.Schema.Attribute(
+                name: "shape",
+                options: [.transformable(by: "MissingTransformer")],
+                valueType: Data.self
+            ),
+        ]
+        do {
+            _ = try SchemaMapper(
+                schema: SwiftData.Schema(entity),
+                tableNameForEntity: PowerSyncDataStoreConfiguration.defaultTableName(forEntityName:)
+            )
+            Issue.record("transformable attribute should be rejected")
+        } catch {
+            #expect(String(describing: error).contains("transformable"))
+        }
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func untranslatablePredicatesFallBackForCountIdentifiersAndBatchDelete() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "fallback-paths", database: database)]
+        )
+        let context = ModelContext(container)
+        for (index, title) in ["alfa", "bravo", "carlos"].enumerated() {
+            context.insert(Note(id: "n\(index)", title: title, done: false, count: index))
+        }
+        try context.save()
+
+        // localizedStandardContains is untranslatable on purpose. SwiftData only applies
+        // the in-memory fallback to fetch(); for count, identifiers and batch delete the
+        // error PROPAGATES — this test pins that contract (documented in the README, with
+        // fetch-based workarounds).
+        let predicate = #Predicate<Note> { $0.title.localizedStandardContains("AR") }
+        let reader = ModelContext(container)
+
+        #expect(throws: DataStoreError.preferInMemoryFilter) {
+            _ = try reader.fetchCount(FetchDescriptor<Note>(predicate: predicate))
+        }
+        #expect(throws: DataStoreError.preferInMemoryFilter) {
+            _ = try reader.fetchIdentifiers(FetchDescriptor<Note>(predicate: predicate))
+        }
+        #expect(throws: DataStoreError.preferInMemoryFilter) {
+            try reader.delete(model: Note.self, where: predicate)
+        }
+
+        // The fetch-based workaround stays correct through the in-memory fallback.
+        let matches = try reader.fetch(FetchDescriptor<Note>(predicate: predicate))
+        #expect(matches.count == 1)
+        for model in matches {
+            reader.delete(model)
+        }
+        try reader.save()
+        let remaining = try ModelContext(container).fetch(FetchDescriptor<Note>())
+        #expect(Set(remaining.map(\.title)) == ["alfa", "bravo"])
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func modelContextLifecycleSmoke() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "lifecycle", database: database)]
+        )
+
+        // rollback() discards pending inserts and the stored row keeps the saved value.
+        // Whether the in-memory edit survives on the model instance is platform-dependent
+        // (macOS keeps "editada", iOS refaults to "guardada" through cachedSnapshots);
+        // DefaultStore shows the same divergence, so only the invariants are pinned.
+        let context = ModelContext(container)
+        let note = Note(id: "n1", title: "guardada", done: false, count: 1)
+        context.insert(note)
+        try context.save()
+        note.title = "editada"
+        context.insert(Note(id: "n2", title: "pendiente", done: false, count: 2))
+        context.rollback()
+        #expect(note.title == "editada" || note.title == "guardada")
+        #expect(try context.fetchCount(FetchDescriptor<Note>()) == 1)
+        let storedTitle = try await database.get(
+            sql: "SELECT title FROM note WHERE id = ?",
+            parameters: ["n1"]
+        ) { try $0.getString(index: 0) }
+        #expect(storedTitle == "guardada")
+
+        // enumerate() walks batched results through the store.
+        let extra = ModelContext(container)
+        for index in 0 ..< 25 {
+            extra.insert(Note(id: "bulk-\(index)", title: "b\(index)", done: false, count: index))
+        }
+        try extra.save()
+        var enumerated = 0
+        try ModelContext(container).enumerate(FetchDescriptor<Note>(), batchSize: 10) { (_: Note) in
+            enumerated += 1
+        }
+        #expect(enumerated == 26)
+
+        // model(for:) returns the registered instance for a known identifier.
+        let reader = ModelContext(container)
+        let fetched = try #require(try reader.fetch(
+            FetchDescriptor<Note>(predicate: #Predicate { $0.id == "n1" })
+        ).first)
+        let viaIdentifier = reader.model(for: fetched.persistentModelID) as? Note
+        #expect(viaIdentifier?.id == "n1")
+
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/MacroTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/MacroTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import PowerSync
+import PowerSyncSwiftDataMacros
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// A model whose key paths are provided through public API by the @PowerSyncModel macro.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+@PowerSyncModel
+final class MacroNote {
+    var id: String
+    var title: String
+    var count: Int
+    @Transient
+    var scratch: Int = 0
+
+    init(id: String, title: String, count: Int) {
+        self.id = id
+        self.title = title
+        self.count = count
+    }
+}
+
+/// The @PowerSyncModel macro: generated conformance, stored-property coverage (skipping
+/// @Transient), and independence from mirrored KEY PATHS (property names still come from
+/// schemaMetadata, guarded by the runtime coverage check).
+@Suite("PowerSyncModel macro")
+struct MacroTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func generatesTheConformanceWithStoredPropertiesOnly() throws {
+        let providing = try #require(MacroNote.self as? any PredicateCodableKeyPathProviding.Type)
+        func keys<P: PredicateCodableKeyPathProviding>(_: P.Type) -> Set<String> {
+            Set(P.predicateCodableKeyPaths.keys)
+        }
+        #expect(keys(providing) == ["id", "title", "count"])
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func macroModelWorksWithReflectionGone() async throws {
+        let database = PowerSyncDatabase(
+            schema: try PowerSyncSchema(for: [MacroNote.self]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([MacroNote.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "macro-model", database: database)]
+        )
+
+        // Even with mirrored key paths suppressed, the macro-provided ones carry the
+        // whole round trip: insert, upload capture, fetch, predicate translation.
+        ModelPropertyReflection._testSuppressMirrorKeyPaths(for: MacroNote.self, true)
+        defer { ModelPropertyReflection._testSuppressMirrorKeyPaths(for: MacroNote.self, false) }
+
+        let context = ModelContext(container)
+        context.insert(MacroNote(id: "m1", title: "macro", count: 7))
+        try context.save()
+
+        let transaction = try #require(try await database.getNextCrudTransaction())
+        #expect(transaction.crud.first?.opData?["title"] == "macro")
+
+        let fetched = try ModelContext(container).fetch(FetchDescriptor<MacroNote>(
+            predicate: #Predicate { $0.count > 5 }
+        ))
+        #expect(fetched.first?.title == "macro")
+        #expect(fetched.first?.scratch == 0)
+
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/MappingValidationTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/MappingValidationTests.swift
@@ -1,0 +1,189 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// Early, descriptive failure for configuration mistakes that previously surfaced as
+/// cryptic SQL errors mid-fetch (or hangs): mapping validated against the actual database,
+/// table-name collisions, conflicting registrations from a second store, unsupported model
+/// inheritance, ephemeral attributes, and out-of-range integers from the backend.
+@Suite("Mapping validation and hardening")
+struct MappingValidationTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func missingTableFailsContainerCreationDescriptively() async throws {
+        // PowerSync schema with NO note table.
+        let database = PowerSyncDatabase(
+            schema: PowerSync.Schema(tables: [Table(name: "unrelated", columns: [.text("x")])]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+
+        let configuration = PowerSyncDataStoreConfiguration(name: "validate-table", database: database)
+        #expect(throws: (any Error).self) {
+            _ = try ModelContainer(
+                for: SwiftData.Schema([Note.self]),
+                configurations: [configuration]
+            )
+        }
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func missingColumnFailsContainerCreationDescriptively() async throws {
+        // note table exists but lacks the `count` column.
+        let database = PowerSyncDatabase(
+            schema: PowerSync.Schema(tables: [
+                Table(name: "note", columns: [.text("title"), .integer("done")]),
+            ]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+
+        let configuration = PowerSyncDataStoreConfiguration(name: "validate-column", database: database)
+        do {
+            _ = try ModelContainer(
+                for: SwiftData.Schema([Note.self]),
+                configurations: [configuration]
+            )
+            Issue.record("container creation should have failed")
+        } catch {
+            #expect(String(describing: error).contains("count"))
+        }
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func tableNameCollisionsAreRejected() throws {
+        #expect(throws: PowerSyncSwiftDataError.self) {
+            _ = try SchemaMapper(
+                schema: SwiftData.Schema([Playlist.self, Song.self]),
+                tableNameForEntity: { _ in "same_table" }
+            )
+        }
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func conflictingEntityShapesAcrossStoresAreRejected() async throws {
+        // First store registers Note with the default table name.
+        let first = try await TestDatabases.makeNoteDatabase()
+        let firstContainer = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "registry-a", database: first)]
+        )
+        _ = firstContainer
+
+        // A second store maps the SAME entity to a different table: registering it would
+        // silently corrupt whichever store loses the registry race, so it must fail.
+        let second = PowerSyncDatabase(
+            schema: PowerSync.Schema(tables: [
+                Table(name: "renamed_note", columns: [.text("title"), .integer("done"), .integer("count")]),
+            ]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await second.disconnectAndClear()
+        let conflicting = PowerSyncDataStoreConfiguration(
+            name: "registry-b",
+            database: second,
+            tableNameForEntity: { _ in "renamed_note" }
+        )
+        #expect(throws: (any Error).self) {
+            _ = try ModelContainer(
+                for: SwiftData.Schema([Note.self]),
+                configurations: [conflicting]
+            )
+        }
+
+        try await first.close()
+        try await second.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func modelInheritanceIsRejectedClearly() throws {
+        let id = SwiftData.Schema.Attribute(name: "id", valueType: String.self)
+        let parent = SwiftData.Schema.Entity("Base")
+        parent.storedProperties = [id]
+        let child = SwiftData.Schema.Entity("Child")
+        child.storedProperties = [SwiftData.Schema.Attribute(name: "id", valueType: String.self)]
+        child.superentityName = "Base"
+        parent.subentities = [child]
+
+        do {
+            _ = try SchemaMapper(
+                schema: SwiftData.Schema(parent, child),
+                tableNameForEntity: PowerSyncDataStoreConfiguration.defaultTableName(forEntityName:)
+            )
+            Issue.record("inheritance should be rejected")
+        } catch {
+            #expect(String(describing: error).contains("inheritance"))
+        }
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func ephemeralAttributesNeverReachPowerSync() async throws {
+        let database = PowerSyncDatabase(
+            schema: try PowerSyncSchema(for: [EphemeralNote.self]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+
+        // The derived schema has no column for the ephemeral attribute.
+        let derived = try PowerSyncSchema(for: [EphemeralNote.self])
+        let table = try #require(derived.tables.first { $0.name == "ephemeral_note" })
+        #expect(!table.columns.contains { $0.name == "draft" })
+
+        let container = try ModelContainer(
+            for: SwiftData.Schema([EphemeralNote.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "ephemeral", database: database)]
+        )
+        let context = ModelContext(container)
+        context.insert(EphemeralNote(id: "e1", title: "hola", draft: "no me subas"))
+        try context.save()
+
+        let transaction = try #require(try await database.getNextCrudTransaction())
+        let entry = try #require(transaction.crud.first)
+        #expect(entry.opData?.keys.contains("draft") == false)
+
+        // Materialization resets the ephemeral value to its default.
+        let fetched = try ModelContext(container).fetch(FetchDescriptor<EphemeralNote>())
+        #expect(fetched.first?.title == "hola")
+        #expect(fetched.first?.draft == "")
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func outOfRangeIntegersThrowInsteadOfTruncating() async throws {
+        let database = try await TestDatabases.makeTypeMixDatabase()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([TypeMix.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "int-range", database: database)]
+        )
+
+        // A backend can sync any 64-bit integer into a column mapped to Int32.
+        _ = try await database.execute(
+            sql: """
+            INSERT INTO ps_data__type_mix (id, data) VALUES (?, json_object(
+                'text', 't', 'integer', 1, 'integer64', 1, 'integer32', 9999999999, 'flag', 0,
+                'fraction', 1.0, 'fraction32', 1.0, 'stamp', 1700000000.0,
+                'payload', 'AQI=', 'token', ?, 'mood', 'sunny', 'level', 1,
+                'geo', '{"lat":0,"lon":0}'
+            ))
+            """,
+            parameters: ["big", UUID().uuidString.lowercased()]
+        )
+
+        do {
+            _ = try ModelContext(container).fetch(FetchDescriptor<TypeMix>())
+            Issue.record("out-of-range Int32 should fail the fetch, not wrap around")
+        } catch {
+            #expect(String(describing: error).contains("integer32"))
+        }
+
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/MaterializationTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/MaterializationTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// A flat `@Model` round-trips through a `ModelContainer` backed by `PowerSyncDataStore`
+/// over an in-memory PowerSync database, writes are captured in the `ps_crud` upload
+/// queue, and materialization happens by property name.
+@Suite("Snapshot materialization")
+struct MaterializationTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func insertSaveCapturesCrudAndFetchesInAnotherContext() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(name: "materialization-store", database: database)
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [configuration]
+        )
+
+        let id = UUID().uuidString.lowercased()
+        let context = ModelContext(container)
+        context.insert(Note(id: id, title: "hola", done: true, count: 3))
+        try context.save()
+
+        // The write must have been captured in PowerSync's upload queue.
+        let maybeTransaction = try await database.getNextCrudTransaction()
+        let transaction = try #require(maybeTransaction)
+        #expect(transaction.crud.count == 1)
+        let entry = try #require(transaction.crud.first)
+        #expect(entry.op == .put)
+        #expect(entry.table == "note")
+        #expect(entry.id == id)
+        let opData = try #require(entry.opData)
+        #expect(opData["title"] == "hola")
+        #expect(opData["done"] == "1")
+        #expect(opData["count"] == "3")
+
+        // A different context materializes the model through the store with correct values
+        // and the same id, without trapping in "Failed to materialize".
+        let otherContext = ModelContext(container)
+        let fetched = try otherContext.fetch(FetchDescriptor<Note>())
+        #expect(fetched.count == 1)
+        let materialized = try #require(fetched.first)
+        #expect(materialized.id == id)
+        #expect(materialized.title == "hola")
+        #expect(materialized.done == true)
+        #expect(materialized.count == 3)
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func materializationMatchesSnapshotValuesByPropertyName() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+
+        // Seed a row directly through PowerSync, bypassing the save path.
+        let id = UUID().uuidString.lowercased()
+        _ = try await database.execute(
+            sql: "INSERT INTO note (id, title, done, count) VALUES (?, ?, ?, ?)",
+            parameters: [id, "hola", Int64(1), Int64(3)]
+        )
+
+        // Control: with property-name-aligned snapshot keys the value arrives. This proves
+        // the fetch pipeline works, so any difference below is attributable to the key name.
+        let alignedConfiguration = PowerSyncDataStoreConfiguration(name: "materialization-aligned", database: database)
+        let alignedContainer = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [alignedConfiguration]
+        )
+        let aligned = try ModelContext(alignedContainer).fetch(FetchDescriptor<Note>())
+        let alignedFirst = try #require(aligned.first)
+        #expect(alignedFirst.title == "hola")
+        try await database.close()
+
+        // Experiment: a store that hands SwiftData snapshots carrying the stored title
+        // under the key "name" instead of the property name "title". SwiftData's model
+        // decoder looks properties up by name and traps on the unknown key
+        // ("Cannot find name because it is not known to this model type" in ModelCoders),
+        // so the proof asserts process death in a child process. If this ever *stops*
+        // failing, snapshot materialization is no longer by property name and the store's
+        // core assumption must be revisited.
+        #if os(macOS)
+        await #expect(processExitsWith: .failure) {
+            let database = try await TestDatabases.makeNoteDatabase()
+            let configuration = PowerSyncDataStoreConfiguration(name: "materialization-misaligned", database: database)
+            configuration._testFetchKeyTransform = { $0 == "title" ? "name" : $0 }
+            let container = try ModelContainer(
+                for: SwiftData.Schema([Note.self]),
+                configurations: [configuration]
+            )
+            _ = try await database.execute(
+                sql: "INSERT INTO note (id, title, done, count) VALUES (?, ?, ?, ?)",
+                parameters: ["misaligned-row", "hola", Int64(1), Int64(3)]
+            )
+            _ = try ModelContext(container).fetch(FetchDescriptor<Note>())
+        }
+        #endif
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/MigrationTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/MigrationTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// Schema evolution. PowerSync tables are views over JSON and the local database is a
+/// cache of synced data, so most "migrations" are absorbed structurally: new models and
+/// columns appear when the database opens with the new derived schema, old rows read NULL
+/// for added columns, and keys of removed properties are simply ignored. These tests pin
+/// the behaviors that need code: defaults for added required properties, a descriptive
+/// error (not a trap) when a required value is missing without a default, and the explicit
+/// rejection of SwiftData migration plans.
+@Suite("Schema evolution")
+struct MigrationTests {
+    static func makeMigratedDatabase() async throws -> any PowerSyncDatabaseProtocol {
+        let database = PowerSyncDatabase(
+            schema: PowerSync.Schema(tables: [
+                Table(name: "migrated", columns: [.text("name"), .integer("rating")]),
+                Table(name: "strict", columns: [.integer("score")]),
+            ]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+        return database
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func addedOptionalPropertiesReadNilForOldRows() async throws {
+        let database = try await TestDatabases.makeTypeMixDatabase()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([TypeMix.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "migration-optional", database: database)]
+        )
+
+        // An "old" row stored before the optional properties existed: its JSON simply
+        // lacks those keys.
+        _ = try await database.execute(
+            sql: """
+            INSERT INTO ps_data__type_mix (id, data) VALUES (?, json_object(
+                'text', 'old', 'integer', 1, 'integer64', 1, 'integer32', 1, 'flag', 0,
+                'fraction', 1.5, 'fraction32', 1.5, 'stamp', 1700000000.0,
+                'payload', 'AQI=', 'token', ?, 'mood', 'sunny', 'level', 1,
+                'geo', '{"lat":0,"lon":0}'
+            ))
+            """,
+            parameters: ["old-row", UUID().uuidString]
+        )
+
+        let fetched = try ModelContext(container).fetch(FetchDescriptor<TypeMix>())
+        let model = try #require(fetched.first)
+        #expect(model.text == "old")
+        #expect(model.subtitle == nil)
+        #expect(model.optionalNumber == nil)
+        #expect(model.optionalStamp == nil)
+        #expect(model.optionalPayload == nil)
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func addedRequiredPropertyUsesItsDefaultForOldRows() async throws {
+        let database = try await Self.makeMigratedDatabase()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Migrated.self, Strict.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "migration-default", database: database)]
+        )
+
+        // An "old" row stored before `rating` existed.
+        _ = try await database.execute(
+            sql: "INSERT INTO ps_data__migrated (id, data) VALUES (?, json_object('name', ?))",
+            parameters: ["m1", "vieja"]
+        )
+
+        let fetched = try ModelContext(container).fetch(FetchDescriptor<Migrated>())
+        let model = try #require(fetched.first)
+        #expect(model.name == "vieja")
+        #expect(model.rating == 5)
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func missingRequiredValueWithoutDefaultThrowsDescriptively() async throws {
+        let database = try await Self.makeMigratedDatabase()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Migrated.self, Strict.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "migration-strict", database: database)]
+        )
+
+        _ = try await database.execute(
+            sql: "INSERT INTO ps_data__strict (id, data) VALUES (?, json_object('other', 1))",
+            parameters: ["s1"]
+        )
+
+        // Materializing a required property with no stored value and no default cannot
+        // succeed; it must surface as a thrown error, never a trap inside SwiftData.
+        #expect(throws: (any Error).self) {
+            _ = try ModelContext(container).fetch(FetchDescriptor<Strict>())
+        }
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func removedPropertyKeysAreIgnored() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "migration-removed", database: database)]
+        )
+
+        // A row written by an older app version whose model had an extra `legacy`
+        // property: the key survives in the JSON and must be ignored.
+        _ = try await database.execute(
+            sql: """
+            INSERT INTO ps_data__note (id, data)
+            VALUES (?, json_object('title', 'hola', 'done', 1, 'count', 2, 'legacy', 'x'))
+            """,
+            parameters: ["n1"]
+        )
+
+        let fetched = try ModelContext(container).fetch(FetchDescriptor<Note>())
+        let note = try #require(fetched.first)
+        #expect(note.title == "hola")
+        #expect(note.count == 2)
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func newModelsWorkOnAnExistingDatabaseFile() async throws {
+        // Version 1 of the app: only Note, on a file-backed database.
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("migration-\(UUID().uuidString)/powersync.db").path
+        let v1 = PowerSyncDatabase(
+            schema: try PowerSyncSchema(for: [Note.self]),
+            dbFilename: path,
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await v1.disconnectAndClear()
+        let containerV1 = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "migration-v1", database: v1)]
+        )
+        let contextV1 = ModelContext(containerV1)
+        contextV1.insert(Note(id: "n1", title: "v1", done: false, count: 1))
+        try contextV1.save()
+        try await v1.close()
+
+        // Version 2 adds the Migrated model: reopening with the new derived schema
+        // regenerates the views; old data is intact and the new table is usable.
+        let v2 = PowerSyncDatabase(
+            schema: try PowerSyncSchema(for: [Note.self, Migrated.self]),
+            dbFilename: path,
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        let containerV2 = try ModelContainer(
+            for: SwiftData.Schema([Note.self, Migrated.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "migration-v2", database: v2)]
+        )
+        let contextV2 = ModelContext(containerV2)
+        let notes = try contextV2.fetch(FetchDescriptor<Note>())
+        #expect(notes.first?.title == "v1")
+        contextV2.insert(Migrated(id: "m1", name: "nueva", rating: 9))
+        try contextV2.save()
+        let migrated = try contextV2.fetch(FetchDescriptor<Migrated>())
+        #expect(migrated.first?.rating == 9)
+
+        try await v2.close(deleteDatabase: true)
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func migrationPlansAreRejected() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(
+            name: "migration-plan",
+            database: database,
+            schema: SwiftData.Schema([Note.self])
+        )
+        #expect(throws: PowerSyncSwiftDataError.self) {
+            _ = try PowerSyncDataStore(configuration, migrationPlan: NoopMigrationPlan.self)
+        }
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/ModelContextCrudTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/ModelContextCrudTests.swift
@@ -1,0 +1,112 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// Full CRUD through `ModelContext`: updates land as PATCH and deletes as DELETE in
+/// `ps_crud`, and empty model ids are minted and remapped robustly.
+@Suite("ModelContext CRUD")
+struct ModelContextCrudTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func updateIsCapturedAsPatchAndPersisted() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(name: "crud-update", database: database)
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [configuration]
+        )
+
+        let id = UUID().uuidString.lowercased()
+        let context = ModelContext(container)
+        let note = Note(id: id, title: "hola", done: false, count: 1)
+        context.insert(note)
+        try context.save()
+        try await #require(try await database.getNextCrudTransaction()).complete()
+
+        note.title = "adiós"
+        note.done = true
+        try context.save()
+
+        let maybePatch = try await database.getNextCrudTransaction()
+        let patch = try #require(maybePatch)
+        let entry = try #require(patch.crud.first)
+        #expect(entry.op == .patch)
+        #expect(entry.table == "note")
+        #expect(entry.id == id)
+        let opData = try #require(entry.opData)
+        #expect(opData["title"] == "adiós")
+        #expect(opData["done"] == "1")
+
+        let fetched = try ModelContext(container).fetch(FetchDescriptor<Note>())
+        let materialized = try #require(fetched.first)
+        #expect(materialized.title == "adiós")
+        #expect(materialized.done == true)
+        #expect(materialized.count == 1)
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func deleteIsCapturedAndRowRemoved() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(name: "crud-delete", database: database)
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [configuration]
+        )
+
+        let id = UUID().uuidString.lowercased()
+        let context = ModelContext(container)
+        let note = Note(id: id, title: "hola", done: false, count: 1)
+        context.insert(note)
+        try context.save()
+        try await #require(try await database.getNextCrudTransaction()).complete()
+
+        context.delete(note)
+        try context.save()
+
+        let maybeDelete = try await database.getNextCrudTransaction()
+        let deletion = try #require(maybeDelete)
+        let entry = try #require(deletion.crud.first)
+        #expect(entry.op == .delete)
+        #expect(entry.table == "note")
+        #expect(entry.id == id)
+
+        let fetched = try ModelContext(container).fetch(FetchDescriptor<Note>())
+        #expect(fetched.isEmpty)
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func emptyIdIsMintedAndReregisteredInOriginalContext() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(name: "crud-mint", database: database)
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [configuration]
+        )
+
+        let context = ModelContext(container)
+        let note = Note(id: "", title: "hola", done: false, count: 0)
+        context.insert(note)
+        try context.save()
+
+        let maybeTransaction = try await database.getNextCrudTransaction()
+        let transaction = try #require(maybeTransaction)
+        let entry = try #require(transaction.crud.first)
+        #expect(!entry.id.isEmpty)
+
+        let fetched = try ModelContext(container).fetch(FetchDescriptor<Note>())
+        let materialized = try #require(fetched.first)
+        #expect(materialized.id == entry.id)
+        #expect(UUID(uuidString: materialized.id) != nil)
+
+        // The save result reregisters the snapshot carrying the minted id, so the model
+        // instance the app inserted must observe it too.
+        #expect(note.id == entry.id)
+
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/MultiProcessTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/MultiProcessTests.swift
@@ -1,0 +1,85 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// Writes from another process (an App Intent or interactive widget) must reach the app
+/// live. Two database instances over the same file use independent pools — the same
+/// blindness two processes exhibit — so this pins the whole chain: SwiftData write on the
+/// "extension" side → ps_crud capture → cross-process signal → app-side observer
+/// reconciliation → `ModelContext.didSave` (the signal `@Query` refreshes on).
+@Suite("Multi-process SwiftData")
+struct MultiProcessTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test(.timeLimit(.minutes(1)))
+    func extensionWritesReachTheAppLive() async throws {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("multiprocess-\(UUID().uuidString)/shared.db").path
+
+        // App side: container + live observer.
+        let appDatabase = PowerSyncDatabase(
+            schema: try PowerSyncSchema(for: [Note.self]),
+            dbFilename: path,
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        let appConfiguration = PowerSyncDataStoreConfiguration(name: "mp-app", database: appDatabase)
+        let appContainer = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [appConfiguration]
+        )
+        let observer = PowerSyncChangeObserver(container: appContainer, configuration: appConfiguration)
+        try await observer.start(observing: [Note.self])
+
+        let observation = Task {
+            for await notification in NotificationCenter.default.notifications(named: ModelContext.didSave) {
+                let inserted = notification.userInfo?["inserted"] as? [PersistentIdentifier] ?? []
+                if !inserted.isEmpty {
+                    return true
+                }
+            }
+            return false
+        }
+
+        // "Extension" side: its own database instance over the same file, default
+        // configuration (writes allowed), one ModelContext save.
+        let extensionDatabase = PowerSyncDatabase(
+            schema: try PowerSyncSchema(for: [Note.self]),
+            dbFilename: path,
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        let extensionContainer = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "mp-extension", database: extensionDatabase)]
+        )
+        let extensionContext = ModelContext(extensionContainer)
+        extensionContext.insert(Note(id: "from-intent", title: "escrita fuera", done: false, count: 1))
+        try extensionContext.save()
+
+        // The write is captured for upload (shared queue at the file level).
+        let batch = try await extensionDatabase.getCrudBatch()
+        #expect(batch?.crud.isEmpty == false)
+
+        // The app side must observe the change live (observer didSave, the signal @Query
+        // refreshes on), not just on re-fetch.
+        let sawInsert = await withTaskGroup(of: Bool.self) { group in
+            group.addTask { await observation.value }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(5))
+                return false
+            }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+        #expect(sawInsert)
+
+        let fetched = try ModelContext(appContainer).fetch(FetchDescriptor<Note>())
+        #expect(fetched.first?.title == "escrita fuera")
+
+        await observer.stop()
+        observation.cancel()
+        try await appDatabase.close()
+        try await extensionDatabase.close(deleteDatabase: true)
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/ObserverRobustnessTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/ObserverRobustnessTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// Failure modes of the change observer: `start()` must throw (never hang) when a watch
+/// cannot prime, the observer must be restartable after failures and after `stop()`, and
+/// bursts of remote changes must coalesce instead of queueing full-table emissions.
+@Suite("Observer robustness")
+struct ObserverRobustnessTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test(.timeLimit(.minutes(1)))
+    func startThrowsInsteadOfHangingWhenTheTableIsMissing() async throws {
+        // A database whose PowerSync schema lacks the note table; the configuration's
+        // SwiftData schema is set directly so no container-level validation runs first.
+        let database = PowerSyncDatabase(
+            schema: PowerSync.Schema(tables: [Table(name: "unrelated", columns: [.text("x")])]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+        let configuration = PowerSyncDataStoreConfiguration(
+            name: "observer-missing-table",
+            database: database,
+            schema: SwiftData.Schema([Note.self])
+        )
+        let observerContainer = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [ModelConfiguration(isStoredInMemoryOnly: true)]
+        )
+        let observer = PowerSyncChangeObserver(container: observerContainer, configuration: configuration)
+        await #expect(throws: (any Error).self) {
+            try await observer.start(observing: [Note.self])
+        }
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test(.timeLimit(.minutes(1)))
+    func observerIsRestartableAfterAFailedStart() async throws {
+        // First start fails (missing table); after fixing the schema, a second start on
+        // the SAME observer succeeds and reactivity works.
+        let database = PowerSyncDatabase(
+            schema: PowerSync.Schema(tables: [Table(name: "unrelated", columns: [.text("x")])]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+        let configuration = PowerSyncDataStoreConfiguration(
+            name: "observer-restart",
+            database: database,
+            schema: SwiftData.Schema([Note.self])
+        )
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [ModelConfiguration(isStoredInMemoryOnly: true)]
+        )
+        let observer = PowerSyncChangeObserver(container: container, configuration: configuration)
+
+        await #expect(throws: (any Error).self) {
+            try await observer.start(observing: [Note.self])
+        }
+
+        try await database.updateSchema(schema: PowerSync.Schema(tables: [
+            Table(name: "note", columns: [.text("title"), .integer("done"), .integer("count")]),
+        ]))
+        try await observer.start(observing: [Note.self])
+        await observer.stop()
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test(.timeLimit(.minutes(1)))
+    func stopThenStartKeepsWorking() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(name: "observer-stopstart", database: database)
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [configuration]
+        )
+        let observer = PowerSyncChangeObserver(container: container, configuration: configuration)
+        try await observer.start(observing: [Note.self])
+        await observer.stop()
+        try await observer.start(observing: [Note.self])
+
+        // Reactivity still functions after the restart.
+        _ = try await database.execute(
+            sql: "INSERT INTO ps_data__note (id, data) VALUES (?, json_object('title', 'tras-restart', 'done', 0, 'count', 1))",
+            parameters: ["r1"]
+        )
+        try await Task.sleep(for: .milliseconds(400))
+        let fetched = try ModelContext(container).fetch(FetchDescriptor<Note>())
+        #expect(fetched.first?.title == "tras-restart")
+
+        await observer.stop()
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test(.timeLimit(.minutes(1)))
+    func rapidRemoteBurstsCoalesceAndConverge() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(name: "observer-burst", database: database)
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [configuration]
+        )
+        let observer = PowerSyncChangeObserver(container: container, configuration: configuration)
+        try await observer.start(observing: [Note.self])
+
+        // A burst of remote writes faster than any reconcile cycle.
+        for index in 0 ..< 50 {
+            _ = try await database.execute(
+                sql: "INSERT INTO ps_data__note (id, data) VALUES (?, json_object('title', ?, 'done', 0, 'count', \(index)))",
+                parameters: ["burst-\(index)", "n\(index)"]
+            )
+        }
+
+        // The observer must converge to the final state.
+        var converged = false
+        for _ in 0 ..< 50 {
+            try await Task.sleep(for: .milliseconds(100))
+            let count = try ModelContext(container).fetchCount(FetchDescriptor<Note>())
+            if count == 50 {
+                converged = true
+                break
+            }
+        }
+        #expect(converged)
+
+        await observer.stop()
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/PerformanceTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/PerformanceTests.swift
@@ -1,0 +1,199 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// Lightweight model for date-window benchmarks.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class Entry {
+    var id: String
+    var stamp: Date
+    var value: Double
+
+    init(id: String, stamp: Date, value: Double) {
+        self.id = id
+        self.stamp = stamp
+        self.value = value
+    }
+}
+
+/// Store-level concurrency stress and date-window benchmarks with generous regression
+/// ceilings.
+@Suite("Performance and stress")
+struct PerformanceTests {
+    // MARK: concurrency stress
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test(.timeLimit(.minutes(1)))
+    func concurrentContextsSaveAndFetchWithoutCorruption() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(name: "performance-stress", database: database)
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [configuration]
+        )
+
+        let workers = 16
+        let perWorker = 5
+        DispatchQueue.concurrentPerform(iterations: workers) { worker in
+            let context = ModelContext(container)
+            for index in 0 ..< perWorker {
+                context.insert(Note(
+                    id: "w\(worker)-\(index)",
+                    title: "worker \(worker)",
+                    done: index % 2 == 0,
+                    count: index
+                ))
+            }
+            do {
+                try context.save()
+                _ = try context.fetch(FetchDescriptor<Note>())
+            } catch {
+                Issue.record("worker \(worker) failed: \(error)")
+            }
+        }
+
+        let reader = ModelContext(container)
+        let total = try reader.fetchCount(FetchDescriptor<Note>())
+        #expect(total == workers * perWorker)
+
+        try await database.close()
+    }
+
+    // MARK: benchmarks
+
+    /// Date-window benchmarks over a 1,000,000-row table (1,000 rows/day x 1,000 days).
+    ///
+    /// The dataset is seeded like a sync download — straight into `ps_data__entry` with a
+    /// recursive CTE — because routing a million models through `ModelContext` would
+    /// benchmark SwiftData's context bookkeeping, flood `ps_crud`, and exhaust memory. The
+    /// write path is benchmarked separately with a 10k-insert batch save on top of the
+    /// loaded table. macOS-only: simulators (especially watchOS) are not a meaningful
+    /// performance environment for a million-row dataset.
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test(.timeLimit(.minutes(5)), .enabled(if: ProcessInfo.isMacOS))
+    func dateWindowBenchmarksAtOneMillionRows() async throws {
+        let database = PowerSyncDatabase(
+            schema: PowerSync.Schema(tables: [
+                Table(
+                    name: "entry",
+                    columns: [.real("stamp"), .real("value")],
+                    indexes: [.ascending(name: "stamp", column: "stamp")]
+                ),
+            ]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Entry.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "performance-bench", database: database)]
+        )
+
+        // 1,000 rows per day across 1,000 days, each day's rows spread inside the day:
+        // for row i, day = i % 1000 and the in-day offset is (i / 1000) * 86.4 seconds,
+        // so every window count below is exact.
+        let totalRows = 1_000_000
+        let now = Date(timeIntervalSince1970: 1_770_000_000)
+        let day: TimeInterval = 86_400
+        let clock = ContinuousClock()
+
+        let seedTime = try await clock.measure {
+            _ = try await database.execute(
+                sql: """
+                WITH RECURSIVE seq(i) AS (
+                    SELECT 0 UNION ALL SELECT i + 1 FROM seq WHERE i < \(totalRows - 1)
+                )
+                INSERT INTO ps_data__entry (id, data)
+                SELECT 'e' || i, json_object(
+                    'stamp', \(now.timeIntervalSince1970) - (i % 1000) * 86400.0 - (i / 1000) * 86.4,
+                    'value', i * 1.0
+                )
+                FROM seq
+                """,
+                parameters: []
+            )
+        }
+        let total = try await database.get(sql: "SELECT COUNT(*) FROM entry", parameters: []) {
+            try $0.getInt(index: 0)
+        }
+        #expect(total == totalRows)
+
+        let reader = ModelContext(container)
+
+        // 28-day count: pure SQL through the translated predicate.
+        let window28Start = now.addingTimeInterval(-28 * day)
+        var window28 = 0
+        let countTime = try clock.measure {
+            window28 = try reader.fetchCount(FetchDescriptor<Entry>(
+                predicate: #Predicate { $0.stamp > window28Start }
+            ))
+        }
+        #expect(window28 == 28 * 1000)
+
+        // 60-day window, sorted, first page of 200: the typical UI query.
+        let window60Start = now.addingTimeInterval(-60 * day)
+        var pageDescriptor = FetchDescriptor<Entry>(
+            predicate: #Predicate { $0.stamp > window60Start },
+            sortBy: [SortDescriptor(\.stamp, order: .reverse)]
+        )
+        pageDescriptor.fetchLimit = 200
+        var page: [Entry] = []
+        let pageTime = try clock.measure {
+            page = try reader.fetch(pageDescriptor)
+        }
+        #expect(page.count == 200)
+        #expect(abs(page[0].stamp.timeIntervalSince(now)) < day)
+
+        // Full 60-day window materialized (60,000 models): the heavy honest case.
+        var window60 = 0
+        let windowTime = try clock.measure {
+            window60 = try reader.fetch(FetchDescriptor<Entry>(
+                predicate: #Predicate { $0.stamp > window60Start },
+                sortBy: [SortDescriptor(\.stamp, order: .reverse)]
+            )).count
+        }
+        #expect(window60 == 60 * 1000)
+
+        // Write path on top of the loaded table: 10k inserts in one batch save.
+        let writer = ModelContext(container)
+        let insertTime = try clock.measure {
+            for index in 0 ..< 10_000 {
+                writer.insert(Entry(
+                    id: "new-\(index)",
+                    stamp: now.addingTimeInterval(Double(index)),
+                    value: Double(index)
+                ))
+            }
+            try writer.save()
+        }
+
+        print("""
+        [bench 1M] seed: \(seedTime); 28-day count: \(countTime); \
+        60-day page(200): \(pageTime); 60-day full fetch (60k models): \(windowTime); \
+        10k-insert save: \(insertTime)
+        """)
+
+        // Generous ceilings: these catch pathological regressions, not micro-variance.
+        #expect(seedTime < .seconds(30))
+        #expect(countTime < .seconds(1))
+        #expect(pageTime < .seconds(1))
+        #expect(windowTime < .seconds(10))
+        #expect(insertTime < .seconds(10))
+
+        try await database.close()
+    }
+}
+
+extension ProcessInfo {
+    /// Benchmarks at million-row scale only run on macOS hosts, not simulators.
+    static var isMacOS: Bool {
+        #if os(macOS)
+        true
+        #else
+        false
+        #endif
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/PredicateNullSemanticsTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/PredicateNullSemanticsTests.swift
@@ -1,0 +1,162 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// SQL three-valued logic must not leak into predicate results: `!=` and `NOT` over
+/// optional columns include NULL rows exactly like Swift's optional semantics, UUID
+/// constants match rows synced by lowercase-rendering backends, and `fetchCount` honors
+/// `fetchOffset`. Every behavior is pinned against the in-memory fallback semantics.
+@Suite("Predicate NULL semantics and count")
+struct PredicateNullSemanticsTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    private static func typeMixTranslator() throws -> PredicateTranslator {
+        let mapper = try SchemaMapper(
+            schema: SwiftData.Schema([TypeMix.self]),
+            tableNameForEntity: PowerSyncDataStoreConfiguration.defaultTableName(forEntityName:)
+        )
+        return PredicateTranslator(entity: try mapper.entity(named: "TypeMix"), modelType: TypeMix.self)
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func notEqualOnOptionalColumnIncludesNullRows() throws {
+        let translator = try Self.typeMixTranslator()
+
+        let notEqual = try translator.translateWhere(#Predicate<TypeMix> { $0.subtitle != "x" })
+        #expect(notEqual.clause == "(\"subtitle\" IS NULL OR \"subtitle\" != ?)")
+
+        // Non-optional columns keep the plain form.
+        let nonOptional = try translator.translateWhere(#Predicate<TypeMix> { $0.text != "x" })
+        #expect(nonOptional.clause == "\"text\" != ?")
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func negationOverNullableClauseCoalesces() throws {
+        let translator = try Self.typeMixTranslator()
+
+        let negated = try translator.translateWhere(#Predicate<TypeMix> { !($0.subtitle == "x") })
+        #expect(negated.clause == "NOT (COALESCE((\"subtitle\" = ?), 0))")
+
+        // Negation over a never-NULL clause keeps the plain form.
+        let plain = try translator.translateWhere(#Predicate<TypeMix> { !($0.text == "x") })
+        #expect(plain.clause == "NOT (\"text\" = ?)")
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func sqlResultsMatchInMemorySemanticsForNullRows() async throws {
+        let database = try await TestDatabases.makeTypeMixDatabase()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([TypeMix.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "null-semantics", database: database)]
+        )
+
+        // Three rows: subtitle = "x", subtitle = "y", subtitle = NULL (key absent).
+        for id in ["a", "b", "c"] {
+            _ = try await database.execute(
+                sql: """
+                INSERT INTO ps_data__type_mix (id, data) VALUES (?, json_object(
+                    'text', 't', 'integer', 1, 'integer64', 1, 'integer32', 1, 'flag', 0,
+                    'fraction', 1.0, 'fraction32', 1.0, 'stamp', 1700000000.0,
+                    'payload', 'AQI=', 'token', ?, 'mood', 'sunny', 'level', 1,
+                    'geo', '{"lat":0,"lon":0}'
+                ))
+                """,
+                parameters: [id, UUID().uuidString.lowercased()]
+            )
+        }
+        _ = try await database.execute(
+            sql: "UPDATE ps_data__type_mix SET data = json_set(data, '$.subtitle', ?) WHERE id = 'a'",
+            parameters: ["x"]
+        )
+        _ = try await database.execute(
+            sql: "UPDATE ps_data__type_mix SET data = json_set(data, '$.subtitle', ?) WHERE id = 'b'",
+            parameters: ["y"]
+        )
+
+        let reader = ModelContext(container)
+
+        // Swift semantics: subtitle != "x" is true for "y" AND for nil.
+        let notEqual = try reader.fetch(FetchDescriptor<TypeMix>(
+            predicate: #Predicate { $0.subtitle != "x" }
+        ))
+        #expect(Set(notEqual.map(\.id)) == ["b", "c"])
+
+        // Swift semantics: !(subtitle == "x") is identical.
+        let negated = try reader.fetch(FetchDescriptor<TypeMix>(
+            predicate: #Predicate { !($0.subtitle == "x") }
+        ))
+        #expect(Set(negated.map(\.id)) == ["b", "c"])
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func uuidPredicatesMatchLowercaseBackendRows() async throws {
+        let database = try await TestDatabases.makeTypeMixDatabase()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([TypeMix.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "uuid-lowercase", database: database)]
+        )
+
+        // Backends (Postgres) render uuid in lowercase; simulate a synced row.
+        let token = UUID()
+        _ = try await database.execute(
+            sql: """
+            INSERT INTO ps_data__type_mix (id, data) VALUES (?, json_object(
+                'text', 't', 'integer', 1, 'integer64', 1, 'integer32', 1, 'flag', 0,
+                'fraction', 1.0, 'fraction32', 1.0, 'stamp', 1700000000.0,
+                'payload', 'AQI=', 'token', ?, 'mood', 'sunny', 'level', 1,
+                'geo', '{"lat":0,"lon":0}'
+            ))
+            """,
+            parameters: ["u1", token.uuidString.lowercased()]
+        )
+
+        let reader = ModelContext(container)
+        let matched = try reader.fetch(FetchDescriptor<TypeMix>(
+            predicate: #Predicate { $0.token == token }
+        ))
+        #expect(matched.count == 1)
+        #expect(matched.first?.token == token)
+
+        // And rows written by the store itself are also stored lowercase.
+        let stored = try await database.get(
+            sql: "SELECT token FROM type_mix WHERE id = ?",
+            parameters: ["u1"]
+        ) { try $0.getString(index: 0) }
+        #expect(stored == stored.lowercased())
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func fetchCountHonorsOffsetAndLimit() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "count-offset", database: database)]
+        )
+        let context = ModelContext(container)
+        for index in 0 ..< 10 {
+            context.insert(Note(id: "n\(index)", title: "t", done: false, count: index))
+        }
+        try context.save()
+
+        let reader = ModelContext(container)
+        var descriptor = FetchDescriptor<Note>()
+        descriptor.fetchOffset = 8
+        #expect(try reader.fetchCount(descriptor) == 2)
+
+        descriptor.fetchLimit = 5
+        #expect(try reader.fetchCount(descriptor) == 2)
+
+        descriptor.fetchOffset = 2
+        #expect(try reader.fetchCount(descriptor) == 5)
+
+        descriptor.fetchOffset = 20
+        #expect(try reader.fetchCount(descriptor) == 0)
+
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/PredicateTranslationTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/PredicateTranslationTests.swift
@@ -1,0 +1,241 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// `FetchDescriptor` translation — predicates to SQL WHERE, sort descriptors to
+/// ORDER BY, limit/offset, count and identifiers; in-memory fallback only for nodes the
+/// translator does not support.
+@Suite("Predicate translation")
+struct PredicateTranslationTests {
+    // MARK: translator units
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    private static func noteTranslator() throws -> PredicateTranslator {
+        let mapper = try SchemaMapper(
+            schema: SwiftData.Schema([Note.self]),
+            tableNameForEntity: PowerSyncDataStoreConfiguration.defaultTableName(forEntityName:)
+        )
+        return PredicateTranslator(
+            entity: try mapper.entity(named: "Note"),
+            modelType: Note.self
+        )
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    private static func typeMixTranslator() throws -> PredicateTranslator {
+        let mapper = try SchemaMapper(
+            schema: SwiftData.Schema([TypeMix.self]),
+            tableNameForEntity: PowerSyncDataStoreConfiguration.defaultTableName(forEntityName:)
+        )
+        return PredicateTranslator(
+            entity: try mapper.entity(named: "TypeMix"),
+            modelType: TypeMix.self
+        )
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func translatesEqualAndComparisons() throws {
+        let translator = try Self.noteTranslator()
+
+        let equal = try translator.translateWhere(#Predicate<Note> { $0.title == "hola" })
+        #expect(equal.clause == "\"title\" = ?")
+        #expect(equal.bindings.count == 1)
+        #expect(equal.bindings[0] as? String == "hola")
+
+        let notEqual = try translator.translateWhere(#Predicate<Note> { $0.title != "hola" })
+        #expect(notEqual.clause == "\"title\" != ?")
+
+        let less = try translator.translateWhere(#Predicate<Note> { $0.count < 5 })
+        #expect(less.clause == "\"count\" < ?")
+        #expect(less.bindings[0] as? Int64 == 5)
+
+        let greaterOrEqual = try translator.translateWhere(#Predicate<Note> { $0.count >= 5 })
+        #expect(greaterOrEqual.clause == "\"count\" >= ?")
+
+        let flipped = try translator.translateWhere(#Predicate<Note> { 5 > $0.count })
+        #expect(flipped.clause == "\"count\" < ?")
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func translatesBooleanLogic() throws {
+        let translator = try Self.noteTranslator()
+
+        let direct = try translator.translateWhere(#Predicate<Note> { $0.done })
+        #expect(direct.clause == "\"done\" = 1")
+
+        let negated = try translator.translateWhere(#Predicate<Note> { !$0.done })
+        #expect(negated.clause == "NOT (\"done\" = 1)")
+
+        let conjunction = try translator.translateWhere(#Predicate<Note> { $0.done && $0.count > 2 })
+        #expect(conjunction.clause == "(\"done\" = 1 AND \"count\" > ?)")
+
+        let disjunction = try translator.translateWhere(#Predicate<Note> { $0.done || $0.count > 2 })
+        #expect(disjunction.clause == "(\"done\" = 1 OR \"count\" > ?)")
+
+        let comparedToLiteral = try translator.translateWhere(#Predicate<Note> { $0.done == true })
+        #expect(comparedToLiteral.clause == "\"done\" = ?")
+        #expect(comparedToLiteral.bindings[0] as? Int64 == 1)
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func translatesNilChecksOnOptionals() throws {
+        let translator = try Self.typeMixTranslator()
+
+        let isNil = try translator.translateWhere(#Predicate<TypeMix> { $0.subtitle == nil })
+        #expect(isNil.clause == "\"subtitle\" IS NULL")
+        #expect(isNil.bindings.isEmpty)
+
+        let isNotNil = try translator.translateWhere(#Predicate<TypeMix> { $0.subtitle != nil })
+        #expect(isNotNil.clause == "\"subtitle\" IS NOT NULL")
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func bindsTypedConstantsUsingColumnRepresentation() throws {
+        let translator = try Self.typeMixTranslator()
+
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        let afterDate = try translator.translateWhere(#Predicate<TypeMix> { $0.stamp > date })
+        #expect(afterDate.clause == "\"stamp\" > ?")
+        #expect(afterDate.bindings[0] as? Double == 1_700_000_000)
+
+        let mood = Mood.stormy
+        let moodEqual = try translator.translateWhere(#Predicate<TypeMix> { $0.mood == mood })
+        #expect(moodEqual.clause == "\"mood\" = ?")
+        #expect(moodEqual.bindings[0] as? String == "stormy")
+
+        let token = UUID()
+        let tokenEqual = try translator.translateWhere(#Predicate<TypeMix> { $0.token == token })
+        #expect(tokenEqual.clause == "\"token\" = ?")
+        #expect(tokenEqual.bindings[0] as? String == token.uuidString.lowercased())
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func translatesCollectionAndRangeMembership() throws {
+        let translator = try Self.noteTranslator()
+
+        let values = [1, 2, 3]
+        let inList = try translator.translateWhere(#Predicate<Note> { values.contains($0.count) })
+        #expect(inList.clause == "\"count\" IN (?, ?, ?)")
+        #expect(inList.bindings.compactMap { $0 as? Int64 } == [1, 2, 3])
+
+        let closed = 1 ... 5
+        let between = try translator.translateWhere(#Predicate<Note> { closed.contains($0.count) })
+        #expect(between.clause == "\"count\" BETWEEN ? AND ?")
+
+        let halfOpen = 1 ..< 5
+        let range = try translator.translateWhere(#Predicate<Note> { halfOpen.contains($0.count) })
+        #expect(range.clause == "(\"count\" >= ? AND \"count\" < ?)")
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func translatesStringOperators() throws {
+        let translator = try Self.noteTranslator()
+
+        let prefix = try translator.translateWhere(#Predicate<Note> { $0.title.starts(with: "ho") })
+        #expect(prefix.clause == "\"title\" LIKE ? ESCAPE '\\'")
+        #expect(prefix.bindings[0] as? String == "ho%")
+
+        let contains = try translator.translateWhere(#Predicate<Note> { $0.title.contains("100%") })
+        #expect(contains.clause == "\"title\" LIKE ? ESCAPE '\\'")
+        #expect(contains.bindings[0] as? String == "%100\\%%")
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func unsupportedNodesPreferInMemoryFiltering() throws {
+        let translator = try Self.noteTranslator()
+
+        #expect(throws: DataStoreError.preferInMemoryFilter) {
+            _ = try translator.translateWhere(
+                #Predicate<Note> { $0.title.localizedStandardContains("hola") }
+            )
+        }
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func translatesSortDescriptors() throws {
+        let translator = try Self.noteTranslator()
+
+        let numeric = try translator.translateOrderBy([SortDescriptor(\Note.count, order: .reverse)])
+        #expect(numeric == "\"count\" DESC")
+
+        let mixed = try translator.translateOrderBy([
+            SortDescriptor(\Note.title),
+            SortDescriptor(\Note.count, order: .reverse),
+        ])
+        #expect(mixed == "\"title\" COLLATE NOCASE ASC, \"count\" DESC")
+    }
+
+    // MARK: integration through ModelContext
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    private static func seededContainer(
+        name: String,
+        database: any PowerSyncDatabaseProtocol
+    ) throws -> ModelContainer {
+        let configuration = PowerSyncDataStoreConfiguration(name: name, database: database)
+        return try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [configuration]
+        )
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func filteredSortedFetchThroughModelContext() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let container = try Self.seededContainer(name: "predicates-fetch", database: database)
+
+        let context = ModelContext(container)
+        for (index, title) in ["alfa", "bravo", "carlos", "delta"].enumerated() {
+            context.insert(Note(id: "n\(index)", title: title, done: index % 2 == 0, count: index))
+        }
+        try context.save()
+
+        var descriptor = FetchDescriptor<Note>(
+            predicate: #Predicate { $0.count >= 1 },
+            sortBy: [SortDescriptor(\.count, order: .reverse)]
+        )
+        let reader = ModelContext(container)
+        let filtered = try reader.fetch(descriptor)
+        #expect(filtered.map(\.title) == ["delta", "carlos", "bravo"])
+
+        descriptor.fetchLimit = 2
+        descriptor.fetchOffset = 1
+        let page = try reader.fetch(descriptor)
+        #expect(page.map(\.title) == ["carlos", "bravo"])
+
+        // An untranslatable predicate must still produce correct results through
+        // SwiftData's in-memory fallback.
+        let fallback = try reader.fetch(FetchDescriptor<Note>(
+            predicate: #Predicate { $0.title.localizedStandardContains("AR") }
+        ))
+        #expect(Set(fallback.map(\.title)) == ["carlos"])
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func fetchCountAndIdentifiersUseSQL() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let container = try Self.seededContainer(name: "predicates-count", database: database)
+
+        let context = ModelContext(container)
+        for index in 0 ..< 5 {
+            context.insert(Note(id: "n\(index)", title: "t\(index)", done: index % 2 == 0, count: index))
+        }
+        try context.save()
+
+        let reader = ModelContext(container)
+        let count = try reader.fetchCount(FetchDescriptor<Note>(predicate: #Predicate { $0.count >= 2 }))
+        #expect(count == 3)
+
+        let identifiers = try reader.fetchIdentifiers(FetchDescriptor<Note>(
+            predicate: #Predicate { $0.done }
+        ))
+        #expect(identifiers.count == 3)
+        #expect(Set(identifiers.map(\.entityName)) == ["Note"])
+
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/ReactivityTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/ReactivityTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// Remote PowerSync changes (sync downloads) are re-injected into a
+/// background `ModelContext` so SwiftData broadcasts them (`ModelContext.didSave`) and
+/// `@Query` re-runs its fetch; the re-injection itself is echo-suppressed and never lands
+/// back in the `ps_crud` upload queue.
+@Suite("Reactivity")
+struct ReactivityTests {
+    /// Waits for a `ModelContext.didSave` notification from the observer's remote-author
+    /// context that carries an identifier matching `key`, or fails after `timeout`.
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    private static func nextRemoteSave(
+        carrying key: ModelContext.NotificationKey,
+        timeout: Duration = .seconds(5)
+    ) async throws -> [PersistentIdentifier] {
+        let rawKey = key.rawValue
+        return try await withThrowingTaskGroup(of: [PersistentIdentifier].self) { group in
+            group.addTask {
+                for await notification in NotificationCenter.default.notifications(named: ModelContext.didSave) {
+                    let author = (notification.object as? ModelContext)?.author
+                    guard author == "powersync-remote" else { continue }
+                    if let identifiers = notification.userInfo?[rawKey] as? [PersistentIdentifier],
+                       !identifiers.isEmpty {
+                        return identifiers
+                    }
+                }
+                throw PowerSyncSwiftDataError.unimplemented("notification stream ended")
+            }
+            group.addTask {
+                try await Task.sleep(for: timeout)
+                throw PowerSyncSwiftDataError.unimplemented("timed out waiting for remote didSave")
+            }
+            guard let result = try await group.next() else {
+                throw PowerSyncSwiftDataError.unimplemented("no result")
+            }
+            group.cancelAll()
+            return result
+        }
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func remoteInsertIsBroadcastAndNotEchoed() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(name: "reactivity-insert", database: database)
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [configuration]
+        )
+        let observer = PowerSyncChangeObserver(container: container, configuration: configuration)
+        try await observer.start(observing: [Note.self])
+
+        // Simulate a sync download: a row appears in PowerSync without going through
+        // SwiftData.
+        async let saved = Self.nextRemoteSave(carrying: .insertedIdentifiers)
+        try await Task.sleep(for: .milliseconds(100))
+        let id = UUID().uuidString.lowercased()
+        // Writing to the internal ps_data__ table (not the view) is what a sync download
+        // does: no INSTEAD OF trigger runs, so nothing is captured into ps_crud.
+        _ = try await database.execute(
+            sql: "INSERT INTO ps_data__note (id, data) VALUES (?, json_object('title', ?, 'done', 0, 'count', 7))",
+            parameters: [id, "remota"]
+        )
+
+        let inserted = try await saved
+        #expect(inserted.contains { $0.entityName == "Note" })
+
+        // The re-injection must not produce upload queue entries.
+        let crud = try await database.getNextCrudTransaction()
+        #expect(crud == nil)
+
+        // And a user context sees the new row.
+        let fetched = try ModelContext(container).fetch(FetchDescriptor<Note>())
+        #expect(fetched.count == 1)
+        #expect(fetched.first?.title == "remota")
+        #expect(fetched.first?.id == id)
+
+        await observer.stop()
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func remoteUpdateIsBroadcastAndNotEchoed() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(name: "reactivity-update", database: database)
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [configuration]
+        )
+
+        // Local seed through SwiftData, upload entry completed.
+        let id = UUID().uuidString.lowercased()
+        let context = ModelContext(container)
+        context.insert(Note(id: id, title: "local", done: false, count: 1))
+        try context.save()
+        try await #require(try await database.getNextCrudTransaction()).complete()
+
+        let observer = PowerSyncChangeObserver(container: container, configuration: configuration)
+        try await observer.start(observing: [Note.self])
+
+        async let saved = Self.nextRemoteSave(carrying: .updatedIdentifiers)
+        try await Task.sleep(for: .milliseconds(100))
+        _ = try await database.execute(
+            sql: "UPDATE ps_data__note SET data = json_set(data, '$.title', ?, '$.count', 9) WHERE id = ?",
+            parameters: ["remota", id]
+        )
+
+        let updated = try await saved
+        #expect(updated.contains { $0.entityName == "Note" })
+
+        let crud = try await database.getNextCrudTransaction()
+        #expect(crud == nil)
+
+        let fetched = try ModelContext(container).fetch(FetchDescriptor<Note>())
+        #expect(fetched.first?.title == "remota")
+        #expect(fetched.first?.count == 9)
+
+        await observer.stop()
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func remoteDeleteIsBroadcastAndNotEchoed() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(name: "reactivity-delete", database: database)
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [configuration]
+        )
+
+        let id = UUID().uuidString.lowercased()
+        let context = ModelContext(container)
+        context.insert(Note(id: id, title: "local", done: false, count: 1))
+        try context.save()
+        try await #require(try await database.getNextCrudTransaction()).complete()
+
+        let observer = PowerSyncChangeObserver(container: container, configuration: configuration)
+        try await observer.start(observing: [Note.self])
+
+        async let saved = Self.nextRemoteSave(carrying: .deletedIdentifiers)
+        try await Task.sleep(for: .milliseconds(100))
+        _ = try await database.execute(sql: "DELETE FROM ps_data__note WHERE id = ?", parameters: [id])
+
+        let deleted = try await saved
+        #expect(deleted.contains { $0.entityName == "Note" })
+
+        let crud = try await database.getNextCrudTransaction()
+        #expect(crud == nil)
+
+        let fetched = try ModelContext(container).fetch(FetchDescriptor<Note>())
+        #expect(fetched.isEmpty)
+
+        await observer.stop()
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func localSavesDoNotLoopThroughTheObserver() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(name: "reactivity-noloop", database: database)
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [configuration]
+        )
+        let observer = PowerSyncChangeObserver(container: container, configuration: configuration)
+        try await observer.start(observing: [Note.self])
+
+        // A local save triggers the watch (the table changed), and the observer's
+        // reconciliation may broadcast it; but it must not generate additional uploads
+        // or rewrite rows.
+        let id = UUID().uuidString.lowercased()
+        let context = ModelContext(container)
+        context.insert(Note(id: id, title: "local", done: false, count: 1))
+        try context.save()
+
+        let transaction = try #require(try await database.getNextCrudTransaction())
+        #expect(transaction.crud.count == 1)
+        try await transaction.complete()
+
+        // Allow a few watch throttle windows for any (buggy) echo writes to surface.
+        try await Task.sleep(for: .milliseconds(400))
+        let crud = try await database.getNextCrudTransaction()
+        #expect(crud == nil)
+
+        await observer.stop()
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/ReadOnlyStoreTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/ReadOnlyStoreTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// The read-only path for app extensions and widgets. The same store fetches
+/// normally but refuses writes, so a widget can render synced data without competing for
+/// the upload queue or risking suspension mid-write.
+@Suite("Read-only store")
+struct ReadOnlyStoreTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func readOnlyStoreFetchesButRefusesWrites() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let configuration = PowerSyncDataStoreConfiguration(
+            name: "readonly-store",
+            database: database,
+            readOnly: true
+        )
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [configuration]
+        )
+
+        // Data that arrived via sync.
+        _ = try await database.execute(
+            sql: "INSERT INTO ps_data__note (id, data) VALUES (?, json_object('title', ?, 'done', 1, 'count', 4))",
+            parameters: ["w1", "widget"]
+        )
+
+        let context = ModelContext(container)
+        let fetched = try context.fetch(FetchDescriptor<Note>())
+        #expect(fetched.count == 1)
+        #expect(fetched.first?.title == "widget")
+
+        // Writes are refused and nothing reaches the upload queue.
+        context.insert(Note(id: "w2", title: "nope", done: false, count: 0))
+        #expect(throws: (any Error).self) {
+            try context.save()
+        }
+        let crud = try await database.getNextCrudTransaction()
+        #expect(crud == nil)
+
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/RelationshipTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/RelationshipTests.swift
@@ -1,0 +1,205 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// Relationships: to-one is stored as a `{name}_id` column; to-many is resolved
+/// through the inverse to-one; identifier remapping covers related models inserted in the
+/// same save; many-to-many without an explicit join model is rejected with guidance.
+@Suite("Relationships")
+struct RelationshipTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    private static func makeContainer(
+        name: String,
+        database: any PowerSyncDatabaseProtocol
+    ) throws -> ModelContainer {
+        try ModelContainer(
+            for: SwiftData.Schema([Playlist.self, Song.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: name, database: database)]
+        )
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func toOneRelationshipMapsToForeignKeyColumn() throws {
+        let mapper = try SchemaMapper(
+            schema: SwiftData.Schema([Playlist.self, Song.self]),
+            tableNameForEntity: PowerSyncDataStoreConfiguration.defaultTableName(forEntityName:)
+        )
+        let song = try mapper.entity(named: "Song")
+        let relationship = try #require(song.toOne.first)
+        #expect(relationship.name == "playlist")
+        #expect(relationship.columnName == "playlist_id")
+        #expect(relationship.destinationEntityName == "Playlist")
+
+        let playlist = try mapper.entity(named: "Playlist")
+        let toMany = try #require(playlist.toMany.first)
+        #expect(toMany.name == "songs")
+        #expect(toMany.destinationEntityName == "Song")
+        #expect(toMany.inverseColumnName == "playlist_id")
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func manyToManyWithoutJoinModelIsRejected() {
+        #expect(throws: PowerSyncSwiftDataError.self) {
+            _ = try SchemaMapper(
+                schema: SwiftData.Schema([Conference.self, Speaker.self]),
+                tableNameForEntity: PowerSyncDataStoreConfiguration.defaultTableName(forEntityName:)
+            )
+        }
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func toOneRoundTripsIncludingSameSaveInserts() async throws {
+        let database = try await TestDatabases.makeMusicDatabase()
+        let container = try Self.makeContainer(name: "relationships-toone", database: database)
+
+        // Parent and child inserted in the SAME save: the child references the parent's
+        // temporary identifier and the store's remapping must rewrite it.
+        let context = ModelContext(container)
+        let playlist = Playlist(id: "pl1", name: "Road trip")
+        let song = Song(id: "s1", title: "Highway", playlist: playlist)
+        context.insert(playlist)
+        context.insert(song)
+        try context.save()
+
+        let transaction = try #require(try await database.getNextCrudTransaction())
+        let byTable = Dictionary(grouping: transaction.crud, by: \.table)
+        #expect(byTable["playlist"]?.count == 1)
+        #expect(byTable["song"]?.count == 1)
+        let songEntry = try #require(byTable["song"]?.first)
+        #expect(songEntry.opData?["playlist_id"] == "pl1")
+        try await transaction.complete()
+
+        // Faulting from a fresh context: the song materializes its playlist through the
+        // store (by identifier), and the playlist sees its songs through the inverse.
+        let reader = ModelContext(container)
+        let fetchedSong = try #require(try reader.fetch(FetchDescriptor<Song>()).first)
+        #expect(fetchedSong.title == "Highway")
+        #expect(fetchedSong.playlist?.id == "pl1")
+        #expect(fetchedSong.playlist?.name == "Road trip")
+
+        let fetchedPlaylist = try #require(try reader.fetch(FetchDescriptor<Playlist>()).first)
+        #expect(fetchedPlaylist.songs.count == 1)
+        #expect(fetchedPlaylist.songs.first?.id == "s1")
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func nullifyingToOnePersistsNull() async throws {
+        let database = try await TestDatabases.makeMusicDatabase()
+        let container = try Self.makeContainer(name: "relationships-nullify", database: database)
+
+        let context = ModelContext(container)
+        let playlist = Playlist(id: "pl1", name: "Road trip")
+        let song = Song(id: "s1", title: "Highway", playlist: playlist)
+        context.insert(playlist)
+        context.insert(song)
+        try context.save()
+        try await #require(try await database.getNextCrudTransaction()).complete()
+
+        song.playlist = nil
+        try context.save()
+
+        let patch = try #require(try await database.getNextCrudTransaction())
+        let entry = try #require(patch.crud.first { $0.table == "song" })
+        #expect(entry.op == .patch)
+        if let stored = entry.opData?["playlist_id"] {
+            #expect(stored == nil)
+        }
+        try await patch.complete()
+
+        let reader = ModelContext(container)
+        let fetched = try #require(try reader.fetch(FetchDescriptor<Song>()).first)
+        #expect(fetched.playlist == nil)
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func cascadeDeleteRemovesChildren() async throws {
+        let database = try await TestDatabases.makeMusicDatabase()
+        let container = try Self.makeContainer(name: "relationships-cascade", database: database)
+
+        let context = ModelContext(container)
+        let playlist = Playlist(id: "pl1", name: "Road trip")
+        context.insert(playlist)
+        context.insert(Song(id: "s1", title: "Highway", playlist: playlist))
+        context.insert(Song(id: "s2", title: "Byway", playlist: playlist))
+        try context.save()
+        try await #require(try await database.getNextCrudTransaction()).complete()
+
+        context.delete(playlist)
+        try context.save()
+
+        let deletion = try #require(try await database.getNextCrudTransaction())
+        let deletes = deletion.crud.filter { $0.op == .delete }
+        #expect(Set(deletes.map(\.table)) == ["playlist", "song"])
+        #expect(deletes.count == 3)
+
+        let reader = ModelContext(container)
+        #expect(try reader.fetch(FetchDescriptor<Song>()).isEmpty)
+        #expect(try reader.fetch(FetchDescriptor<Playlist>()).isEmpty)
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func translatesIdentifierAndRelationshipPredicates() async throws {
+        let database = try await TestDatabases.makeMusicDatabase()
+        let container = try Self.makeContainer(name: "relationships-predicates", database: database)
+
+        let context = ModelContext(container)
+        let roadTrip = Playlist(id: "pl1", name: "Road trip")
+        let chill = Playlist(id: "pl2", name: "Chill")
+        context.insert(roadTrip)
+        context.insert(chill)
+        context.insert(Song(id: "s1", title: "Highway", playlist: roadTrip))
+        context.insert(Song(id: "s2", title: "Lo-fi", playlist: chill))
+        context.insert(Song(id: "s3", title: "Byway", playlist: roadTrip))
+        try context.save()
+
+        let mapper = try SchemaMapper(
+            schema: SwiftData.Schema([Playlist.self, Song.self]),
+            tableNameForEntity: PowerSyncDataStoreConfiguration.defaultTableName(forEntityName:)
+        )
+        let translator = PredicateTranslator(
+            entity: try mapper.entity(named: "Song"),
+            modelType: Song.self
+        )
+
+        // persistentModelID equality binds the PowerSync primary key. Note: the song's
+        // OWN identifier compares against the id column; this test uses a song pid.
+        let songPid = try #require(try context.fetch(
+            FetchDescriptor<Song>(predicate: #Predicate { $0.id == "s1" })
+        ).first).persistentModelID
+        let byIdentifier = try translator.translateWhere(#Predicate<Song> { song in
+            song.persistentModelID == songPid
+        })
+        #expect(byIdentifier.clause == "\"id\" = ?")
+        #expect(byIdentifier.bindings[0] as? String == "s1")
+
+        // Identifier membership (the shape SwiftData uses when faulting by identifiers).
+        let pids: Set<PersistentIdentifier> = [songPid]
+        let byMembership = try translator.translateWhere(#Predicate<Song> { song in
+            pids.contains(song.persistentModelID)
+        })
+        #expect(byMembership.clause == "\"id\" IN (?)")
+        #expect(byMembership.bindings[0] as? String == "s1")
+
+        // Filtering by a related row's id through optional chaining translates to the
+        // foreign-key column directly (see ChainedPredicateTests for the full matrix).
+        let chained = try translator.translateWhere(#Predicate<Song> { song in
+            song.playlist?.id == "pl1"
+        })
+        #expect(chained.clause == "\"playlist_id\" = ?")
+        let reader = ModelContext(container)
+        let songs = try reader.fetch(FetchDescriptor<Song>(predicate: #Predicate { song in
+            song.playlist?.id == "pl1"
+        }))
+        #expect(Set(songs.map(\.id)) == ["s1", "s3"])
+
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/SDKDriftGuardTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/SDKDriftGuardTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// Pins the private SwiftData surfaces the integration relies on, so an SDK update that
+/// changes them fails loudly here instead of producing silent data loss.
+@Suite("SDK drift guards")
+struct SDKDriftGuardTests {
+    /// The only reliable source of attribute key paths is reflecting
+    /// `PersistentModel.schemaMetadata` with the child labels `name`/`keypath`. If an SDK
+    /// update renames them, this fails with a precise message instead of empty snapshots.
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func schemaMetadataMirrorShapeIsStable() throws {
+        let metadata = Note.schemaMetadata
+        #expect(!metadata.isEmpty)
+        for property in metadata {
+            let labels = Set(Mirror(reflecting: property).children.compactMap(\.label))
+            #expect(
+                labels.contains("name") && labels.contains("keypath"),
+                "Schema.PropertyMetadata children renamed (\(labels)); ModelPropertyReflection must be updated"
+            )
+        }
+        let reflected = ModelPropertyReflection.properties(for: Note.self)
+        #expect(Set(reflected.map(\.name)) == ["id", "title", "done", "count"])
+    }
+
+    /// `PersistentIdentifier` is decoded through its private Codable envelope
+    /// (`implementation.primaryKey`) to recover the PowerSync id. If the encoding changes,
+    /// this fails before anything else does.
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func persistentIdentifierEnvelopeIsStable() throws {
+        let identifier = try PersistentIdentifier.identifier(
+            for: "drift-guard",
+            entityName: "Note",
+            primaryKey: "abc-123"
+        )
+        #expect(try identifier.powerSyncPrimaryKey() == "abc-123")
+        #expect(identifier.entityName == "Note")
+        #expect(identifier.storeIdentifier == "drift-guard")
+    }
+
+    /// The snapshot encodes values under `DataStoreSnapshotCodingKey.modeledProperty`;
+    /// SwiftData's model decoder matches them by property name through `stringValue`.
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func modeledPropertyCodingKeyRoundTrips() throws {
+        let key = DataStoreSnapshotCodingKey.modeledProperty("title")
+        let reconstructed = DataStoreSnapshotCodingKey(stringValue: key.stringValue)
+        guard case let .modeledProperty(name) = reconstructed else {
+            Issue.record("stringValue \(key.stringValue) no longer reconstructs a modeledProperty key")
+            return
+        }
+        #expect(name == "title")
+    }
+
+    // MARK: runtime drift defenses
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func mintCacheResolvesPrimaryKeysWithoutTheEnvelope() throws {
+        let before = PrimaryKeyResolver._testCacheCount
+        let identifier = try PrimaryKeyResolver.mint(
+            store: "drift-cache",
+            entityName: "Note",
+            primaryKey: "pk-123"
+        )
+        #expect(try PrimaryKeyResolver.primaryKey(of: identifier) == "pk-123")
+        #expect(PrimaryKeyResolver._testCacheCount > before)
+    }
+
+    /// Simulated reflection drift on a dedicated model: the first fetch fails with a
+    /// descriptive error instead of materializing garbage, and a save of an extracted-empty
+    /// snapshot fails instead of persisting empty rows.
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func simulatedReflectionDriftFailsDescriptively() async throws {
+        let database = PowerSyncDatabase(
+            schema: try PowerSyncSchema(for: [DriftProbe.self]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([DriftProbe.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "drift-probe", database: database)]
+        )
+
+        ModelPropertyReflection._testSuppressMirrorKeyPaths(for: DriftProbe.self, true)
+        defer {
+            ModelPropertyReflection._testSuppressMirrorKeyPaths(for: DriftProbe.self, false)
+            ReflectionHealth._testReset()
+        }
+
+        // Read path: descriptive failure on first fetch.
+        do {
+            _ = try ModelContext(container).fetch(FetchDescriptor<DriftProbe>())
+            Issue.record("fetch should fail under reflection drift")
+        } catch {
+            #expect(String(describing: error).contains("key paths"))
+        }
+
+        // Write path: the snapshot extracts empty, and save() refuses to persist it.
+        let writer = ModelContext(container)
+        writer.insert(DriftProbe(id: "d1", value: 1))
+        #expect(throws: (any Error).self) {
+            try writer.save()
+        }
+        let stored = try await database.get(
+            sql: "SELECT COUNT(*) FROM drift_probe",
+            parameters: []
+        ) { try $0.getInt(index: 0) }
+        #expect(stored == 0)
+
+        try await database.close()
+    }
+
+    /// A model that provides its key paths through PUBLIC API keeps working even when
+    /// mirrored key paths are gone.
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func publiclyProvidedKeyPathsSurviveReflectionDrift() async throws {
+        let database = PowerSyncDatabase(
+            schema: try PowerSyncSchema(for: [DriftSafe.self]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([DriftSafe.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "drift-safe", database: database)]
+        )
+
+        ModelPropertyReflection._testSuppressMirrorKeyPaths(for: DriftSafe.self, true)
+        defer { ModelPropertyReflection._testSuppressMirrorKeyPaths(for: DriftSafe.self, false) }
+
+        let context = ModelContext(container)
+        context.insert(DriftSafe(id: "s1", label: "publica"))
+        try context.save()
+        let fetched = try ModelContext(container).fetch(FetchDescriptor<DriftSafe>())
+        #expect(fetched.first?.label == "publica")
+
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/SaveSemanticsTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/SaveSemanticsTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// Save-request semantics: statement ordering supports the delete+insert "replace by id"
+/// pattern in one save, and the id of a saved model is immutable (the row is addressed by
+/// its persistent identifier, and mutating the property fails loudly instead of silently
+/// targeting nothing).
+@Suite("Save semantics")
+struct SaveSemanticsTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func deleteAndInsertWithSameIdInOneSaveReplacesTheRow() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "save-replace", database: database)]
+        )
+
+        let context = ModelContext(container)
+        let original = Note(id: "x", title: "vieja", done: false, count: 1)
+        context.insert(original)
+        try context.save()
+        try await #require(try await database.getNextCrudTransaction()).complete()
+
+        // Replace: delete the old model and insert a new one with the SAME id in one save.
+        context.delete(original)
+        context.insert(Note(id: "x", title: "nueva", done: true, count: 2))
+        try context.save()
+
+        let reader = ModelContext(container)
+        let fetched = try reader.fetch(FetchDescriptor<Note>())
+        #expect(fetched.count == 1)
+        #expect(fetched.first?.id == "x")
+        #expect(fetched.first?.title == "nueva")
+
+        // The upload queue saw the delete BEFORE the insert.
+        let transaction = try #require(try await database.getNextCrudTransaction())
+        let ops = transaction.crud.filter { $0.id == "x" }.map(\.op)
+        #expect(ops == [.delete, .put])
+
+        try await database.close()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func mutatingTheIdOfASavedModelFailsLoudly() async throws {
+        let database = try await TestDatabases.makeNoteDatabase()
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Note.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "save-id-mutation", database: database)]
+        )
+
+        let context = ModelContext(container)
+        let note = Note(id: "original", title: "t", done: false, count: 0)
+        context.insert(note)
+        try context.save()
+
+        note.id = "renamed"
+        note.title = "cambiada"
+        #expect(throws: (any Error).self) {
+            try context.save()
+        }
+
+        // The stored row is untouched under its original id.
+        let stored = try await database.get(
+            sql: "SELECT title FROM note WHERE id = ?",
+            parameters: ["original"]
+        ) { try $0.getString(index: 0) }
+        #expect(stored == "t")
+
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/SchemaBuilderTests.swift
+++ b/Tests/PowerSyncSwiftDataTests/SchemaBuilderTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import PowerSync
+@testable import PowerSyncSwiftData
+import SwiftData
+import Testing
+
+/// The PowerSync schema is derived from the SwiftData models, so applications
+/// declare their `@Model`s once instead of duplicating tables and columns.
+@Suite("Schema builder")
+struct SchemaBuilderTests {
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func derivesTablesColumnsAndForeignKeyIndexes() throws {
+        let schema = try PowerSyncSchema(for: [Playlist.self, Song.self, TypeMix.self])
+
+        let tables = Dictionary(uniqueKeysWithValues: schema.tables.map { ($0.name, $0) })
+        #expect(Set(tables.keys) == ["playlist", "song", "type_mix"])
+
+        let song = try #require(tables["song"])
+        let songColumns = Dictionary(uniqueKeysWithValues: song.columns.map { ($0.name, $0.type) })
+        #expect(songColumns["title"] == .text)
+        #expect(songColumns["playlist_id"] == .text)
+        // The implicit PowerSync id column must never be declared.
+        #expect(songColumns["id"] == nil)
+        // Foreign keys get an index for the inverse to-many resolution.
+        #expect(song.indexes.contains { $0.name == "playlist_id" })
+
+        let typeMix = try #require(tables["type_mix"])
+        let columns = Dictionary(uniqueKeysWithValues: typeMix.columns.map { ($0.name, $0.type) })
+        #expect(columns["text"] == .text)
+        #expect(columns["integer"] == .integer)
+        #expect(columns["flag"] == .integer)
+        #expect(columns["fraction"] == .real)
+        #expect(columns["stamp"] == .real)
+        #expect(columns["payload"] == .text)
+        #expect(columns["token"] == .text)
+        #expect(columns["mood"] == .text)
+        #expect(columns["level"] == .integer)
+        #expect(columns["geo"] == .text)
+        #expect(columns["subtitle"] == .text)
+        #expect(columns["optionalStamp"] == .real)
+
+        try schema.validate()
+    }
+
+    @available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+    @Test func builtSchemaRoundTripsThroughTheStore() async throws {
+        let database = PowerSyncDatabase(
+            schema: try PowerSyncSchema(for: [Playlist.self, Song.self]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+
+        let container = try ModelContainer(
+            for: SwiftData.Schema([Playlist.self, Song.self]),
+            configurations: [PowerSyncDataStoreConfiguration(name: "schema-builder-roundtrip", database: database)]
+        )
+        let context = ModelContext(container)
+        let playlist = Playlist(id: "pl1", name: "Derivada")
+        context.insert(playlist)
+        context.insert(Song(id: "s1", title: "Uno", playlist: playlist))
+        try context.save()
+
+        let reader = ModelContext(container)
+        let fetched = try #require(try reader.fetch(FetchDescriptor<Playlist>()).first)
+        #expect(fetched.songs.count == 1)
+
+        try await database.close()
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/Support/EphemeralNote.swift
+++ b/Tests/PowerSyncSwiftDataTests/Support/EphemeralNote.swift
@@ -1,0 +1,18 @@
+import Foundation
+import SwiftData
+
+/// A model with an ephemeral (transient) attribute that must never reach PowerSync.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class EphemeralNote {
+    var id: String
+    var title: String
+    @Attribute(.ephemeral)
+    var draft: String = ""
+
+    init(id: String, title: String, draft: String = "") {
+        self.id = id
+        self.title = title
+        self.draft = draft
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/Support/JoinModels.swift
+++ b/Tests/PowerSyncSwiftDataTests/Support/JoinModels.swift
@@ -1,0 +1,60 @@
+import Foundation
+import SwiftData
+
+/// Self-referential to-one used to exercise a true reference cycle in one save.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class Twin {
+    var id: String
+    var name: String
+    var partner: Twin?
+
+    init(id: String, name: String, partner: Twin? = nil) {
+        self.id = id
+        self.name = name
+        self.partner = partner
+    }
+}
+
+/// Many-to-many modeled the supported way: an explicit join @Model with two to-ones.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class Student {
+    var id: String
+    var name: String
+    @Relationship(deleteRule: .cascade, inverse: \Enrollment.student)
+    var enrollments: [Enrollment] = []
+
+    init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class Course {
+    var id: String
+    var title: String
+    @Relationship(deleteRule: .cascade, inverse: \Enrollment.course)
+    var enrollments: [Enrollment] = []
+
+    init(id: String, title: String) {
+        self.id = id
+        self.title = title
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class Enrollment {
+    var id: String
+    var student: Student?
+    var course: Course?
+
+    init(id: String, student: Student? = nil, course: Course? = nil) {
+        self.id = id
+        self.student = student
+        self.course = course
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/Support/MigrationModels.swift
+++ b/Tests/PowerSyncSwiftDataTests/Support/MigrationModels.swift
@@ -1,0 +1,37 @@
+import Foundation
+import SwiftData
+
+/// Simulates a model that gained a required-with-default property after rows existed.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class Migrated {
+    var id: String
+    var name: String
+    var rating: Int = 5
+
+    init(id: String, name: String, rating: Int = 5) {
+        self.id = id
+        self.name = name
+        self.rating = rating
+    }
+}
+
+/// A model with a required property and no default, to pin the failure mode when stored
+/// rows predate the property.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class Strict {
+    var id: String
+    var score: Int
+
+    init(id: String, score: Int) {
+        self.id = id
+        self.score = score
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+enum NoopMigrationPlan: SchemaMigrationPlan {
+    static var schemas: [any VersionedSchema.Type] { [] }
+    static var stages: [MigrationStage] { [] }
+}

--- a/Tests/PowerSyncSwiftDataTests/Support/RelationshipModels.swift
+++ b/Tests/PowerSyncSwiftDataTests/Support/RelationshipModels.swift
@@ -1,0 +1,60 @@
+import Foundation
+import SwiftData
+
+/// Parent side of a classic to-one/to-many pair.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class Playlist {
+    var id: String
+    var name: String
+    @Relationship(deleteRule: .cascade, inverse: \Song.playlist)
+    var songs: [Song] = []
+
+    init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class Song {
+    var id: String
+    var title: String
+    var playlist: Playlist?
+
+    init(id: String, title: String, playlist: Playlist? = nil) {
+        self.id = id
+        self.title = title
+        self.playlist = playlist
+    }
+}
+
+/// A many-to-many pair WITHOUT an explicit join model — unsupported by design (the join
+/// table must exist as a synced PowerSync table anyway).
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class Conference {
+    var id: String
+    var name: String
+    @Relationship(inverse: \Speaker.conferences)
+    var speakers: [Speaker] = []
+
+    init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class Speaker {
+    var id: String
+    var name: String
+    var conferences: [Conference] = []
+
+    init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/Support/TestDatabases.swift
+++ b/Tests/PowerSyncSwiftDataTests/Support/TestDatabases.swift
@@ -1,0 +1,79 @@
+import Foundation
+import PowerSync
+
+/// In-memory PowerSync databases for the test models.
+enum TestDatabases {
+    /// Table for ``Note``.
+    static func makeNoteDatabase() async throws -> any PowerSyncDatabaseProtocol {
+        let database = PowerSyncDatabase(
+            schema: PowerSync.Schema(tables: [
+                Table(
+                    name: "note",
+                    columns: [
+                        .text("title"),
+                        .integer("done"),
+                        .integer("count"),
+                    ]
+                ),
+            ]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+        return database
+    }
+
+    /// Table for ``TypeMix`` (every supported attribute type).
+    static func makeTypeMixDatabase() async throws -> any PowerSyncDatabaseProtocol {
+        let database = PowerSyncDatabase(
+            schema: PowerSync.Schema(tables: [
+                Table(
+                    name: "type_mix",
+                    columns: [
+                        .text("text"),
+                        .integer("integer"),
+                        .integer("integer64"),
+                        .integer("integer32"),
+                        .integer("flag"),
+                        .real("fraction"),
+                        .real("fraction32"),
+                        .real("stamp"),
+                        .text("payload"),
+                        .text("token"),
+                        .text("mood"),
+                        .integer("level"),
+                        .text("geo"),
+                        .text("subtitle"),
+                        .integer("optionalNumber"),
+                        .real("optionalStamp"),
+                        .text("optionalPayload"),
+                    ]
+                ),
+            ]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+        return database
+    }
+
+    /// Tables for ``Playlist``/``Song`` (to-one and to-many relationships).
+    static func makeMusicDatabase() async throws -> any PowerSyncDatabaseProtocol {
+        let database = PowerSyncDatabase(
+            schema: PowerSync.Schema(tables: [
+                Table(name: "playlist", columns: [.text("name")]),
+                Table(
+                    name: "song",
+                    columns: [
+                        .text("title"),
+                        .text("playlist_id"),
+                    ]
+                ),
+            ]),
+            dbFilename: ":memory:",
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+        try await database.disconnectAndClear()
+        return database
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/Support/TestModels.swift
+++ b/Tests/PowerSyncSwiftDataTests/Support/TestModels.swift
@@ -1,0 +1,71 @@
+import Foundation
+import SwiftData
+
+/// Flat model used by the phase 1 go/no-go gate.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class Note {
+    var id: String
+    var title: String
+    var done: Bool
+    var count: Int
+
+    init(id: String, title: String, done: Bool, count: Int) {
+        self.id = id
+        self.title = title
+        self.done = done
+        self.count = count
+    }
+}
+
+/// Dedicated probe for simulating key-path reflection drift without affecting other suites.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class DriftProbe {
+    var id: String
+    var value: Int
+
+    init(id: String, value: Int) {
+        self.id = id
+        self.value = value
+    }
+}
+
+/// Like ``DriftProbe`` but with key paths provided through PUBLIC API, so it survives
+/// simulated reflection drift.
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class DriftSafe {
+    var id: String
+    var label: String
+
+    init(id: String, label: String) {
+        self.id = id
+        self.label = label
+    }
+}
+
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+extension DriftSafe: PredicateCodableKeyPathProviding {
+    static var predicateCodableKeyPaths: [String: any PartialKeyPath<DriftSafe> & Sendable] {
+        [
+            "id": \DriftSafe.id,
+            "label": \DriftSafe.label,
+        ]
+    }
+}
+
+/// Exercises per-property column-name overrides (camelCase property, snake_case column).
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class Stamp {
+    var id: String
+    var createdAt: Date
+    var displayName: String
+
+    init(id: String, createdAt: Date, displayName: String) {
+        self.id = id
+        self.createdAt = createdAt
+        self.displayName = displayName
+    }
+}

--- a/Tests/PowerSyncSwiftDataTests/Support/TypeMix.swift
+++ b/Tests/PowerSyncSwiftDataTests/Support/TypeMix.swift
@@ -1,0 +1,81 @@
+import Foundation
+import SwiftData
+
+enum Mood: String, Codable, Sendable {
+    case sunny
+    case stormy
+}
+
+enum Level: Int, Codable, Sendable {
+    case low = 1
+    case high = 9
+}
+
+struct Geo: Codable, Equatable, Sendable {
+    var lat: Double
+    var lon: Double
+}
+
+/// Exercises every attribute type the store supports (spec §6).
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+@Model
+final class TypeMix {
+    var id: String
+    var text: String
+    var integer: Int
+    var integer64: Int64
+    var integer32: Int32
+    var flag: Bool
+    var fraction: Double
+    var fraction32: Float
+    var stamp: Date
+    var payload: Data
+    var token: UUID
+    var mood: Mood
+    var level: Level
+    var geo: Geo
+    var subtitle: String?
+    var optionalNumber: Int?
+    var optionalStamp: Date?
+    var optionalPayload: Data?
+
+    init(
+        id: String,
+        text: String,
+        integer: Int,
+        integer64: Int64,
+        integer32: Int32,
+        flag: Bool,
+        fraction: Double,
+        fraction32: Float,
+        stamp: Date,
+        payload: Data,
+        token: UUID,
+        mood: Mood,
+        level: Level,
+        geo: Geo,
+        subtitle: String?,
+        optionalNumber: Int?,
+        optionalStamp: Date?,
+        optionalPayload: Data?
+    ) {
+        self.id = id
+        self.text = text
+        self.integer = integer
+        self.integer64 = integer64
+        self.integer32 = integer32
+        self.flag = flag
+        self.fraction = fraction
+        self.fraction32 = fraction32
+        self.stamp = stamp
+        self.payload = payload
+        self.token = token
+        self.mood = mood
+        self.level = level
+        self.geo = geo
+        self.subtitle = subtitle
+        self.optionalNumber = optionalNumber
+        self.optionalStamp = optionalStamp
+        self.optionalPayload = optionalPayload
+    }
+}

--- a/docs/superpowers/specs/2026-06-09-powersync-swiftdata-design.md
+++ b/docs/superpowers/specs/2026-06-09-powersync-swiftdata-design.md
@@ -1,0 +1,364 @@
+# PowerSyncSwiftData — Diseño (custom DataStore de SwiftData sobre PowerSync)
+
+- **Fecha:** 2026-06-09
+- **Estado:** Diseño aprobado (pendiente de validación del spec por el autor)
+- **Rama:** `feature/swiftdata-integration`
+- **Objetivo:** nuevo producto `PowerSyncSwiftData` en `powersync-swift` que expone un **custom `DataStore` de SwiftData respaldado por PowerSync**, de modo que una app use `@Model` / `@Query` / `ModelContext` con normalidad y, por debajo, el almacenamiento y la sincronización los gestione PowerSync.
+- **Destino:** PR a `powersync-ja/powersync-swift` como propuesta de solución al [issue #126](https://github.com/powersync-ja/powersync-swift/issues/126), una vez **terminado y battle-tested**.
+
+---
+
+## 1. Resumen ejecutivo
+
+SwiftData (iOS 18+) permite stores personalizados mediante los protocolos `DataStore`, `DataStoreConfiguration` y `DataStoreSnapshot`. Construimos un store que traduce las operaciones de SwiftData a la API nativa de PowerSync (`getAll`/`execute`/`writeTransaction`/`watch`), reutilizando el SQLite que PowerSync ya gestiona y su cola de subida `ps_crud`. **No** dependemos de GRDB ni de DataStoreKit; **aprendemos** de DataStoreKit (librería propia del autor, Apache-2.0) reimplementando sus técnicas en código propio.
+
+**Arquitectura elegida ("C"):** un `DataStore` nativo y delgado sobre la API async de PowerSync. PowerSync **es** el motor SQLite (single source of truth) — no abrimos una segunda conexión, evitando contención de locks y crashes `0xDEAD10CC`. El coste es un puente síncrono→asíncrono acotado y centralizado.
+
+---
+
+## 2. Contexto y decisiones
+
+| Decisión | Resultado | Motivo |
+|---|---|---|
+| Topología | **C** (DataStore nativo sobre la API de PowerSync) | Sin segunda conexión, single source of truth, PR-friendly. "A" exigiría reimplementar un motor SQLite que PowerSync ya da. |
+| DataStoreKit | **Referencia, no dependencia ni copia** | El autor quiere una solución propia y limpia para el PR. |
+| GRDB | **No usar como dependencia** | Preferencia del autor; PowerSync nativo basta. |
+| Alcance | **Read-write + reactividad live** | Requisito del autor. |
+| Modo dual | **iOS 18 base + iOS 27 mejora** vía `@available` | Requisito del autor (no targets separados). |
+| `HistoryObserver` | **NO-GO** | La subida ya es automática vía `ps_crud`; implementar `HistoryProviding` sería un substrato paralelo especulativo sin beneficio. |
+| Listón de entrega | **Producto completo, battle-tested, listo para lanzar** | Requisito del autor. El "PoC" es solo la Fase 1 de des-risking. |
+
+---
+
+## 3. Hechos verificados (restricciones que moldean el diseño)
+
+- **`fetch(_:)`/`save(_:)` son SÍNCRONOS + throwing** y **WWDC 2026 (iOS 27) NO añadió DataStores async**. PowerSync es 100% async ⇒ **puente async→sync bloqueante inevitable**.
+- **`DefaultSnapshot` es opaco** (sin accesores por propiedad) ⇒ usamos un **snapshot custom** (`PowerSyncSnapshot`).
+- **El acceso por propiedad vive en `BackingData`** vía `KeyPath<Model,Value>` tipado, entregado solo dentro de `DataStoreSnapshot.init(from:relatedBackingDatas:)`.
+- **`ModelContext` materializa el modelo desde el snapshot por NOMBRE de propiedad** (confirmado WWDC24; "by-name vs Codable-order" es inferido → se valida en Fase 1). `fetch` debe devolver en `fetchedSnapshots` solo snapshots de la entidad pedida (`persistentIdentifier.entityName == String(describing: T.self)`) y los relacionados en `relatedSnapshots`, o `ModelContext` aborta con *"Failed to materialize"*.
+- **PowerSync:** API `async throws` (`getAll`/`get`/`execute`/`writeTransaction`/`readTransaction`); `watch` devuelve `AsyncThrowingStream`; `SqlCursor` solo válido **dentro del mapper**; tablas como vistas sobre `ps_data__*` (JSON), `id` TEXT UUID implícito (no personalizable), tipos de columna `text`/`integer`/`real`; las escrituras vía `execute` se **capturan automáticamente a `ps_crud`**.
+- **Convenciones del repo:** `swift-tools: 6.1`, plataformas paquete iOS 15 / macOS 12 / watchOS 9 / tvOS 15 (NO se suben; el producto se anota `@available(iOS 18, …)`); productos declarados con `.library`; demos como apps Xcode con conector Supabase; tests con PowerSync `:memory:`; `CHANGELOG.md` con formato `## x.y.z`; sin swiftformat/swiftlint (se sigue el estilo existente).
+
+---
+
+## 4. Arquitectura
+
+### 4.1 Estructura de ficheros
+
+```
+Sources/
+└── PowerSyncSwiftData/
+    ├── PowerSyncDataStore.swift            // DataStore + DataStoreBatching
+    ├── PowerSyncDataStoreConfiguration.swift
+    ├── PowerSyncSnapshot.swift             // DataStoreSnapshot custom (pieza crítica)
+    ├── SchemaMapper.swift                  // reflexión SwiftData.Schema → tablas/columnas/keypaths
+    ├── PowerSyncSchemaBuilder.swift        // (opcional) deriva PowerSync.Schema desde SwiftData.Schema
+    ├── PredicateTranslator.swift           // FetchDescriptor → SQL
+    ├── ValueCoercion.swift                 // Swift ↔ columnas SQLite
+    ├── AsyncBridge.swift                   // _blocking (async→sync)
+    ├── PowerSyncChangeObserver.swift       // reactividad (watch → ModelContext)
+    ├── PowerSyncSwiftDataError.swift
+    └── README.md
+Demos/
+└── SwiftDataDemo/                          // app to-do (@Query/@Model) + Widget read-only + conector Supabase
+Tests/
+└── PowerSyncSwiftDataTests/
+```
+
+### 4.2 Tipos núcleo
+
+| Tipo | Conformidades | Responsabilidad |
+|---|---|---|
+| `PowerSyncDataStore` | `DataStore, DataStoreBatching` | `fetch`/`save`/`erase`/`delete` por lote; orquesta el resto. |
+| `PowerSyncDataStoreConfiguration` | `DataStoreConfiguration` | Lleva el `PowerSyncDatabaseProtocol`, la `SwiftData.Schema`, overrides de mapeo y opciones. |
+| `PowerSyncSnapshot` | `DataStoreSnapshot` | Snapshot custom genérico: `persistentIdentifier` + valores por nombre de propiedad. |
+| `SchemaMapper` | — | Construye y cachea `[entidad: [propiedad: PropertyMapping]]` desde la `Schema`. |
+| `PredicateTranslator` | — | `FetchDescriptor` → `(WHERE, ORDER BY, LIMIT/OFFSET, bindings)`; `preferInMemory*` para nodos no soportados. |
+| `AsyncBridge` (`_blocking`) | — | Ejecuta trabajo async desde un contexto síncrono, con contrato de seguridad. |
+| `PowerSyncChangeObserver` | — | Suscribe `watch`, reinyecta cambios remotos en un `ModelContext`, suprime eco. |
+| `PowerSyncSwiftDataError` | `Error` | Errores tipados. |
+
+### 4.3 Flujo de datos
+
+```
+LECTURA:   @Query / ModelContext.fetch
+  → PowerSyncDataStore.fetch(req)                                  [SÍNC]
+    → PredicateTranslator: descriptor → SQL + binds
+    → _blocking { await db.getAll(sql, binds) { cursor → fila } }  // cursor no escapa
+    → fila → PowerSyncSnapshot (valores por nombre, PID acuñado)
+  → DataStoreFetchResult(descriptor, fetchedSnapshots, relatedSnapshots)
+  → ModelContext materializa @Model por nombre de propiedad
+
+ESCRITURA: ModelContext.save()
+  → PowerSyncDataStore.save(req)                                   [SÍNC]
+    → _blocking { await db.writeTransaction { tx in
+         inserted/updated/deleted → INSERT/UPDATE/DELETE sobre la vista } }
+       → triggers de PowerSync → ps_crud → connector sube al backend
+  → DataStoreSaveChangesResult(remappedIdentifiers, snapshotsToReregister)
+
+SYNC ↓:    PowerSync baja del servidor → cambia tabla
+  → watch emite → PowerSyncChangeObserver → reinyección vía ModelContext (author="powersync-remote")
+  → SwiftData propaga → @Query re-ejecuta fetch()
+```
+
+---
+
+## 5. Diseño por componente
+
+### 5.1 `PowerSyncDataStoreConfiguration`
+
+```swift
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+public final class PowerSyncDataStoreConfiguration: DataStoreConfiguration {
+    public typealias Store = PowerSyncDataStore
+    public var name: String
+    public var schema: Schema?                       // SwiftData.Schema (lo inyecta ModelContainer)
+    public let database: any PowerSyncDatabaseProtocol
+    public let tableNameForEntity: (String) -> String   // override; por defecto snake_case(entityName)
+    public let options: Options                       // política de fallback de predicates, autor de sync, etc.
+
+    public init(name: String,
+                database: any PowerSyncDatabaseProtocol,
+                tableNameForEntity: @escaping (String) -> String = defaultTableName,
+                options: Options = .init())
+
+    public static func == (lhs, rhs) -> Bool { lhs.name == rhs.name }
+    public func hash(into:)  { hasher.combine(name) }
+    public func validate() throws { /* comprobar mapeo entidad↔tabla contra el schema de PowerSync */ }
+}
+```
+
+La app crea el `PowerSyncDatabase`, llama `connect(connector:)`, y construye el `ModelContainer` con esta configuración apuntando a esa `database`.
+
+### 5.2 `PowerSyncSnapshot` (pieza crítica)
+
+```swift
+@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)
+public struct PowerSyncSnapshot: DataStoreSnapshot {
+    public let persistentIdentifier: PersistentIdentifier
+    let entityName: String
+    let primaryKey: String                 // el id TEXT de PowerSync
+    var values: [String: PowerSyncValue]   // CLAVE = nombre de propiedad (espejo del @Model)
+
+    // model → snapshot (lo invoca SwiftData en save)
+    public init(from backingData: any BackingData,
+                relatedBackingDatas: inout [PersistentIdentifier: any BackingData]) { … }
+
+    // fila SQL → snapshot (lo construimos en fetch)
+    init(row: [String: PowerSyncValue], entity: EntityMapping, storeIdentifier: String) throws { … }
+
+    public func copy(persistentIdentifier: PersistentIdentifier,
+                     remappedIdentifiers: [PersistentIdentifier: PersistentIdentifier]?) -> Self { … }
+}
+
+enum PowerSyncValue: Codable, Sendable { case text(String), int(Int64), real(Double), blob(Data), null }
+```
+
+**Reglas de oro:**
+1. **Los nombres de propiedad del snapshot DEBEN ser espejo de los del `@Model`** (la materialización es por nombre).
+2. `init(from:)` recorre las propiedades del `Schema` y por cada una hace `backingData.getValue(forKey: keyPath)`, **despachando el `AnyKeyPath` con cast de existencial abierto** (patrón de DataStoreKit), parametrizado por el `valueType` del schema:
+   ```swift
+   switch keyPath {
+   case let kp as KeyPath<Model, V>:  return backingData.getValue(forKey: kp)
+   case let kp as KeyPath<Model, V?>: return backingData.getValue(forKey: kp)
+   default: return nil
+   }
+   ```
+   - to-one → `relatedModel.persistentModelID`; to-many → `[persistentModelID]`.
+3. `init(row:)` coacciona cada columna al tipo de la propiedad (ver §6) y acuña el `PersistentIdentifier` con `PersistentIdentifier.identifier(for: storeId, entityName:, primaryKey: row["id"])`.
+4. `copy(...)` reescribe las referencias de relación (to-one PID y to-many [PID]) aplicando `remappedIdentifiers`.
+
+> **Obtención de KeyPaths tipados (tarea de robustez nº1):** preferir las **APIs públicas de `Schema`** (`Schema.Attribute`/`Schema.Relationship`) si exponen el `AnyKeyPath`; recurrir a reflejar el `schemaMetadata` del macro `@Model` con `Mirror` **solo si** no hay alternativa pública. La fuente elegida se cubre con tests-guardia de deriva de SDK.
+
+### 5.3 `SchemaMapper`
+
+En el init del store: recorre `schema.entities`; por entidad y `entity.storedProperties`:
+- `Schema.Attribute` → columna = `attribute.name`; captura `valueType`, `isOptional`, `isUnique`, `options` (detecta `.externalStorage`).
+- `Schema.Relationship` to-one → columna `{name}_id`; kind `.toOne(destination)`.
+- to-many / many-to-many → sin columna en este lado; se resuelve por consulta / tabla de unión.
+
+Cachea `[entityName: EntityMapping]` (con tablas de lookup nombre↔columna y nombre→keypath), protegido por el `Mutex` (`os_unfair_lock`) ya existente en el repo (`Sources/PowerSync/Utils/Mutex.swift`).
+
+### 5.4 `PowerSyncSchemaBuilder` (opcional, reduce duplicación)
+
+Como reflejamos la `SwiftData.Schema`, podemos **derivar automáticamente la `PowerSync.Schema`** (entidad→`Table`, atributos→`Column` con el tipo mapeado), de modo que el desarrollador solo declare sus `@Model` + el conector, evitando la duplicación que sufre la integración GRDB. Con escape hatch para overrides manuales. Recomendado, pero no bloqueante para la Fase 1.
+
+### 5.5 `AsyncBridge`
+
+```swift
+func _blocking<T: Sendable>(_ body: @escaping @Sendable () async throws -> T) throws -> T {
+    dispatchPrecondition(condition: .notOnQueue(.main))    // defensivo
+    let sem = DispatchSemaphore(value: 0)
+    let box = Box<Result<T, Error>>()                      // carrier con el Mutex del repo (iOS 15-safe)
+    Task.detached(priority: .userInitiated) {
+        do { box.set(.success(try await body())) } catch { box.set(.failure(error)) }
+        sem.signal()
+    }
+    sem.wait()
+    return try box.get().get()
+}
+```
+
+**Por qué es seguro:** `Task.detached` no hereda aislamiento `@MainActor`; el `await` de PowerSync corre en el cooperative pool mientras `wait()` bloquea un hilo **distinto** y no-cooperativo; el semáforo es la barrera *happens-before*.
+
+**Contrato (documentado en voz alta):** llamar solo desde el hilo de callback del store, **nunca** dentro de otro `Task`/función async, idealmente nunca en `@MainActor`; el cuerpo de PowerSync no debe saltar de vuelta al actor bloqueado. Se valida en Fase 1 (estrés de concurrencia + confirmar que el hilo de callback de SwiftData está fuera del cooperative pool).
+
+### 5.6 `PredicateTranslator`
+
+`translate(_ descriptor: FetchDescriptor<T>, _ entity: EntityMapping) -> (sql, bindings)`:
+- Soporta: `==,!=,<,>,<=,>=`, `&&/||/!`, `IN`/`contains`, prefijo/sufijo de String, rangos, fechas, keypaths a columnas de la propia entidad y to-one (`{rel}_id`).
+- `sortBy` → `ORDER BY` (asc/desc); `fetchLimit`/`fetchOffset` → `LIMIT`/`OFFSET`.
+- Nodos no traducibles → `throw DataStoreError.preferInMemoryFilter` / `.preferInMemorySort` (SwiftData filtra en memoria). **Solo** como último recurso, documentado y testeado.
+- `fetchCount` → `SELECT COUNT(*)`; `fetchIdentifiers` → `SELECT id`.
+
+### 5.7 `PowerSyncChangeObserver` (reactividad)
+
+- **Cimiento (iOS 18+):** suscribe `db.watch(sql:)` por tabla/consulta; al emitir, reinyecta las filas afectadas en un `ModelContext` de fondo con `editingState.author = "powersync-remote"`. SwiftData propaga el cambio entre contextos → `@Query` re-ejecuta `fetch()` (que lee fresco de PowerSync; la reinyección solo genera la notificación).
+- **Supresión de eco:** en `save`, si `request.editingState.author == "powersync-remote"`, **no** se reescribe a PowerSync (el dato ya está sincronizado).
+- **Capa iOS 27 (`@available`, opcional):** `ResultsObserver` para observación estilo `@Query` fuera de SwiftUI (p.ej. el propio observer / lógica del widget). **Sin `HistoryObserver`/`HistoryProviding`.**
+
+---
+
+## 6. Mapeo de tipos Swift ↔ PowerSync
+
+| Swift | Columna PowerSync | Notas |
+|---|---|---|
+| `String` | `text` | passthrough |
+| `Int`/`Int64`/`Int32` | `integer` | |
+| `Bool` | `integer` | 0/1 |
+| `Double`/`Float` | `real` | |
+| `Date` | `real` (epoch) o `text` (ISO) | decisión: `real` por defecto (indexable, compacto) |
+| `Data` | `blob` | |
+| enum `RawRepresentable` | según raw (`integer`/`text`) | `init(rawValue:)` al leer |
+| `@Attribute(.codable)` (iOS 27) | `text` (JSON) | **opaco a predicates/sort** |
+| Opcional `T?` | nullable | `null` ↔ `nil` |
+| to-one | columna `{rel}_id` (`text`) | guarda el `id` del relacionado |
+| to-many / m2m | sin columna | consulta inversa / tabla de unión |
+
+`id`: cada `@Model` sincronizado expone un identificador `String` mapeado al `id` de PowerSync (nombre configurable, por defecto `id`). En `insert` se acuña UUID si está vacío.
+
+---
+
+## 7. Flujos `fetch` / `save`
+
+### 7.1 `fetch`
+
+```swift
+func fetch<T>(_ req: DataStoreFetchRequest<T>) throws -> DataStoreFetchResult<T, PowerSyncSnapshot> {
+  let entity = mapper.entity(for: String(describing: T.self))
+  let (sql, params) = try translator.build(req.descriptor, entity)
+  let rows = try _blocking {
+     try await database.getAll(sql: sql, parameters: params) { cursor in
+        entity.rowDict(from: cursor)        // lee TODO dentro del mapper (cursor no escapa)
+     }
+  }
+  let fetched = try rows.map { try PowerSyncSnapshot(row: $0, entity: entity, storeIdentifier: identifier) }
+  return DataStoreFetchResult(descriptor: req.descriptor, fetchedSnapshots: fetched, relatedSnapshots: [:])
+}
+```
+
+### 7.2 `save`
+
+```swift
+func save(_ req: DataStoreSaveChangesRequest<PowerSyncSnapshot>) throws -> DataStoreSaveChangesResult<PowerSyncSnapshot> {
+  if req.editingState.author == options.remoteAuthor { return .init(for: identifier) } // eco: no-op
+  var remapped: [PersistentIdentifier: PersistentIdentifier] = [:]
+  try _blocking {
+    try await database.writeTransaction { tx in
+      for s in req.inserted {
+        let pk = s.primaryKeyOrNewUUID()
+        remapped[s.persistentIdentifier] = try .identifier(for: identifier, entityName: s.entityName, primaryKey: pk)
+        try tx.execute(sql: s.insertSQL(table:), parameters: s.insertValues(pk: pk))   // → ps_crud automático
+      }
+      for s in req.updated { try tx.execute(sql: s.updateSQL(table:), parameters: s.updateValues()) }
+      for s in req.deleted { try tx.execute(sql: s.deleteSQL(table:), parameters: [s.primaryKey]) }
+    }
+  }
+  var saved: [PersistentIdentifier: PowerSyncSnapshot] = [:]
+  for s in req.inserted { let pid = remapped[s.persistentIdentifier]!; saved[pid] = s.copy(persistentIdentifier: pid, remappedIdentifiers: remapped) }
+  return DataStoreSaveChangesResult(for: identifier, remappedIdentifiers: remapped, snapshotsToReregister: saved)
+}
+```
+
+Un `writeTransaction` = lote atómico (`BEGIN IMMEDIATE`/`COMMIT`/`ROLLBACK`). Inserts con dependencia circular: reintento diferido hasta resolver los FKs (patrón de DataStoreKit).
+
+---
+
+## 8. Modo dual iOS 18 / iOS 27
+
+- **Todo lo esencial corre en iOS 18+.** La API pública del producto se anota `@available(iOS 18, macOS 15, watchOS 11, tvOS 18, *)`.
+- **iOS 27 añade**, tras `if #available(iOS 27, *)`: `ResultsObserver` (observación fuera de SwiftUI), y opcionalmente `@Query(sectionBy:)`/`@Attribute(.codable)` en el lado de la app/demo. **No** cambia el mecanismo de reactividad (sigue siendo `watch`+reinyección).
+
+---
+
+## 9. Ruta solo-lectura para extensión/widget
+
+El caso real del issue #126. La extensión abre el `PowerSyncDatabase` (App Group) y usa el mismo `PowerSyncDataStore` en modo de solo-lectura (`save` lanza `unsupportedFeature`). Seguridad ante suspensión: la lectura es corta y se cancela ante `willResignActive` (`interrupt`). Se valida bajo suspensión antes de declararlo listo.
+
+---
+
+## 10. Definition of Done (producto terminado y battle-tested)
+
+**Funcionalidad completa:** todos los tipos de atributo (opcionales, `Date`, enums, `Data`, transformable, codable); relaciones to-one + to-many + many-to-many; `PredicateTranslator` exhaustivo (+ sort/limit/offset/count/identifiers; fallback en memoria solo para nodos intraducibles, documentado y testeado); `DataStoreBatching`; `erase`; remapeo de ids robusto (incl. circular); reactividad + supresión de eco; ruta solo-lectura para extensión con seguridad ante suspensión.
+
+**Battle-tested:** suite con **Swift Testing** — unitarios + integración sobre PowerSync `:memory:` + **estrés de concurrencia/deadlock** del puente + **benchmarks** (incl. ventanas 60/28 días) + **tests-guardia de deriva del SDK**; demo + widget ejercitados; CI.
+
+**Documentación:** `README.md` del módulo, entrada en `CHANGELOG.md`, doc-comments en la API pública.
+
+---
+
+## 11. Fases de ejecución
+
+1. **Fase 1 — Gate de des-risking (NO es el entregable):** un `@Model Note{id,title,done,count}` plano + PowerSync `:memory:`. `insert`+`save` → verificar captura con `getNextCrudTransaction()` → `fetch` en otro contexto → **assert** valores+id correctos sin *"Failed to materialize"*. Incluye la *prueba de nombre desalineado*. Valida: materialización por nombre, `_blocking` sin deadlock, captura a `ps_crud`. **GO/NO-GO.**
+2. CRUD completo + remapeo de ids + coerción de todos los tipos.
+3. `PredicateTranslator` exhaustivo (+ sort/limit/offset/count).
+4. Reactividad (`watch`+reinyección + eco) + capa iOS 27 (`ResultsObserver`).
+5. Relaciones to-one → to-many/many-to-many.
+6. Ruta solo-lectura extensión/widget + seguridad ante suspensión.
+7. `PowerSyncSchemaBuilder` (derivar PowerSync.Schema) + ergonomía de API.
+8. Demo `SwiftDataDemo` + widget.
+9. Suite de tests completa + benchmarks + CI.
+10. Endurecido, documentado, README/CHANGELOG, PR a #126.
+
+---
+
+## 12. Riesgos y mitigaciones
+
+| Riesgo | Sev. | Mitigación |
+|---|---|---|
+| Materialización snapshot→modelo es **por nombre** (inferido, no API pública) | CRÍTICO | Fase 1 lo prueba (assert + prueba de nombre desalineado). Si falla, se pivota. |
+| Dependencia de **internals privados** (`schemaMetadata` vía `Mirror`) para KeyPaths | ALTO | Preferir API pública de `Schema`; tests-guardia de deriva de SDK; fijar/declarar versiones probadas. **Se divulga en el PR.** |
+| Puente `_blocking` → deadlock / inversión de prioridad | ALTO | `Task.detached` + semáforo en hilo distinto; contrato estricto; `dispatchPrecondition`; estrés de concurrencia. |
+| `SqlCursor` escapa del mapper → crash | MEDIO | Extraer todo dentro del closure; nunca retener el cursor. |
+| Traducción de predicates incompleta no escala | MEDIO | Cobertura amplia + fallback documentado; índices en consultas calientes. |
+| Relaciones m2m / external storage / transformables | MEDIO | Fuera de Fase 1; cubiertos en fases 5+ con tests. |
+| Suspensión 0xDEAD10CC en extensión | MEDIO | Lecturas cortas + `interrupt` en `willResignActive`; validar antes de lanzar. |
+| Cambios futuros de SwiftData rompen la integración | MEDIO | **No se promete inmutabilidad**; tests-guardia + versiones fijadas; etiqueta de madurez la deciden los maintainers. |
+
+---
+
+## 13. Entregables y convenciones del repo
+
+- **`Package.swift`:** `.library(name: "PowerSyncSwiftData", targets: ["PowerSyncSwiftData"])` + target dependiente de `PowerSync` + `.testTarget("PowerSyncSwiftDataTests")`. No se suben las plataformas del paquete; la API se anota `@available`.
+- **`README.md`:** entrada en "Available Products" (con etiqueta de madurez según decidan los maintainers) + sección de Usage.
+- **`CHANGELOG.md`:** entrada nueva con formato `## x.y.z`.
+- **`Demos/SwiftDataDemo`:** layout de `PowerSyncExample` (`Screens/`, `Components/`, `PowerSync/` con schema + conector Supabase) + **Widget extension** de solo-lectura (caso del issue #126). README del demo.
+- **Estilo:** seguir el código existente (sin swiftformat/swiftlint en el repo).
+
+---
+
+## 14. Fuera de alcance (futuro)
+
+- Compartición multi-proceso multi-escritor (niveles 3-4 de simolus3 en #126).
+- Migraciones complejas de schema entre versiones de modelo (más allá de lo básico).
+- `HistoryProviding`/`HistoryObserver` (descartado salvo que un consumidor futuro lo justifique).
+
+---
+
+## 15. Cuestiones abiertas a cerrar en Fase 1
+
+1. Confirmar que la materialización es **por nombre** (no por orden Codable) — prueba de nombre desalineado.
+2. Confirmar que el hilo de callback de `fetch`/`save` está **fuera del cooperative pool** (estrés de deadlock).
+3. Verificar las formas exactas en el SDK objetivo: `DataStoreFetchRequest.descriptor` (acceso a predicate/sortBy), `DataStoreSaveChangesRequest.inserted/updated/deleted`, `DataStoreSaveChangesResult(for:remappedIdentifiers:snapshotsToReregister:)`, y que devolver `remappedIdentifiers` evita el fatal de materialización.
+4. Elegir la **fuente más estable de KeyPaths tipados** (API pública de `Schema` vs `Mirror` de `schemaMetadata`).
+5. Validar coerción de tipos en ambas direcciones para las afinidades SQLite de PowerSync.


### PR DESCRIPTION
## What

A new **`PowerSyncSwiftData`** product: a SwiftData custom `DataStore` backed by PowerSync, proposed as a solution to the use cases discussed in #126. Apps use `@Model` / `@Query` / `ModelContext` as usual; underneath, PowerSync owns the SQLite database, local writes are captured into `ps_crud`, and sync downloads update `@Query` views live.

**The store is multi-process**, delivering levels 1–3 of the quality model @simolus3 outlined in #126: widgets and App Intents extensions read **and write** the shared App Group database, changes from any process update the app's `@Query` views live. Only `connect()` stays single-owner (level 4 deliberately not pursued, as discussed there).

> **Stacked on #147.** The three core SDK changes this builds on (absolute paths, concurrent-open retry, cross-process change signal) live in #147 for separate review. Until that merges this branch still contains those commits, so the diff here includes them; they drop out once #147 lands and this rebases on `main`.

```swift
let database = PowerSyncDatabase(schema: try PowerSyncSchema(for: [Note.self]))
try await database.connect(connector: myConnector)

let configuration = PowerSyncDataStoreConfiguration(name: "powersync", database: database)
let container = try ModelContainer(for: SwiftData.Schema([Note.self]), configurations: [configuration])

let observer = PowerSyncChangeObserver(container: container, configuration: configuration)
try await observer.start(observing: [Note.self])
```

Full documentation in [`Sources/PowerSyncSwiftData/README.md`](https://github.com/Chubby-Studio/powersync-swift/blob/feature/swiftdata-integration/Sources/PowerSyncSwiftData/README.md), including supported types, predicate translation, relationships, schema evolution, multi-process setup and every known limitation.

## How it works (short version)

- **One database, no second connection.** The store translates SwiftData operations to the async PowerSync API over the app's existing `PowerSyncDatabase`. `fetch`/`save` are synchronous, so a small bridge blocks the calling thread while the async work runs on a dedicated `TaskExecutor` over a private GCD queue — neither the work nor its continuations ever need a cooperative-pool thread (stress-tested with the pool saturated).
- **Snapshots are dictionaries keyed by property name.** SwiftData materializes models from a custom snapshot's `Codable` representation by property name (`DataStoreSnapshotCodingKey.modeledProperty`); the suite pins this with a misaligned-name exit test.
- **Writes** go through PowerSync's views inside one write transaction per save, so triggers capture them for upload exactly like handwritten SQL.
- **Reactivity**: `PowerSyncChangeObserver` watches the observed tables; on changes that didn't come through this process's SwiftData (sync downloads, other processes) it reconciles into a background context and saves — echo-suppressed by author, so nothing loops or re-uploads — and `ModelContext.didSave` is what `@Query` reacts to.
- **Multi-process**: each process opens its own database + container over the App Group file (the standard SwiftData pattern). Data already flowed safely through WAL; the two missing pieces were SDK-level and are part of this PR (see below).

## Core SDK changes

The multi-process support rests on three changes to the `PowerSync` target (absolute database paths, concurrent-open retry, and a cross-process Darwin change signal). They are in **#147** with their own description and tests.
## Key decisions (and why)

- **Native thin store over the async PowerSync API** — no second SQLite connection, no GRDB dependency; PowerSync stays the single source of truth.
- **`PowerSyncSchema(for: models)` derives the PowerSync schema** from the `@Model`s, removing the duplication the GRDB integration suffers (manual overrides remain possible).
- **`erase()` deliberately throws**: resetting local data is `disconnectAndClear()`'s job; erasing through the store would upload a DELETE for every row.
- **Sync ownership stays single-process** (`connect()` only from the app); extension writes upload when the app's client runs — immediately if it's alive, thanks to the signal.
- **No private-API mimicry for `@Query` refresh**: the observer achieves live updates through public `didSave` semantics instead of imitating SwiftData's internal remote-change notification.
- **Two private SwiftData surfaces are used, with defense in depth** (disclosed prominently): attribute key paths via `Mirror` over `schemaMetadata` (`Schema.Attribute` exposes no key path, unlike `Schema.Relationship`), and the `PersistentIdentifier` Codable envelope. Both are behind runtime tripwires that fail descriptively on first use rather than corrupting, the envelope is only a fallback behind an identifier→key mint cache, and models can opt their key paths into public API via `PredicateCodableKeyPathProviding` — generated automatically by the optional **`@PowerSyncModel` macro** (separate `PowerSyncSwiftDataMacros` product, so the core gains no dependency; macro plugins build for the host and modern toolchains use swift-syntax prebuilts).

## Testing and validation

**79 new Swift Testing tests** (joining the existing 109 XCTests; strict-concurrency build clean), organized by functional area:

- Round trips for every attribute type; CRUD verified against `getNextCrudTransaction()` (PUT/PATCH/DELETE with column values); identifier minting/remapping incl. reference cycles in one save; many-to-many through a join model end to end.
- Predicate translation units + integration, NULL-safe `!=`/`NOT` semantics over optionals verified against the in-memory fallback, lowercase UUID storage/bindings (Postgres renders uuids lowercase), `fetchCount` honoring offset, the documented fallback contract (SwiftData only falls back in-memory for `fetch()`).
- Reactivity (downloads simulated by writing `ps_data__*` directly), observer robustness (`start()` throws instead of hanging on misconfiguration, streams restart with backoff, bursts coalesce), echo suppression and loop freedom.
- Multi-process: concurrent-open retry (reproduced in-process with a system-SQLite lock holder), cross-process signal (two pools over one file reproduce two-process blindness deterministically), the full extension-write chain (write on store B → shared crud queue → app-side `didSave` within milliseconds).
- SDK-drift guards for both private surfaces, including simulated-drift tests exercising the runtime failure paths (read fails descriptively; save refuses to persist; a `@PowerSyncModel` model keeps working with reflection suppressed).
- Schema evolution (added optional/required-with-default properties, removed keys, new models on an existing file, migration plans rejected) and bridge stress (cooperative pool saturated at 4× cores; 16 concurrent contexts).
- Benchmarks over a **1,000,000-row table** (macOS): 28-day count ≈ 1–3 ms, 60-day sorted first page of 200 ≈ 3 ms, full 60-day window materializing 60,000 models ≈ 0.6 s, 10k-insert batch save ≈ 0.5 s.

**Beyond the suite:**

- A **real two-process harness** (separate OS processes over one file) validated concurrent cold opens, external-write visibility, `ps_crud` sharing, writer contention, and the signal chain ending in `ModelContext.didSave`.
- An adversarial multi-agent audit produced 52 verified findings; every correctness finding was fixed and pinned by a test (several listed above).
- **Real-world pilot**: a production app (FitWoody, our app from the original #126 report) ran the store against its existing PowerSync database with live Supabase sync — including App Intents from Shortcuts reading and writing through `ModelContext` with the app's `@Query` views updating live. Happy to share findings as we keep testing, per the offer in the issue thread.
- `Demos/SwiftDataDemo`: a SwiftData to-do app with a Supabase connector and a widget sharing the database via App Group, including an interactive button whose intent **writes from the widget's process**.

## Known limitations (all documented in the module README)

- String sorts use `COLLATE NOCASE`; `starts(with:)`/`contains` map to `LIKE` (ASCII case-insensitivity differs from Swift); locale-aware operators fall back to in-memory. Optional-chained to-one predicates (`$0.playlist?.id == x`, `$0.playlist?.attr == x`) DO translate (FK comparison / `IN (SELECT ...)` subquery, NULL-safe).
- The observer re-reads a watched table per change burst and keeps observed models registered (memory ∝ rows) — fine for UI-scale tables, documented for large ones.
- No transformables, no `.unique` upsert semantics, no model inheritance, no `ModelContainer.erase()`. `ModelContext.fetchHistory`/`deleteHistory` are not provided (the protocol can't be fully satisfied by a third-party store today; kept on a branch for a follow-up once there's a clean story).
- Two SwiftData SDK gaps block full protocol fidelity and are disclosed: `HistoryTombstone` has no public initializer (deletions surface as `deletedIdentifiers` on the concrete transaction type), and `any PartialKeyPath<M> & Sendable` can only be built from key-path literals (updates carry `updatedPropertyNames`). Public initializers for these — and a public key-path accessor on `Schema.Attribute` — would let third-party stores drop every workaround; we intend to file Feedbacks.
- Device-level suspension validation for extensions remains a manual procedure (documented in the demo README); saves are single short transactions by construction.

## Review guide

- Start with [`Sources/PowerSyncSwiftData/README.md`](https://github.com/Chubby-Studio/powersync-swift/blob/feature/swiftdata-integration/Sources/PowerSyncSwiftData/README.md) — it is the contract this PR implements.
- The store core: `PowerSyncDataStore` (fetch/save/batch/history), `PowerSyncSnapshot` (by-name Codable materialization), `SchemaMapper`/`ValueCoercion` (mapping + types), `PredicateTranslator`, `AsyncBridge`, `PowerSyncChangeObserver`, `PowerSyncHistory`.
- Core SDK changes are isolated: `AsyncConnectionPool` (absolute paths + open retry + signal wiring), `CrossProcessChangeSignal`, one-line filters in `watch.swift` and `StreamingSyncClient`.
- History is linear and commit messages are written to be read; the design doc that drove the work is in `docs/` (in Spanish — happy to translate any part on request).
- Maturity label is of course your call — the README says **alpha**, mirroring `PowerSyncGRDB`.

