### PR TITLE
Fix crash when running queries in cursor callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.14.4 (unreleased)
+
+- Fix crash when running a statement in a cursor callback ([#148](https://github.com/powersync-ja/powersync-swift/issues/148)).
+
 ## 1.14.3
 
 - Fix CRUD uploads entering a `Delaying due to previously encountered CRUD item` loop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 1.14.4 (unreleased)
+## 1.14.4
 
 - Fix crash when running a statement in a cursor callback ([#148](https://github.com/powersync-ja/powersync-swift/issues/148)).
 

--- a/Sources/PowerSync/CurrentVersion.swift
+++ b/Sources/PowerSync/CurrentVersion.swift
@@ -1,2 +1,2 @@
 // The current version of the PowerSync Swift SDK. This should be updated to the latest version in `CHANGELOG.md` when a new version is released.
-let libraryVersion = "1.14.3"
+let libraryVersion = "1.14.4"

--- a/Sources/PowerSync/Implementation/queries/LeaseContext.swift
+++ b/Sources/PowerSync/Implementation/queries/LeaseContext.swift
@@ -1,9 +1,11 @@
+import Foundation
+
 /// An implementation of ``ConnectionContext`` based on a raw ``SQLiteConnectionLease``.
 final class ConnectionLeaseContext: ConnectionContext {
-    private let lease: Mutex<SQLiteConnectionLease>
+    private let lease: ThreadPinnedValue<SQLiteConnectionLease>
 
     init(lease: consuming SQLiteConnectionLease) {
-        self.lease = Mutex(lease)
+        self.lease = ThreadPinnedValue(lease)
     }
 
     /// Maps any parameter array to typed SQLite values.
@@ -24,13 +26,13 @@ final class ConnectionLeaseContext: ConnectionContext {
     }
 
     func execute(sql: String, parameters: [(any Sendable)?]?) throws -> Int64 {
-        try lease.withLock { lease in
+        try lease.use { lease in
             return try lease.execute(sql: sql, parameters: mapParameters(parameters))
         }
     }
 
     func getOptional<RowType>(sql: String, parameters: [(any Sendable)?]?, mapper: @escaping @Sendable (any SqlCursor) throws -> RowType) throws -> RowType? {
-        try lease.withLock { lease in
+        try lease.use { lease in
             try lease.withIterator(sql: sql, parameters: mapParameters(parameters)) { rows in
                 return try rows.next(callback: mapper)
             }
@@ -38,7 +40,7 @@ final class ConnectionLeaseContext: ConnectionContext {
     }
     
     func getAll<RowType>(sql: String, parameters: [(any Sendable)?]?, mapper: @escaping @Sendable (any SqlCursor) throws -> RowType) throws -> [RowType] {
-        try lease.withLock { lease in
+        try lease.use { lease in
             try lease.withIterator(sql: sql, parameters: mapParameters(parameters)) { rows in
                 var result: [RowType] = []
                 while let row = try rows.next(callback: mapper) {
@@ -50,7 +52,7 @@ final class ConnectionLeaseContext: ConnectionContext {
     }
     
     func get<RowType>(sql: String, parameters: [(any Sendable)?]?, mapper: @escaping @Sendable (any SqlCursor) throws -> RowType) throws -> RowType {
-        try lease.withLock { lease in
+        try lease.use { lease in
             try lease.withIterator(sql: sql, parameters: mapParameters(parameters)) { rows in
                 guard let cursor = try rows.next(callback: mapper) else {
                     throw PowerSyncError.operationFailed(message: "Expected \(sql) to return a row, but got an empty result set.")
@@ -58,5 +60,28 @@ final class ConnectionLeaseContext: ConnectionContext {
                 return cursor
             }
         }
+    }
+}
+
+/// A value that can only be used on the thread creating it.
+private struct ThreadPinnedValue<T: ~Copyable>: @unchecked Sendable, ~Copyable {
+    // This is behind a pointer to silence a compiler error about mutating its contents in a non-mutating func.
+    private let value: UnsafeMutablePointer<T> = .allocate(capacity: 1)
+    private let owningThread: Thread
+
+    init(_ value: consuming T) {
+        self.value.initialize(to: value)
+        self.owningThread = Thread.current
+    }
+    
+    func use<R: ~Copyable>(_ action: (_ value: inout T) throws -> R) throws -> R {
+        if owningThread != Thread.current {
+            throw PowerSyncError.operationFailed(
+                message: "A ConnectionLeaseContext may not be used on multiple threads",
+                underlyingError: nil
+            )
+        }
+        
+        return try action(&value.pointee)
     }
 }

--- a/Sources/PowerSync/Implementation/queries/LeaseContext.swift
+++ b/Sources/PowerSync/Implementation/queries/LeaseContext.swift
@@ -84,4 +84,9 @@ private struct ThreadPinnedValue<T: ~Copyable>: @unchecked Sendable, ~Copyable {
         
         return try action(&value.pointee)
     }
+    
+    deinit {
+        self.value.deinitialize(count: 1)
+        self.value.deallocate()
+    }
 }

--- a/Sources/PowerSync/Protocol/db/ConnectionContext.swift
+++ b/Sources/PowerSync/Protocol/db/ConnectionContext.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+// TODO (breaking change): This type should not be sendable.
 public protocol ConnectionContext: Sendable {
     /**
      Executes a SQL statement with optional parameters.

--- a/Tests/PowerSyncTests/Implementation/DatabaseImplementationTests.swift
+++ b/Tests/PowerSyncTests/Implementation/DatabaseImplementationTests.swift
@@ -23,4 +23,23 @@ struct DatabaseImplementationTests {
         try await db.close(deleteDatabase: true)
         #expect(description.contains("attempt to write a readonly database"))
     }
+    
+    @Test func canUseConnectionInCallback() async throws {
+        let db = PowerSyncDatabase(
+            schema: Schema(),
+            dbFilename: ":memory:",
+            logger: DefaultLogger()
+        )
+        
+        let results = try await db.readTransaction { tx in
+            try tx.getAll(sql: "VALUES (1), (2), (3)", parameters: []) { outerCursor in
+                let outerValue = try outerCursor.getInt64(index: 0)
+                return try tx.get(sql: "SELECT 2 * ?", parameters: [outerValue]) { innerCursor in
+                    try innerCursor.getInt64(index: 0)
+                }
+            }
+        }
+        try #require(results == [2, 4, 6])
+        try await db.close()
+    }
 }


### PR DESCRIPTION
`ConnectionContext` is the protocol we use to represent transactions and active read/write locks. It is marked as `Sendable`, indicating that it can safely be used concurrently. I believe adding that label was likely an oversight we didn't notice in the Kotlin days, a single SQLite connection is absolutely not safe to use concurrently. Before this PR, we used a (non-recursive) mutex to restore thread safety.

As reported in #148, there are legitimate uses for using connection contexts recursively. Currently, those crash when trying to acquire the mutex though. Instead of adding recursive mutexes at a higher cost, this just throws when a connection context is used across multiple threads. It's worth noting that all callbacks receiving connection contexts are synchronous, so users would really have to do silly things like explicitly spawning threads in that callback to hit this issue.

Ideally, we should just not mark `ConnectionContext` as thread-safe and let concurrency checking in Swift do the rest. That might be breaking though, so this cheaper runtime check fixes the issue.

Clsoes #148.