### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -32,10 +32,10 @@ jobs:
         run: xcrun xctrace list devices
 
       - name: Test on iOS simulator
-        run: xcodebuild test -scheme PowerSync-Package -destination "platform=iOS Simulator,name=iPhone 16"
+        run: xcodebuild test -scheme PowerSync-Package -destination "platform=iOS Simulator,name=iPhone 17"
       - name: Test on macOS simulator
         run: xcodebuild test -scheme PowerSync-Package -destination "platform=macOS,arch=arm64,name=My Mac"
       - name: Test on watchOS simulator
-        run: xcodebuild test -scheme PowerSync-Package -destination "platform=watchOS Simulator,arch=arm64,name=Apple Watch Ultra 2 (49mm)"
+        run: xcodebuild test -scheme PowerSync-Package -destination "platform=watchOS Simulator,arch=arm64,name=Apple Watch Ultra"
       - name: Test on tvOS simulator
         run: xcodebuild test -scheme PowerSync-Package -destination "platform=tvOS Simulator,arch=arm64,name=Apple TV"

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -36,6 +36,6 @@ jobs:
       - name: Test on macOS
         run: xcodebuild test -scheme PowerSync-Package -destination "platform=macOS,arch=arm64,name=My Mac"
       - name: Test on watchOS simulator
-        run: xcodebuild test -scheme PowerSync-Package -destination "platform=watchOS Simulator,arch=arm64,name=Apple Watch Ultra 3"
+        run: xcodebuild test -scheme PowerSync-Package -destination "platform=watchOS Simulator,arch=arm64,name=Apple Watch Ultra 3 (49mm)"
       - name: Test on tvOS simulator
         run: xcodebuild test -scheme PowerSync-Package -destination "platform=tvOS Simulator,arch=arm64,name=Apple TV"

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -33,9 +33,9 @@ jobs:
 
       - name: Test on iOS simulator
         run: xcodebuild test -scheme PowerSync-Package -destination "platform=iOS Simulator,name=iPhone 17"
-      - name: Test on macOS simulator
+      - name: Test on macOS
         run: xcodebuild test -scheme PowerSync-Package -destination "platform=macOS,arch=arm64,name=My Mac"
       - name: Test on watchOS simulator
-        run: xcodebuild test -scheme PowerSync-Package -destination "platform=watchOS Simulator,arch=arm64,name=Apple Watch Ultra"
+        run: xcodebuild test -scheme PowerSync-Package -destination "platform=watchOS Simulator,arch=arm64,name=Apple Watch Ultra 3"
       - name: Test on tvOS simulator
         run: xcodebuild test -scheme PowerSync-Package -destination "platform=tvOS Simulator,arch=arm64,name=Apple TV"

--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up XCode

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Build
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           persist-credentials: false
       - name: Set up XCode

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -17,7 +17,7 @@ jobs:
       security-events: write # Needed to upload findings as code scanning results.
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 


### PR DESCRIPTION
This includes the dependabot PR to upgrade `actions/checkout`, but it mainly updates `build_and_test.yaml` to update simulator names to fix the CI.