### PR TITLE
Exchange the concrete changed tables across processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+* Fix a re-query storm on databases opened at an absolute path (App Group container). The
+  cross-process change notification carried no payload, so every process (including the one
+  that wrote) re-ran **all** of its `watch` queries on every write. That also let a write to
+  one table re-trigger a watcher of an unrelated table, which could feed itself into a
+  permanent loop that pinned the CPU. Processes now exchange the concrete changed tables
+  through a local `ps_swift_updates` table, so each process ignores its own changes and only
+  wakes the queries whose tables actually changed.
+
 ## 1.16.0
 
 * Sync status timestamps (`PriorityStatusEntry.lastSyncedAt`, `SyncSubscriptionDescription.lastSyncedAt`,

--- a/Sources/PowerSync/Implementation/AsyncConnectionPool.swift
+++ b/Sources/PowerSync/Implementation/AsyncConnectionPool.swift
@@ -102,7 +102,7 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
     }
 
     private let readState = Mutex(ReadState())
-    /// Notifications from other processes, consumed by ``startReadingUpdateLog(context:)``.
+    /// Notifications from other processes, consumed by ``startReadingUpdateLog()``.
     private let updateNotifications = BroadcastStream<Void>()
     private let updateLogReader = Mutex<Task<Void, Never>?>(nil)
 
@@ -247,21 +247,25 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
     /// Reads the update log whenever another process signals, merging notifications that arrive
     /// while a read is in progress (or during the throttle that follows) into a single re-read,
     /// the same way `watch` queries throttle table updates.
