### PR TITLE
Avoid race condition when updating sync streams

### DIFF
--- a/Sources/PowerSync/Implementation/SyncStreams.swift
+++ b/Sources/PowerSync/Implementation/SyncStreams.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 final class StreamTracker: Sendable {
-    // For each active stream key, how many StreamSubscription instances are active in that key.
     private let groups: Mutex<ActiveStreamsState> = Mutex(ActiveStreamsState())
 
     /// Returns a snapshot of currently active streams, and a stream that will emit an event for all subsequent
@@ -50,6 +49,7 @@ final class StreamTracker: Sendable {
 }
 
 fileprivate class ActiveStreamsState {
+    // For each active stream key, how many StreamSubscription instances are active in that key.
     var groups: Dictionary<StreamKey, Int> = [:]
     let streamsChanged = BroadcastStream<[StreamKey]>()
 

--- a/Sources/PowerSync/Implementation/SyncStreams.swift
+++ b/Sources/PowerSync/Implementation/SyncStreams.swift
@@ -2,17 +2,17 @@ import Foundation
 
 final class StreamTracker: Sendable {
     // For each active stream key, how many StreamSubscription instances are active in that key.
-    private let groups: Mutex<Dictionary<StreamKey, Int>> = Mutex([:])
-    let streamsChanged = BroadcastStream<[StreamKey]>()
-    
-    var currentStreams: [StreamKey] {
-        groups.withLock { groups in Array(groups.keys) }
+    private let groups: Mutex<ActiveStreamsState> = Mutex(ActiveStreamsState())
+
+    /// Returns a snapshot of currently active streams, and a stream that will emit an event for all subsequent
+    /// updates to the list of active streams.
+    func observeActiveStreams() -> ([StreamKey], AsyncStream<[StreamKey]>) {
+        groups.withLock { groups in
+            let subscription = groups.streamsChanged.subscribe()
+            return (groups.activeStreams, subscription)
+        }
     }
-    
-    private func markActiveStreamsHaveChanged() {
-        streamsChanged.dispatch(event: currentStreams)
-    }
-    
+
     fileprivate func subscriptionsCommand(db: PowerSyncDatabaseImpl, request: RustSubscriptionChangeRequest) async throws {
         let _ = try await db.writeTransaction { tx in
             let payload = String(data: try StreamingSyncClient.jsonEncoder.encode(request), encoding: .utf8)
@@ -21,10 +21,10 @@ final class StreamTracker: Sendable {
                 payload
             ])
         }
-        
+
         try await db.resolveOfflineSyncStatusIfNotConnected()
     }
-    
+
     fileprivate func subscribe(db: PowerSyncDatabaseImpl, stream: PendingSyncStream, ttl: TimeInterval?, priority: BucketPriority?) async throws -> SyncSubscriptionImplementation {
         let key = stream.key
         try await subscriptionsCommand(
@@ -35,44 +35,53 @@ final class StreamTracker: Sendable {
                 priority: priority
             )
         )
-        
-        let didCreateGroup = groups.withLock { groups in
-            if let existingCount = groups[key] {
-                groups[key] = existingCount + 1
-                return false
-            } else {
-                groups[key] = 1
-                return true
-            }
-        }
-        
-        if didCreateGroup {
-            markActiveStreamsHaveChanged()
-        }
-        
+
+        groups.withLock { state in state.addStream(key: key) }
         return SyncSubscriptionImplementation(db: db, key: key)
     }
-    
+
     fileprivate func removeStreamGroup(key: StreamKey) {
-        let _ = groups.withLock { groups in groups.removeValue(forKey: key) }
-        markActiveStreamsHaveChanged()
+        groups.withLock { state in state.removeStreamGroup(key: key) }
     }
-    
+
     fileprivate func decrementRefCount(key: StreamKey) {
-        let didChangeStreams = groups.withLock { groups in
-            if let count = groups[key] {
-                if count == 1 {
-                    groups.removeValue(forKey: key)
-                    return true
-                } else {
-                    groups[key] = count - 1
-                }
-            }
-            
-            return false
+        groups.withLock { state in state.decrementRefCount(key: key) }
+    }
+}
+
+fileprivate class ActiveStreamsState {
+    var groups: Dictionary<StreamKey, Int> = [:]
+    let streamsChanged = BroadcastStream<[StreamKey]>()
+
+    var activeStreams: [StreamKey] {
+        Array(groups.keys)
+    }
+
+    private func emit() {
+        streamsChanged.dispatch(event: activeStreams)
+    }
+
+    func addStream(key: StreamKey) {
+        if let existingCount = groups[key] {
+            groups[key] = existingCount + 1
+        } else {
+            groups[key] = 1
+            emit()
         }
-        if didChangeStreams {
-            markActiveStreamsHaveChanged()
+    }
+
+    func removeStreamGroup(key: StreamKey) {
+        groups.removeValue(forKey: key)
+        emit()
+    }
+
+    func decrementRefCount(key: StreamKey) {
+        if let count = groups[key] {
+            if count == 1 {
+                removeStreamGroup(key: key)
+            } else {
+                groups[key] = count - 1
+            }
         }
     }
 }

--- a/Sources/PowerSync/Implementation/SyncStreams.swift
+++ b/Sources/PowerSync/Implementation/SyncStreams.swift
@@ -6,9 +6,9 @@ final class StreamTracker: Sendable {
     /// Returns a snapshot of currently active streams, and a stream that will emit an event for all subsequent
     /// updates to the list of active streams.
     func observeActiveStreams() -> ([StreamKey], AsyncStream<[StreamKey]>) {
-        groups.withLock { groups in
-            let subscription = groups.streamsChanged.subscribe()
-            return (groups.activeStreams, subscription)
+        groups.withLock { state in
+            let subscription = state.streamsChanged.subscribe()
+            return (state.activeStreams, subscription)
         }
     }
 

--- a/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
+++ b/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
@@ -254,7 +254,8 @@ private struct ActiveSyncIteration: Sendable {
     
     func run(group: inout ThrowingTaskGroup<Void, any Error>?) async throws -> SyncIterationResult {
         // Notify the core extension for changed Sync Stream subscriptions, as we might have to reconnect.
-        async let _ = watchSyncStreams()
+        let (currentStreams, streamChanges) = syncClient.db.group.syncCoordinator.streams.observeActiveStreams()
+        async let _ = watchSyncStreams(changes: streamChanges)
         // Notify the core extension for completed crud uploads, as we might want to retry applying a
         // checkpoint in that case.
         async let _ = watchCompletedCrudUploads()
@@ -263,7 +264,7 @@ private struct ActiveSyncIteration: Sendable {
             parameters: syncClient.options.params,
             schema: await syncClient.db.schema.inner,
             includeDefaults: syncClient.options.includeDefaultStreams,
-            activeStreams: syncClient.db.group.syncCoordinator.streams.currentStreams,
+            activeStreams: currentStreams,
             appMetadata: syncClient.options.appMetadata,
         )))
 
@@ -376,8 +377,7 @@ private struct ActiveSyncIteration: Sendable {
         }
     }
     
-    private func watchSyncStreams() async throws {
-        let changes = syncClient.db.group.syncCoordinator.streams.streamsChanged.subscribe()
+    private func watchSyncStreams(changes: AsyncStream<[StreamKey]>) async throws {
         for await change in changes {
             self.localEvents.dispatch(event: .updateSubscriptions(streams: change))
         }


### PR DESCRIPTION
In an `ActiveSyncIteration`, we asynchronously watch active stream subscriptions to notify the core extension about changes when `subscribe()` is called. We also query the list of active stream subscriptions for the initial `powersync_congrol('start')` call.

Because stream subscriptions are watched asynchronously, it's possible for the `currentStreams` getter to be called before `streamsChanged.subscribe()`, leaving a brief window for race conditions if streams are updated during that time. These updates would not be forwarded to the core extension, meaning that the sync client only sees them when querying the local database state on keepalive lines.

This improves the reliability of observing active sync streams by querying the current state and the active listener while holding a mutex. This ensures that all prior stream updates are reflected in the initial state, and all subsequent updates cause the listener to get notified. This also restructures some update logic to avoid acquiring the mutex twice (once to mutate the dictionary of active streams and then again to read the current snapshot).

This is related to https://github.com/powersync-ja/powersync-swift/issues/157, although I couldn't reproduce that issue locally.