### PR TITLE
fix: clear upload errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   avoid conflicts and can share update notifications across the main app and extensions.
 * Fix `SyncStatus.asFlow()` emitting the same object, causing SwiftUI to miss updates.
 * Add the `ObservableSyncStatus` utility, which can be used to track Sync Status updates through an `@Observable` class.
+* Clear `SyncStatus.uploadError` after a successful upload.
 
 ## 1.14.4
 

--- a/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
+++ b/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
@@ -76,13 +76,13 @@ The next upload iteration will be delayed.
                     lastUploadItem = nextItem
                     db.syncStatus.mutateStatus { $0.uploading = true }
                     try await connector.uploadData(database: db)
+                } else {
+                    // Uploading is completed
+                    try await self.uploadLocalTarget()
                     db.syncStatus.maybeMutateStatus(
                         shouldUpdate: { $0.internalUploadError != nil },
                         apply: { $0.internalUploadError = nil }
                     )
-                } else {
-                    // Uploading is completed
-                    try await self.uploadLocalTarget()
                     break
                 }
             } catch {

--- a/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
+++ b/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
@@ -76,6 +76,10 @@ The next upload iteration will be delayed.
                     lastUploadItem = nextItem
                     db.syncStatus.mutateStatus { $0.uploading = true }
                     try await connector.uploadData(database: db)
+                    db.syncStatus.maybeMutateStatus(
+                        shouldUpdate: { $0.internalUploadError != nil },
+                        apply: { $0.internalUploadError = nil }
+                    )
                 } else {
                     // Uploading is completed
                     try await self.uploadLocalTarget()

--- a/Tests/PowerSyncTests/SyncTests.swift
+++ b/Tests/PowerSyncTests/SyncTests.swift
@@ -232,6 +232,9 @@ class InMemorySyncIntegrationTests {
         )])))
         try await channel.pushLine(.checkpointComplete(lastOpId: "1"))
         try #require(try await query.next() == ["from server"])
+
+        // The error should have been cleared after the successful upload
+        await waitForStatus(db.currentStatus) { $0.uploadError == nil && !$0.uploading }
     }
     
     @Test @MainActor func uploadsOfflineWrites() async throws {


### PR DESCRIPTION
When testing the Request Checkpoint PR work - I noticed that the sync status `uploadError` is never cleared after a successful upload.

Steps to reproduce:
- Trigger an upload, but it should fail (maybe close the backend) - the sync status should reflect the error.
- Allow the upload to succeed, the uploadError should be cleared. 

I added an assertion in the `recoversFromUploadErrors` test. Making this changes causes the test to hang forever on `main`. 

---
AI disclosure: I asked Codex to sanity check, review and verify the implementation with other SDKs.