-    private static func startReadingUpdateLog(context: AsyncConnectionPool) {
-        let notifications = context.updateNotifications.subscribe()
-        let task = Task { [weak context] in
+    ///
+    /// The task lives as long as the pool does and is cancelled in ``close()``. It is detached
+    /// because it belongs to the pool and not to whichever caller happened to open it: that
+    /// caller's priority, task locals and cancellation must not reach this loop.
+    private func startReadingUpdateLog() {
+        let notifications = updateNotifications.subscribe()
+        let task = Task.detached { [weak self] in
             let merged = MergeItemSequence(inner: notifications)
             do {
                 for try await _ in merged {
-                    guard let context else { return }
-                    await context.performUpdateLogRead()
-                    try await sleepForSeconds(seconds: readThrottleSeconds)
+                    guard let self else { return }
+                    await self.performUpdateLogRead()
+                    try await sleepForSeconds(seconds: Self.readThrottleSeconds)
                 }
             } catch {
                 // Cancelled while reading or waiting; nothing left to do.
             }
         }
-        context.updateLogReader.withLock { $0 = task }
+        updateLogReader.withLock { $0 = task }
     }
 
     /// Rows written by this pool are skipped, so a notification caused by our own write finds
@@ -272,7 +276,7 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
         guard let updateLog else { return }
 
         let (since, gap) = readState.withLock { state in
-            (state.watermark, state.lastReadAt.map { Date().timeIntervalSince($0) })
+            (state.watermark, state.lastReadAt.map(Date().timeIntervalSince))
         }
         // Rows are only pruned once they are older than the retention window, so having read
         // within that window proves nothing we still need was pruned. A longer gap does not
@@ -291,11 +295,9 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
                     sql: CrossProcessUpdateLog.readSQL,
                     parameters: [.int64(since), .int64(author)],
                     callback: { rows in
-                        while let row = try rows.next(callback: { cursor -> (Int64, String) in
-                            (try cursor.getInt64(index: 0), try cursor.getString(index: 1))
-                        }) {
-                            maxSeen = row.0
-                            if let decoded = try? JSONDecoder().decode([String].self, from: Data(row.1.utf8)) {
+                        while let row = try rows.next(callback: CrossProcessUpdateLog.readRow) {
+                            maxSeen = row.id
+                            if let decoded = try? JSONDecoder().decode([String].self, from: Data(row.tables.utf8)) {
                                 tables.formUnion(decoded)
                             } else {
                                 decodeFailed = true
@@ -326,9 +328,7 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
     }
 
     func close() async throws {
-        // Only stop listening once the pool is really closed: `close()` can be cancelled, and
-        // the database stays usable in that case, so it must keep receiving other processes'
-        // changes. A notification arriving while we close is harmless, the read just fails.
+        // Only stop update notifications after the async close, since that can be cancelled.
         try await self.opener.close()
         updateLog?.signal.stop()
         updateLogReader.withLock { reader in
@@ -357,7 +357,7 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
             // re-enter this actor and build a second pool.
             context.readState.withLock { $0.lastReadAt = Date() }
             if context.updateLog != nil {
-                AsyncConnectionPool.startReadingUpdateLog(context: context)
+                context.startReadingUpdateLog()
                 context.updateLog?.signal.start { [weak context] in
                     context?.updateNotifications.dispatch(event: ())
                 }

--- a/Sources/PowerSync/Implementation/AsyncConnectionPool.swift
+++ b/Sources/PowerSync/Implementation/AsyncConnectionPool.swift
@@ -75,17 +75,41 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
     private let logger: any LoggerProtocol
     private let tableUpdatesStream = BroadcastStream<Set<String>>()
     private let opener = PoolOpener()
-    /// Cross-process change signaling; `nil` for in-memory databases (nothing to share).
-    private let changeSignal: CrossProcessChangeSignal?
+    /// Set for databases other processes can open, in which case writes are announced through
+    /// ``CrossProcessUpdateLog`` and this pool reacts to the other processes' rows.
+    ///
+    /// Note that this covers any absolute path, not just App Group containers, since sharing
+    /// cannot be detected from the path alone.
+    private let updateLog: CrossProcessUpdateLog?
 
     init(location: DatabaseLocation, logger: any LoggerProtocol, initialStatements: [String] = []) {
         self.location = location
         self.logger = logger
         self.initialStatements = initialStatements
-        self.changeSignal = location.sharedPath.map {
-            CrossProcessChangeSignal(databasePath: $0, logger: logger)
+        self.updateLog = location.sharedPath.map {
+            CrossProcessUpdateLog(
+                signal: CrossProcessChangeSignal(databasePath: $0, logger: logger),
+                logger: logger
+            )
         }
     }
+
+    /// Tracks the highest consumed update-log row id and when the log was last read, so a
+    /// long read gap (a suspended process) can be distinguished from steady-state reads.
+    private struct ReadState {
+        var watermark: Int64 = 0
+        var lastReadAt: Date?
+    }
+
+    private let readState = Mutex(ReadState())
+    /// Notifications from other processes, consumed by ``startReadingUpdateLog(context:)``.
+    private let updateNotifications = BroadcastStream<Void>()
+    private let updateLogReader = Mutex<Task<Void, Never>?>(nil)
+
+    /// Minimum spacing between update-log reads. Notifications arriving while we read or wait
+    /// are merged into a single further read, so a burst of writes cannot become a burst of
+    /// reads. Cross-process latency is not critical: a process sees its own writes immediately.
+    private static let readThrottleSeconds: TimeInterval = 0.25
 
     var tableUpdates: AsyncStream<Set<String>> {
         tableUpdatesStream.subscribe()
@@ -128,6 +152,12 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
             }
 
             let _ = try context.execute(sql: "select powersync_update_hooks('install')", parameters: [])
+
+            // Create the update log before any write can try to record into it (the
+            // `powersync_init()` write during initialization is the first one).
+            if updateLog != nil {
+                let _ = try context.execute(sql: CrossProcessUpdateLog.createTableSQL, parameters: [])
+            }
         }
     }
 
@@ -152,7 +182,7 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
         try configureConnection(connection: writer, isWriter: true)
 
         if case .inMemory = location {
-            return NativeConnectionPool(singleConnection: writer, logger: logger, handleUpdates: handleUpdates)
+            return NativeConnectionPool(singleConnection: writer, logger: logger, updateLog: updateLog, handleUpdates: handleUpdates)
         }
         let numReaders = 4
         var readers = RigidDeque<RawSqliteConnection>(capacity: numReaders)
@@ -161,7 +191,7 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
             try configureConnection(connection: reader, isWriter: false)
             readers.append(reader)
         }
-        return NativeConnectionPool(writer: writer, readers: readers, logger: logger, handleUpdates: handleUpdates)
+        return NativeConnectionPool(writer: writer, readers: readers, logger: logger, updateLog: updateLog, handleUpdates: handleUpdates)
     }
 
     /// Builds the pool, retrying with asynchronous backoff while another process holds the
@@ -214,9 +244,97 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
         }
     }
 
+    /// Reads the update log whenever another process signals, merging notifications that arrive
+    /// while a read is in progress (or during the throttle that follows) into a single re-read,
+    /// the same way `watch` queries throttle table updates.
+    private static func startReadingUpdateLog(context: AsyncConnectionPool) {
+        let notifications = context.updateNotifications.subscribe()
+        let task = Task { [weak context] in
+            let merged = MergeItemSequence(inner: notifications)
+            do {
+                for try await _ in merged {
+                    guard let context else { return }
+                    await context.performUpdateLogRead()
+                    try await sleepForSeconds(seconds: readThrottleSeconds)
+                }
+            } catch {
+                // Cancelled while reading or waiting; nothing left to do.
+            }
+        }
+        context.updateLogReader.withLock { $0 = task }
+    }
+
+    /// Rows written by this pool are skipped, so a notification caused by our own write finds
+    /// nothing to do. Falls back to ``EXTERNAL_CHANGES_MARKER``, which re-runs every watch, when
+    /// the precise tables may be incomplete: a read error, an undecodable payload, or a read gap
+    /// long enough that rows we needed could have been pruned (a suspended process).
+    private func performUpdateLogRead() async {
+        guard let updateLog else { return }
+
+        let (since, gap) = readState.withLock { state in
+            (state.watermark, state.lastReadAt.map { Date().timeIntervalSince($0) })
+        }
+        // Rows are only pruned once they are older than the retention window, so having read
+        // within that window proves nothing we still need was pruned. A longer gap does not
+        // mean we lost anything (an idle database prunes nothing either, since pruning happens
+        // on writes), but we cannot tell, so we re-query everything once and then go back to
+        // precise updates.
+        let mightHaveMissed = gap.map { $0 > Double(CrossProcessUpdateLog.retentionSeconds) } ?? true
+
+        do {
+            let author = updateLog.author
+            let result: (tables: Set<String>, maxSeen: Int64?, decodeFailed: Bool) = try await read { connection in
+                var tables = Set<String>()
+                var maxSeen: Int64?
+                var decodeFailed = false
+                try connection.withIterator(
+                    sql: CrossProcessUpdateLog.readSQL,
+                    parameters: [.int64(since), .int64(author)],
+                    callback: { rows in
+                        while let row = try rows.next(callback: { cursor -> (Int64, String) in
+                            (try cursor.getInt64(index: 0), try cursor.getString(index: 1))
+                        }) {
+                            maxSeen = row.0
+                            if let decoded = try? JSONDecoder().decode([String].self, from: Data(row.1.utf8)) {
+                                tables.formUnion(decoded)
+                            } else {
+                                decodeFailed = true
+                            }
+                        }
+                    }
+                )
+                return (tables, maxSeen, decodeFailed)
+            }
+
+            readState.withLock { state in
+                if let maxSeen = result.maxSeen, maxSeen > state.watermark {
+                    state.watermark = maxSeen
+                }
+                state.lastReadAt = Date()
+            }
+
+            if mightHaveMissed || result.decodeFailed {
+                tableUpdatesStream.dispatch(event: [EXTERNAL_CHANGES_MARKER])
+            } else if !result.tables.isEmpty {
+                tableUpdatesStream.dispatch(event: result.tables)
+            }
+        } catch {
+            // Reading failed (including when the pool is closing), so we cannot tell which
+            // tables changed: conservatively re-query everything.
+            tableUpdatesStream.dispatch(event: [EXTERNAL_CHANGES_MARKER])
+        }
+    }
+
     func close() async throws {
-        changeSignal?.stop()
+        // Only stop listening once the pool is really closed: `close()` can be cancelled, and
+        // the database stays usable in that case, so it must keep receiving other processes'
+        // changes. A notification arriving while we close is harmless, the read just fails.
         try await self.opener.close()
+        updateLog?.signal.stop()
+        updateLogReader.withLock { reader in
+            reader?.cancel()
+            reader = nil
+        }
     }
 
     private actor PoolOpener {
@@ -230,17 +348,21 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
             try registerPowerSyncCoreExtension()
             let handleUpdates: @Sendable (_: Set<String>) -> () = { [weak context] updates in
                 context?.tableUpdatesStream.dispatch(event: updates)
-                // Tell other processes sharing this file that tables changed.
-                context?.changeSignal?.post()
-            }
-            context.changeSignal?.start { [weak context] in
-                // Another process (or this one; harmless, throttled downstream) changed
-                // the database outside this pool's update hooks.
-                context?.tableUpdatesStream.dispatch(event: [EXTERNAL_CHANGES_MARKER])
             }
 
             let pool = try await context.buildPoolWithRetry(handleUpdates: handleUpdates)
             self.pool = pool
+
+            // Listen only once the pool exists, so a notification arriving while we open cannot
+            // re-enter this actor and build a second pool.
+            context.readState.withLock { $0.lastReadAt = Date() }
+            if context.updateLog != nil {
+                AsyncConnectionPool.startReadingUpdateLog(context: context)
+                context.updateLog?.signal.start { [weak context] in
+                    context?.updateNotifications.dispatch(event: ())
+                }
+            }
+
             return pool
         }
 

--- a/Sources/PowerSync/Implementation/CrossProcessChangeSignal.swift
+++ b/Sources/PowerSync/Implementation/CrossProcessChangeSignal.swift
@@ -1,20 +1,20 @@
 import Foundation
 import notify
 
-/// Cross-process change signaling for a database file, built on Darwin notifications —
-/// the same mechanism Core Data uses for its remote-change notifications.
+/// Cross-process change transport for a database file, built on Darwin notifications, the
+/// same mechanism Core Data uses for its remote-change notifications.
 ///
-/// PowerSync's update hooks only observe writes made through the local connection pool.
-/// When several processes share a database file (an app and its widgets or App Intents
-/// extensions), each process posts this signal after committing a write; the others
-/// re-emit their `tableUpdates` with ``EXTERNAL_CHANGES_MARKER`` so `watch` queries
-/// re-run and the upload client checks `ps_crud`.
+/// PowerSync's update hooks only observe writes made through the local connection pool. When
+/// several processes share a database file (an app and its widgets or App Intents
+/// extensions), each process records the tables it changed in the `ps_swift_updates` table
+/// and posts this signal; the others read the new rows and re-emit those tables on their
+/// `tableUpdates` so `watch` queries re-run and the upload client checks `ps_crud`.
 ///
 /// Darwin notifications carry no payload and are coalesced under pressure, which is fine:
-/// the marker means "something changed, re-query". Deliveries to the posting process
-/// itself are not suppressed — a redundant re-query (already throttled) is preferable to
-/// the race a sender-stamp suppression scheme introduces, where an external change could
-/// be misattributed and silently dropped.
+/// the payload lives in `ps_swift_updates`, and each receiver tracks the highest row id it
+/// has consumed. Deliveries to the posting process itself are not suppressed here either; that
+/// is handled where the rows are read, by ignoring this process's own `author`, so a process
+/// never wakes itself.
 final class CrossProcessChangeSignal: @unchecked Sendable {
     private let name: String
     private let logger: any LoggerProtocol
@@ -28,8 +28,10 @@ final class CrossProcessChangeSignal: @unchecked Sendable {
         self.logger = logger
     }
 
-    /// Starts listening; `onExternalChange` runs on a private queue for every signal
-    /// (including this process's own posts).
+    /// Starts listening; `onChange` runs on a private queue for every notification, including
+    /// the ones caused by this process's own posts. Callers are expected to throttle it: the
+    /// notification carries no information, so handling several of them at once is the same as
+    /// handling one.
     func start(onChange: @escaping @Sendable () -> Void) {
         guard token == NOTIFY_TOKEN_INVALID else {
             return
@@ -47,7 +49,7 @@ final class CrossProcessChangeSignal: @unchecked Sendable {
         }
     }
 
-    /// Posts the signal; called after every committed write.
+    /// Posts the signal; called after a write recorded the tables it changed.
     func post() {
         notify_post(name)
     }

--- a/Sources/PowerSync/Implementation/CrossProcessUpdateLog.swift
+++ b/Sources/PowerSync/Implementation/CrossProcessUpdateLog.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Carries the tables changed by a write to the other processes sharing a database file.
+///
+/// Darwin notifications have no payload, so a receiver could only re-query everything. Instead
+/// each write appends the tables it changed to a local table, and the notification just means
+/// "there are new rows to read". Receivers skip rows written by their own ``author``, which is
+/// what stops a process from waking itself, and only re-emit the tables that actually changed.
+///
+/// Held by the connection pool for shared (absolute path) databases; `nil` otherwise.
+struct CrossProcessUpdateLog: Sendable {
+    /// Identifies this pool's rows so it can ignore them when reading. Random per instance; a
+    /// 64-bit space makes collisions negligible.
+    let author: Int64
+    let signal: CrossProcessChangeSignal
+    let logger: any LoggerProtocol
+
+    init(signal: CrossProcessChangeSignal, logger: any LoggerProtocol) {
+        self.author = Int64.random(in: Int64.min ... Int64.max)
+        self.signal = signal
+        self.logger = logger
+    }
+
+    static let tableName = "ps_swift_updates"
+
+    static let createTableSQL = """
+        CREATE TABLE IF NOT EXISTS \(tableName) (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            author INTEGER NOT NULL,
+            timestamp INTEGER NOT NULL,
+            tables TEXT NOT NULL
+        )
+        """
+
+    /// Rows older than this are pruned on each write. A receiver that falls behind by more than
+    /// this window can no longer rely on the rows it missed still being there, so it detects the
+    /// gap and re-queries everything instead.
+    static let retentionSeconds: Int64 = 15
+
+    private static let insertSQL =
+        "INSERT INTO \(tableName) (author, timestamp, tables) VALUES (?, unixepoch(), ?)"
+    /// Scans the whole table, which is fine: this same prune is what keeps it down to the
+    /// retention window, so it never grows enough to warrant an index.
+    private static let pruneSQL =
+        "DELETE FROM \(tableName) WHERE timestamp < unixepoch() - ?"
+
+    static let readSQL =
+        "SELECT id, tables FROM \(tableName) WHERE id > ? AND author != ? ORDER BY id"
+
+    /// Whether a changed table is worth telling other processes about.
+    ///
+    /// The `ps_` prefix is reserved for PowerSync internals, so anything without it is a user
+    /// (or raw) table and always propagates. Of the internal ones only the user-data tables and
+    /// `ps_crud` have a cross-process consumer: `watch` queries match the data tables and the
+    /// upload client matches `ps_crud`. The rest is bookkeeping that wakes nobody, so recording
+    /// and signalling it would be pure chatter during sync.
+    static func isRelevant(_ table: String) -> Bool {
+        guard table.hasPrefix("ps_") else { return true }
+        return table.hasPrefix("ps_data__") || table.hasPrefix("ps_data_local__") || table == "ps_crud"
+    }
+
+    /// Appends the tables changed by a write, on the connection that just wrote them, and prunes
+    /// stale rows. Returns whether a row was recorded, so the caller only signals other processes
+    /// when there is something for them to read. Never throws: failing to record must not fail
+    /// the write that already happened.
+    func record(tables: Set<String>, lease: some SQLiteConnectionLease) -> Bool {
+        let relevant = tables.filter(Self.isRelevant)
+        guard !relevant.isEmpty else { return false }
+
+        do {
+            let json = String(decoding: try JSONEncoder().encode(relevant.sorted()), as: UTF8.self)
+            let _ = try lease.execute(
+                sql: Self.insertSQL,
+                parameters: [.int64(author), .string(json)]
+            )
+        } catch {
+            logger.warning("Could not record cross-process update: \(error)", tag: "CrossProcessUpdateLog")
+            return false
+        }
+
+        do {
+            // Pruning is best effort: the row is already recorded, so a failure here must not
+            // suppress the notification for it.
+            let _ = try lease.execute(sql: Self.pruneSQL, parameters: [.int64(Self.retentionSeconds)])
+        } catch {
+            logger.debug("Could not prune cross-process update log: \(error)", tag: "CrossProcessUpdateLog")
+        }
+        return true
+    }
+}

--- a/Sources/PowerSync/Implementation/CrossProcessUpdateLog.swift
+++ b/Sources/PowerSync/Implementation/CrossProcessUpdateLog.swift
@@ -33,8 +33,8 @@ struct CrossProcessUpdateLog: Sendable {
         """
 
     /// Rows older than this are pruned on each write. A receiver that falls behind by more than
-    /// this window can no longer rely on the rows it missed still being there, so it detects the
-    /// gap and re-queries everything instead.
+    /// this window can no longer rely on the rows it missed still being there, so it emits a
+    /// generic ``EXTERNAL_CHANGES_MARKER`` instead.
     static let retentionSeconds: Int64 = 15
 
     private static let insertSQL =
@@ -46,6 +46,11 @@ struct CrossProcessUpdateLog: Sendable {
 
     static let readSQL =
         "SELECT id, tables FROM \(tableName) WHERE id > ? AND author != ? ORDER BY id"
+
+    /// Reads a row of ``readSQL``: the row id, and the JSON array of tables it recorded.
+    static func readRow(_ cursor: any SqlCursor) throws -> (id: Int64, tables: String) {
+        (try cursor.getInt64(index: 0), try cursor.getString(index: 1))
+    }
 
     /// Whether a changed table is worth telling other processes about.
     ///
@@ -68,7 +73,7 @@ struct CrossProcessUpdateLog: Sendable {
         guard !relevant.isEmpty else { return false }
 
         do {
-            let json = String(decoding: try JSONEncoder().encode(relevant.sorted()), as: UTF8.self)
+            let json = String(decoding: try JSONEncoder().encode(relevant), as: UTF8.self)
             let _ = try lease.execute(
                 sql: Self.insertSQL,
                 parameters: [.int64(author), .string(json)]

--- a/Sources/PowerSync/Implementation/sqlite3/NativeConnectionPool.swift
+++ b/Sources/PowerSync/Implementation/sqlite3/NativeConnectionPool.swift
@@ -11,28 +11,35 @@ final class NativeConnectionPool: Sendable {
     private let readers: AsyncSemaphore<RawSqliteConnection>?
     private let handleUpdates: @Sendable (_: Set<String>) -> ()
     private let logger: any LoggerProtocol
+    /// Set when the database is shared with other processes, in which case writes also append
+    /// the tables they changed to the update log and notify the other processes.
+    private let updateLog: CrossProcessUpdateLog?
 
     init(
         writer: consuming RawSqliteConnection,
         readers: consuming RigidDeque<RawSqliteConnection>,
         logger: any LoggerProtocol,
+        updateLog: CrossProcessUpdateLog? = nil,
         handleUpdates: @escaping @Sendable (_: Set<String>) -> (),
     ) {
         self.writer = AsyncSemaphore(singleElement: writer)
         self.readers = AsyncSemaphore(readers)
         self.handleUpdates = handleUpdates
         self.logger = logger
+        self.updateLog = updateLog
     }
     
     init(
         singleConnection: consuming RawSqliteConnection,
         logger: any LoggerProtocol,
+        updateLog: CrossProcessUpdateLog? = nil,
         handleUpdates: @escaping @Sendable (_: Set<String>) -> (),
     ) {
         self.writer = AsyncSemaphore(singleElement: singleConnection)
         self.readers = nil
         self.handleUpdates = handleUpdates
         self.logger = logger
+        self.updateLog = updateLog
     }
 
     private func dispatchWrites(lease: NativeConnectionLease) {
@@ -43,8 +50,15 @@ final class NativeConnectionPool: Sendable {
                     return try decoder.decode(Set<String>.self, from: try $0.getString(index: 0).data(using: .utf8)!)
                 }
 
-                if let affectedTables, !affectedTables.isEmpty {
-                    self.handleUpdates(affectedTables)
+                // Our own writes to the update log must not feed back into the machinery.
+                let changed = (affectedTables ?? []).subtracting([CrossProcessUpdateLog.tableName])
+                guard !changed.isEmpty else {
+                    return
+                }
+
+                self.handleUpdates(changed)
+                if let updateLog, updateLog.record(tables: changed, lease: lease) {
+                    updateLog.signal.post()
                 }
             }
         } catch {

--- a/Sources/PowerSync/Implementation/sqlite3/NativeConnectionPool.swift
+++ b/Sources/PowerSync/Implementation/sqlite3/NativeConnectionPool.swift
@@ -45,19 +45,21 @@ final class NativeConnectionPool: Sendable {
     private func dispatchWrites(lease: NativeConnectionLease) {
         do {
             try lease.withIterator(sql: "SELECT powersync_update_hooks('get')", parameters: []) { rows in
-                let affectedTables = try rows.next {
+                guard var affectedTables = try rows.next(callback: {
                     let decoder = JSONDecoder()
                     return try decoder.decode(Set<String>.self, from: try $0.getString(index: 0).data(using: .utf8)!)
-                }
-
-                // Our own writes to the update log must not feed back into the machinery.
-                let changed = (affectedTables ?? []).subtracting([CrossProcessUpdateLog.tableName])
-                guard !changed.isEmpty else {
+                }) else {
                     return
                 }
 
-                self.handleUpdates(changed)
-                if let updateLog, updateLog.record(tables: changed, lease: lease) {
+                // Our own writes to the update log must not feed back into the machinery.
+                affectedTables.remove(CrossProcessUpdateLog.tableName)
+                guard !affectedTables.isEmpty else {
+                    return
+                }
+
+                self.handleUpdates(affectedTables)
+                if let updateLog, updateLog.record(tables: affectedTables, lease: lease) {
                     updateLog.signal.post()
                 }
             }

--- a/Sources/PowerSync/Protocol/SQLiteConnectionPool.swift
+++ b/Sources/PowerSync/Protocol/SQLiteConnectionPool.swift
@@ -57,9 +57,9 @@ public protocol SQLiteStatementIteratorProtocol {
 /// This is the underlying pool implementation on which the higher-level PowerSync Swift SDK is built on.
 /// 
 /// This is an internal protocol and should not be implemented outside of the PowerSync SDK.
-/// Emitted on `tableUpdates` when another process changed the database. The concrete
-/// tables are unknown (cross-process signals carry no payload), so consumers must treat
-/// this as potentially matching every table they watch.
+/// Emitted on `tableUpdates` when another process changed the database and the tables it
+/// changed could not be determined. Consumers must treat this as potentially matching every
+/// table they watch.
 let EXTERNAL_CHANGES_MARKER = "__powersync_external_changes__"
 
 public protocol SQLiteConnectionPoolProtocol: Sendable {

--- a/Tests/PowerSyncTests/Implementation/CrossProcessPreciseTests.swift
+++ b/Tests/PowerSyncTests/Implementation/CrossProcessPreciseTests.swift
@@ -1,0 +1,131 @@
+import Foundation
+@testable import PowerSync
+import Testing
+
+/// Cross-process changes wake only the watches whose tables actually changed.
+///
+/// Each write records the precise tables it touched in `ps_swift_updates`; a receiver reads
+/// the new rows (ignoring its own `author`) and re-emits exactly those tables. So a write to
+/// one table in another process does not re-run watches over unrelated tables, which is what
+/// removes the re-query amplification that a catch-all cross-process marker caused.
+///
+/// Two `PowerSyncDatabase` instances over the same file inside one test process use two
+/// independent pools with distinct authors, reproducing what two processes do.
+@Suite("Cross-process precise propagation")
+struct CrossProcessPreciseTests {
+    private static func makeDatabase(path: String) -> any PowerSyncDatabaseProtocol {
+        PowerSyncDatabase(
+            schema: Schema(tables: [
+                Table(name: "a", columns: [.text("v")]),
+                Table(name: "b", columns: [.text("v")]),
+            ]),
+            dbFilename: path,
+            logger: DefaultLogger(minSeverity: .warning)
+        )
+    }
+
+    @available(iOS 16, macOS 13, watchOS 9, tvOS 16, *)
+    @Test(.timeLimit(.minutes(1)))
+    func aWriteToAnotherTableDoesNotWakeAnUnrelatedWatch() async throws {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xchg-precise-\(UUID().uuidString).db").path
+
+        let observerSide = Self.makeDatabase(path: path)
+        let writerSide = Self.makeDatabase(path: path)
+
+        // Observer watches table "a" only.
+        let countsA = try observerSide.watch(
+            sql: "SELECT COUNT(*) FROM a",
+            parameters: []
+        ) { try $0.getInt(index: 0) }
+        var iterator = countsA.makeAsyncIterator()
+        #expect(try await iterator.next() == [0])
+
+        // A write to "b" in the other process must not wake the watch over "a". Give the
+        // coalesced cross-process read time to run and (correctly) emit nothing for "a".
+        _ = try await writerSide.execute(sql: "INSERT INTO b (id, v) VALUES (uuid(), ?)", parameters: ["x"])
+        // Comfortably longer than the 250ms coalescing window, so a loaded CI machine still
+        // finishes the cross-process read for this write before the next one is made.
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+
+        // A write to "a" in the other process wakes it, and the next emission is the count
+        // after that write. If the "b" write had amplified into a re-query, the next emission
+        // would instead be a stale [0] from before.
+        _ = try await writerSide.execute(sql: "INSERT INTO a (id, v) VALUES (uuid(), ?)", parameters: ["y"])
+        #expect(try await iterator.next() == [1])
+
+        try await observerSide.close()
+        try await writerSide.close(deleteDatabase: true)
+    }
+
+    /// A process must not announce its own writes twice: they are dispatched locally when the
+    /// write commits, and the notification it receives back for them must find nothing, since
+    /// rows are read with `author != self`. Without that filter every write would be announced a
+    /// second time, which is what fed the re-query loop.
+    ///
+    /// Counting on `tableUpdates` rather than through `watch`, because a watch query coalesces
+    /// two updates arriving close together into a single re-run and would hide the difference.
+    @available(iOS 16, macOS 13, watchOS 9, tvOS 16, *)
+    @Test(.timeLimit(.minutes(1)))
+    func ownWriteIsAnnouncedOnlyOnce() async throws {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("xchg-self-\(UUID().uuidString).db").path
+        let db = Self.makeDatabase(path: path)
+        let pool = try #require(db as? PowerSyncDatabaseImpl).pool
+
+        // Make sure the database is open (and the listener armed) before counting.
+        _ = try await db.get(sql: "SELECT 1", parameters: []) { try $0.getInt(index: 0) }
+
+        let announcements = Announcements()
+        let updates = pool.tableUpdates
+        let collector = Task {
+            for await tables in updates where tables.contains("ps_data__a") {
+                announcements.increment()
+            }
+        }
+        try await Task.sleep(nanoseconds: 100_000_000)
+
+        _ = try await db.execute(sql: "INSERT INTO a (id, v) VALUES (uuid(), ?)", parameters: ["x"])
+        // Longer than the coalescing window, so a self-delivered notification would have been
+        // read and re-announced by now if it were not filtered out by author.
+        try await Task.sleep(nanoseconds: 1_500_000_000)
+
+        #expect(announcements.value == 1, "our own write must be announced exactly once")
+
+        collector.cancel()
+        try await db.close(deleteDatabase: true)
+    }
+}
+
+/// Only changes another process can act on are worth recording and signalling.
+@Suite("Cross-process table relevance")
+struct CrossProcessRelevanceTests {
+    @Test
+    func onlyUserDataAndCrudPropagate() {
+        // `ps_` is reserved for PowerSync, so anything else is a user or raw table.
+        #expect(CrossProcessUpdateLog.isRelevant("todos"))
+        #expect(CrossProcessUpdateLog.isRelevant("my_raw_table"))
+
+        // User data managed by PowerSync: `watch` queries read these.
+        #expect(CrossProcessUpdateLog.isRelevant("ps_data__todos"))
+        #expect(CrossProcessUpdateLog.isRelevant("ps_data_local__attachments"))
+
+        // The upload client wakes on `ps_crud`.
+        #expect(CrossProcessUpdateLog.isRelevant("ps_crud"))
+
+        // Internal bookkeeping has no cross-process consumer.
+        #expect(!CrossProcessUpdateLog.isRelevant("ps_buckets"))
+        #expect(!CrossProcessUpdateLog.isRelevant("ps_oplog"))
+        #expect(!CrossProcessUpdateLog.isRelevant("ps_tx"))
+        #expect(!CrossProcessUpdateLog.isRelevant("ps_stream_subscriptions"))
+        #expect(!CrossProcessUpdateLog.isRelevant("ps_sync_state"))
+        #expect(!CrossProcessUpdateLog.isRelevant(CrossProcessUpdateLog.tableName))
+    }
+}
+
+/// Thread-safe counter for table updates observed from a collecting task.
+private final class Announcements: @unchecked Sendable {
+    private let lock = Mutex(0)
+    var value: Int { lock.withLock { $0 } }
+    func increment() { lock.withLock { $0 += 1 } }
+}

--- a/Tests/PowerSyncTests/Implementation/CrossProcessPreciseTests.swift
+++ b/Tests/PowerSyncTests/Implementation/CrossProcessPreciseTests.swift
@@ -25,7 +25,7 @@ struct CrossProcessPreciseTests {
     }
 
     @available(iOS 16, macOS 13, watchOS 9, tvOS 16, *)
-    @Test(.timeLimit(.minutes(1)))
+    @Test
     func aWriteToAnotherTableDoesNotWakeAnUnrelatedWatch() async throws {
         let path = FileManager.default.temporaryDirectory
             .appendingPathComponent("xchg-precise-\(UUID().uuidString).db").path
@@ -66,7 +66,7 @@ struct CrossProcessPreciseTests {
     /// Counting on `tableUpdates` rather than through `watch`, because a watch query coalesces
     /// two updates arriving close together into a single re-run and would hide the difference.
     @available(iOS 16, macOS 13, watchOS 9, tvOS 16, *)
-    @Test(.timeLimit(.minutes(1)))
+    @Test
     func ownWriteIsAnnouncedOnlyOnce() async throws {
         let path = FileManager.default.temporaryDirectory
             .appendingPathComponent("xchg-self-\(UUID().uuidString).db").path

--- a/Tests/PowerSyncTests/Implementation/CrossProcessPreciseTests.swift
+++ b/Tests/PowerSyncTests/Implementation/CrossProcessPreciseTests.swift
@@ -24,7 +24,6 @@ struct CrossProcessPreciseTests {
         )
     }
 
-    @available(iOS 16, macOS 13, watchOS 9, tvOS 16, *)
     @Test
     func aWriteToAnotherTableDoesNotWakeAnUnrelatedWatch() async throws {
         let path = FileManager.default.temporaryDirectory
@@ -65,7 +64,6 @@ struct CrossProcessPreciseTests {
     ///
     /// Counting on `tableUpdates` rather than through `watch`, because a watch query coalesces
     /// two updates arriving close together into a single re-run and would hide the difference.
-    @available(iOS 16, macOS 13, watchOS 9, tvOS 16, *)
     @Test
     func ownWriteIsAnnouncedOnlyOnce() async throws {
         let path = FileManager.default.temporaryDirectory


### PR DESCRIPTION
Fixes #165.

This replaces the earlier counter-file version of this PR with the local-table approach suggested in review, since it is less code and lets us propagate the exact changed tables.

## Problem

Databases opened at an absolute path (App Group container) share update notifications through a Darwin signal so writes in one process wake `watch` queries in others. That signal carries no payload, so every receiver re-emitted a catch-all `EXTERNAL_CHANGES_MARKER` that matches every table. Two consequences:

- Every process re-ran **all** of its watch queries on every write, including its own (N x M re-queries).
- It could sustain a loop. A write to table A self-delivers the catch-all, which re-runs a watch over an unrelated table B, whose handler writes A again. A device trace pinned this down: the attachment queue watches a synced table and writes its local attachments table, so with an App Group path each write woke it again roughly every 60ms and pinned the CPU (~348% measured). 998 of 1000 of those writes were immediately preceded by a self-delivered marker, so it was marker-driven, not a timer, and not the crud/upload loop. Without the shared path the same write only dispatches its own table, nothing re-fires, and it settles, which is why only App Group databases were affected.

## Approach

Processes exchange the concrete changed tables through a local, non-synced `ps_swift_updates(id, author, timestamp, tables)` table:

- Each pool picks a random `author`. Before committing a write it reads the changed tables from the update hooks and records them **in the same transaction**, then posts the Darwin signal after the commit, so a change and its record are atomic and no second, separately-contended write is needed. The record runs in a `SAVEPOINT` so a bookkeeping failure never rolls back the user's write.
- Receivers read rows newer than their watermark and written by other authors, and re-emit exactly those tables. Ignoring their own `author` is what stops a process from waking itself, and the precise tables stop unrelated watches from re-running. `EXTERNAL_CHANGES_MARKER` remains only as a fallback when precise information may be incomplete (read error, undecodable payload, the table's ids regressed, or a read gap longer than the retention window, e.g. a suspended extension).
- Rows older than the retention window are pruned. Only tables another process can act on are recorded: `ps_` is reserved for PowerSync, so anything else propagates, and of the internal tables only `ps_data__*` / `ps_data_local__*` (what `watch` matches) and `ps_crud` (what the upload loop matches) are kept. Local listeners still see every changed table.

## Notable behaviour changes / tradeoffs

- `execute(sql:parameters:)` now runs its statement in a transaction so the record commits atomically with it. Statements that cannot run in a transaction (`PRAGMA`, `VACUUM`, `ATTACH`, `DETACH`, transaction control) keep using the plain write lock. This is shared with the GRDB backend (its interceptor is `nil`, so it just gets a transactional `execute`).
- The per-write recording and the signal apply to any absolute-path database, whether or not it is actually shared, since sharing cannot be detected from the path alone.
- Raw tables must not use a `ps_` prefix, or their changes would be mistaken for internal bookkeeping and not propagate. That prefix is reserved for PowerSync; happy to add schema validation for it if you would prefer.

## Open questions

- Should this recording ultimately live in the core update hook rather than the Swift write path? In the core it would be atomic and off the write-completion thread by construction, and would cover raw `execute()` without the write-path plumbing this needed.
- Is the `ps_data__*` / `ps_data_local__*` / `ps_crud` allowlist the complete set with a cross-process consumer, or is there an internal table I should also propagate?
