### PR TITLE
Fix sync status observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
   as-is so the database can live in an App Group container shared with app extensions.
   Plain filenames keep the existing behavior. The SDK coordinates opening the database to
   avoid conflicts and can share update notifications across the main app and extensions.
+* Fix `SyncStatus.asFlow()` emitting the same object, causing SwiftUI to miss updates.
+* Add the `ObservableSyncStatus` utility, which can be used to track Sync Status updates through an `@Observable` class.
 
 ## 1.14.4
 
-- Fix crash when running a statement in a cursor callback ([#148](https://github.com/powersync-ja/powersync-swift/issues/148)).
+* Fix crash when running a statement in a cursor callback ([#148](https://github.com/powersync-ja/powersync-swift/issues/148)).
 
 ## 1.14.3
 

--- a/Demos/PowerSyncExample/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demos/PowerSyncExample/PowerSyncExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift.git",
       "state" : {
-        "revision" : "aa0079aeb82a4bf00324561a40bffe68c6fe1c26",
-        "version" : "7.9.0"
+        "revision" : "b83108d10f42680d78f23fe4d4d80fc88dab3212",
+        "version" : "7.11.1"
       }
     },
     {

--- a/Demos/PowerSyncExample/PowerSyncExample/Components/ListView.swift
+++ b/Demos/PowerSyncExample/PowerSyncExample/Components/ListView.swift
@@ -10,28 +10,19 @@ struct ListView: View {
     @State private var error: Error?
     @State private var newList: NewListContent?
     @State private var editing: Bool = false
-    @State private var status: SyncStatusData? = nil
 
     var body: some View {
-        if status?.hasSynced != true {
-            VStack {
-                if let status = self.status {
-                    if status.hasSynced != true {
-                        Text("Busy with initial sync...")
-                        
-                        if let progress = status.downloadProgress {
-                            ProgressView(value: progress.fraction)
-                            
-                            if progress.downloadedOperations == progress.totalOperations {
-                                Text("Applying server-side changes...")
-                            } else {
-                                Text("Downloaded \(progress.downloadedOperations) out of \(progress.totalOperations)")
-                            }
-                        }
-                    }
+        let status = system.db.currentStatus.observable
+        
+        if status.hasSynced != true {
+            Text("Busy with initial sync...")
+            if let progress = status.downloadProgress {
+                ProgressView(value: progress.fraction)
+                
+                if progress.downloadedOperations == progress.totalOperations {
+                    Text("Applying server-side changes...")
                 } else {
-                    ProgressView()
-                        .progressViewStyle(CircularProgressViewStyle())
+                    Text("Downloaded \(progress.downloadedOperations) out of \(progress.totalOperations)")
                 }
             }
         }
@@ -92,13 +83,6 @@ struct ListView: View {
                 withAnimation {
                     self.lists = IdentifiedArrayOf(uniqueElements: ls)
                 }
-            }
-        }
-        .task {
-            self.status = system.db.currentStatus
-            
-            for await status in system.db.currentStatus.asFlow() {
-                self.status = status
             }
         }
     }

--- a/Demos/PowerSyncExample/PowerSyncExample/Components/ListView.swift
+++ b/Demos/PowerSyncExample/PowerSyncExample/Components/ListView.swift
@@ -13,16 +13,23 @@ struct ListView: View {
 
     var body: some View {
         let status = system.db.currentStatus.observable
-        
+
         if status.hasSynced != true {
-            Text("Busy with initial sync...")
-            if let progress = status.downloadProgress {
-                ProgressView(value: progress.fraction)
-                
-                if progress.downloadedOperations == progress.totalOperations {
-                    Text("Applying server-side changes...")
+            VStack {
+                if status.hasSynced != nil {
+                    Text("Busy with initial sync...")
+                    if let progress = status.downloadProgress {
+                        ProgressView(value: progress.fraction)
+                        
+                        if progress.downloadedOperations == progress.totalOperations {
+                            Text("Applying server-side changes...")
+                        } else {
+                            Text("Downloaded \(progress.downloadedOperations) out of \(progress.totalOperations)")
+                        }
+                    }
                 } else {
-                    Text("Downloaded \(progress.downloadedOperations) out of \(progress.totalOperations)")
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle())
                 }
             }
         }

--- a/Sources/PowerSync/Implementation/sync/Status.swift
+++ b/Sources/PowerSync/Implementation/sync/Status.swift
@@ -111,7 +111,6 @@ fileprivate struct SyncStatusDataImpl: SyncStatusData {
 fileprivate struct SyncStatusContainer: ~Copyable {
     var inner: MutableSyncStatus
     var snapshot: SyncStatusDataImpl
-    var observable: Any? // ObservableSyncStatus, only available on newer platform versions
 
     init(inner: consuming MutableSyncStatus) {
         self.snapshot = SyncStatusDataImpl(status: inner)
@@ -122,6 +121,7 @@ fileprivate struct SyncStatusContainer: ~Copyable {
 final class SwiftSyncStatus: SyncStatus {
     private let current: Mutex<SyncStatusContainer>
     private let listeners: BroadcastStream<any SyncStatusData> = BroadcastStream()
+    @MainActor private var _observable: Any? // ObservableSyncStatus, only available on newer platform versions
 
     init() {
         self.current = Mutex(SyncStatusContainer(inner: MutableSyncStatus()))
@@ -164,19 +164,13 @@ final class SwiftSyncStatus: SyncStatus {
     
     @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
     @MainActor var observable: ObservableSyncStatus {
-        let (observable, didCreate) = self.current.withLock {
-            if let observable = $0.observable as? ObservableSyncStatus {
-                return (observable, false)
-            }
-            
-            let observable = ObservableSyncStatus(status: $0.snapshot)
-            $0.observable = observable
-            return (observable, true)
+        if let observable = _observable as? ObservableSyncStatus {
+            return observable
         }
         
-        if didCreate {
-            observable.trackUpdates(from: self.listeners)
-        }
+        let observable = ObservableSyncStatus(status: copySnapshot())
+        observable.trackUpdates(from: self.listeners)
+        _observable = observable
         return observable
     }
 

--- a/Sources/PowerSync/Implementation/sync/Status.swift
+++ b/Sources/PowerSync/Implementation/sync/Status.swift
@@ -111,6 +111,7 @@ fileprivate struct SyncStatusDataImpl: SyncStatusData {
 fileprivate struct SyncStatusContainer: ~Copyable {
     var inner: MutableSyncStatus
     var snapshot: SyncStatusDataImpl
+    var observable: Any? // ObservableSyncStatus, only available on newer platform versions
 
     init(inner: consuming MutableSyncStatus) {
         self.snapshot = SyncStatusDataImpl(status: inner)
@@ -128,6 +129,10 @@ final class SwiftSyncStatus: SyncStatus {
 
     private func readStatus<T>(status: (borrowing SyncStatusDataImpl) -> T) -> T {
         return self.current.withLock { status($0.snapshot) }
+    }
+    
+    private func copySnapshot() -> any SyncStatusData {
+        self.current.withLock { status in status.snapshot }
     }
 
     internal func mutateStatus(update: (_ status: inout MutableSyncStatus) -> Void) {
@@ -149,12 +154,30 @@ final class SwiftSyncStatus: SyncStatus {
         }
         
         if didUpdate {
-            self.listeners.dispatch(event: self)
+            self.listeners.dispatch(event: copySnapshot())
         }
     }
 
     func asFlow() -> AsyncStream<any SyncStatusData> {
-        self.listeners.subscribe(addInitial: self)
+        self.listeners.subscribe(addInitial: copySnapshot())
+    }
+    
+    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    @MainActor var observable: ObservableSyncStatus {
+        let (observable, didCreate) = self.current.withLock {
+            if let observable = $0.observable as? ObservableSyncStatus {
+                return (observable, false)
+            }
+            
+            let observable = ObservableSyncStatus(status: $0.snapshot)
+            $0.observable = observable
+            return (observable, true)
+        }
+        
+        if didCreate {
+            observable.trackUpdates(from: self.listeners)
+        }
+        return observable
     }
 
     /// Waits for the first sync status matching a predicate.
@@ -247,4 +270,3 @@ struct IndexedCoreDownloadProgress: SyncDownloadProgress {
         return (prev.0 + total, prev.1 + downloaded)
     }
 }
-

--- a/Sources/PowerSync/Protocol/sync/SyncStatusData.swift
+++ b/Sources/PowerSync/Protocol/sync/SyncStatusData.swift
@@ -63,6 +63,10 @@ public protocol SyncStatus: SyncStatusData, Sendable {
     /// Provides a flow of synchronization status updates.
     /// - Returns: An `AsyncStream` that emits updates whenever the synchronization status changes.
     func asFlow() -> AsyncStream<SyncStatusData>
+    
+    /// An observable alternative to `asFlow()` that updates when the sync status changes.
+    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+    @MainActor var observable: ObservableSyncStatus {get}
 }
 
 /// Current information about a ``SyncStreamSubscription``.
@@ -86,4 +90,58 @@ public struct SyncStreamStatus: Sendable {
         // Parse from same decoder (it's [flatten]ed in Rust)
         self.subscription = try SyncSubscriptionDescription(from: decoder)
     }
+}
+
+/// An observable version of ``SyncStatusData``.
+///
+/// In SwiftUI views and other reactive frameworks, this can be used as an alternative to ``SyncStatus/asFlow()`` to auto-update observers
+/// when the PowerSync status changes.
+@available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
+@MainActor
+@Observable()
+public final class ObservableSyncStatus {
+    internal var status: any SyncStatusData
+    @ObservationIgnored
+    private var observationTask: Task<(), Never>?
+
+    internal init(status: any SyncStatusData) {
+        self.status = status
+    }
+
+    deinit {
+        self.observationTask?.cancel()
+        self.observationTask = nil
+    }
+    
+    internal func trackUpdates(from stream: BroadcastStream<any SyncStatusData>) {
+        // Create iterator synchronously to make sure a listener is installed before we return, ensuring that
+        // all updates are eventually dispatched to the task.
+        let subscription = stream.subscribe()
+
+        self.observationTask = Task { [weak self] in
+            var iterator = subscription.makeAsyncIterator()
+            while let snapshot = await iterator.next() {
+                self?.status = snapshot
+            }
+        }
+    }
+
+    // This currently updates all listeners for every change, since status is the only observed field.
+    // That matches asFlow(), in the future we might want to extract these values into separate fields and
+    // only update them in trackUpdates when they've actually changed.
+
+    public var connected: Bool { status.connected }
+    public var connecting: Bool { status.connecting }
+    public var downloading: Bool { status.downloading }
+    public var downloadProgress: (any SyncDownloadProgress)? { status.downloadProgress }
+    public var uploading: Bool { status.uploading }
+    public var lastSyncedAt: Date? { status.lastSyncedAt }
+    public var hasSynced: Bool? { status.hasSynced }
+    public var uploadError: Any? { status.uploadError }
+    public var downloadError: Any? { status.downloadError }
+    public var anyError: Any? { status.anyError }
+    public var priorityStatusEntries: [PriorityStatusEntry] { status.priorityStatusEntries }
+    public var syncStreams: [SyncStreamStatus]? { status.syncStreams }
+    public func statusForPriority(_ priority: BucketPriority) -> PriorityStatusEntry { status.statusForPriority(priority) }
+    public func forStream(stream: any SyncStreamDescription) -> SyncStreamStatus? { status.forStream(stream: stream) }
 }

--- a/Tests/PowerSyncTests/Implementation/SyncStatusTests.swift
+++ b/Tests/PowerSyncTests/Implementation/SyncStatusTests.swift
@@ -4,6 +4,7 @@ import Foundation
 import Testing
 
 struct SyncStatusTests {
+    @available(macOS 14.0, iOS 17.0, watchOS 10.0, tvOS 17.0, *)
     @Test @MainActor func canObserve() async throws {
         let status = SwiftSyncStatus()
         let observable = status.observable

--- a/Tests/PowerSyncTests/Implementation/SyncStatusTests.swift
+++ b/Tests/PowerSyncTests/Implementation/SyncStatusTests.swift
@@ -1,0 +1,31 @@
+import AsyncAlgorithms
+import Foundation
+@testable import PowerSync
+import Testing
+
+struct SyncStatusTests {
+    @Test @MainActor func canObserve() async throws {
+        let status = SwiftSyncStatus()
+        let observable = status.observable
+        #expect(observable === status.observable, "observable instances should be re-used")
+        
+        var hasDownloadError = false
+        let updatesChannel = AsyncChannel<Void>()
+
+        let observeStatus: () -> Void = {
+            hasDownloadError = observable.downloadError != nil
+        }
+
+        withObservationTracking {
+            observeStatus()
+        } onChange: {
+            Task { await updatesChannel.send(()) }
+        }
+        
+        var updates = updatesChannel.makeAsyncIterator()
+        #expect(!hasDownloadError)
+        
+        status.mutateStatus { $0.internalDownloadError = PowerSyncError.operationFailed(message: "test error", underlyingError: nil) }
+        await updates.next()
+    }
+}

--- a/Tests/PowerSyncTests/SyncTests.swift
+++ b/Tests/PowerSyncTests/SyncTests.swift
@@ -738,7 +738,10 @@ class InMemorySyncIntegrationTests {
 
     @Test func subscriptionsUpdateWhileOffline() async throws {
         let db = openDatabase(PlatformHttpClient.shared)
+        // Make sure the database is initialized
+        try await db.readLock { _ in }
         var statusUpdates = db.currentStatus.asFlow().makeAsyncIterator()
+        let _ = try #require(await statusUpdates.next()) // Initial snapshot
 
         // Subscribing while offline should add the stream to subscriptions reported in the status.
         let subscription = try await db.syncStream(name: "a", params: nil).subscribe()


### PR DESCRIPTION
`SyncStatus.asFlow()` emits the same `SwiftSyncStatus` instance whenever it's changed (as that instance is mutable). With the existing `@State private var status: SyncStatusData` pattern we use in demos, updating the variable to itself means that sync status updates can be lost. The fix is to emit a fresh snapshot instance each time (as done with `copySnapshot()` in this PR).

Even with that fixed, the pattern of having to listen to the status flow in every SwiftUI view interested in it is not optimal. Swift has a builtin implementation of the observer pattern through the `@Observable` macro, which allows tracking updates in a more natural way. This adds the `ObservableSyncStatus` class, exposed through `db.currentStatus.observable`, to expose status updates with that mechanism.