### PR TITLE
Prepare 1.15.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.15.0
 
 * `PowerSyncDatabase(dbFilename:)` now accepts an absolute path (starting with `/`), used
   as-is so the database can live in an App Group container shared with app extensions.

--- a/Sources/PowerSync/CurrentVersion.swift
+++ b/Sources/PowerSync/CurrentVersion.swift
@@ -1,2 +1,2 @@
 // The current version of the PowerSync Swift SDK. This should be updated to the latest version in `CHANGELOG.md` when a new version is released.
-let libraryVersion = "1.14.4"
+let libraryVersion = "1.15.0"


### PR DESCRIPTION
This prepares the 1.15.0 release, with the following changes since 1.14.4:

- Experimental multi-process database support (#147).
- The `ObservableSyncStatus` utility (#154).
- Fix clearing the `uploadError` field after successful uploads (#156).
- Allow custom URL sessions, e.g. to add additional headers (#158).

I'll prepare documentation updates for this in https://github.com/powersync-ja/powersync-docs/pull/526.