### PR TITLE
Fix race condition in MergeItemSequence dropping errors

### DIFF
--- a/Sources/PowerSync/Utils/MergeItemSequence.swift
+++ b/Sources/PowerSync/Utils/MergeItemSequence.swift
@@ -29,14 +29,14 @@ struct MergeItemSequence<Base: AsyncSequence & Sendable>: AsyncSequence where Ba
         init(inner: Base) {
             let state = IteratorState()
             self.pollTask = Task {
-                defer { state.inner.withLock { $0.transitionToDone() } }
-
                 do {
-                    for try await event in inner {
-                        state.inner.withLock { $0.markHasEvent(event: .success(event)) }
+                    for try await _ in inner {
+                        state.inner.withLock { $0.markHasEvent() }
                     }
+
+                    state.inner.withLock { $0.transitionToDone() }
                 } catch {
-                    state.inner.withLock { $0.markHasEvent(event: .failure(error)) }
+                    state.inner.withLock { $0.markFailed(error: error) }
                 }
             }
 
@@ -74,7 +74,12 @@ private enum MergeSequenceState {
     /// We're waiting in next() for an upstream emission.
     case waitingForUpstream(CheckedContinuation<()?, any Error>)
     /// We have an upstream emission that has not yet been sent (due to backpressure or throttle).
-    case hasPendingEvent(Result<(), any Error>)
+    case hasPendingEvent
+    /// Fetching from upstream failed.
+    /// 
+    /// This is a final state, we just need to ensure it gets emitted downstream before transitioning
+    /// to done.
+    case failure(any Error)
     case done
     
     mutating func registerListener(_ continuation: CheckedContinuation<()?, any Error>) {
@@ -83,20 +88,32 @@ private enum MergeSequenceState {
             self = .waitingForUpstream(continuation)
         case .waitingForUpstream(_):
             fatalError("Async throttle sequence has two concurrent listeners?!")
-        case .hasPendingEvent(let pending):
-            continuation.resume(with: pending.map { _ in () })
+        case .hasPendingEvent:
+            continuation.resume(returning: ())
             self = .idle
+        case .failure(let error):
+            continuation.resume(throwing: error)
+            self = .done
         case .done:
             continuation.resume(returning: nil)
         }
     }
 
-    mutating func markHasEvent(event: Result<(), any Error>) {
+    mutating func markHasEvent() {
         if case let .waitingForUpstream(continuation) = self {
-            continuation.resume(with: event.map { _ in () })
+            continuation.resume(returning: ())
             self = .idle
         } else {
-            self = .hasPendingEvent(event)
+            self = .hasPendingEvent
+        }
+    }
+
+    mutating func markFailed(error: any Error) {
+        if case let .waitingForUpstream(continuation) = self {
+            continuation.resume(throwing: error)
+            self = .done
+        } else {
+            self = .failure(error)
         }
     }
 

--- a/Sources/PowerSync/Utils/MergeItemSequence.swift
+++ b/Sources/PowerSync/Utils/MergeItemSequence.swift
@@ -77,8 +77,12 @@ private enum MergeSequenceState {
     case hasPendingEvent
     /// Fetching from upstream failed.
     /// 
-    /// This is a final state, we just need to ensure it gets emitted downstream before transitioning
-    /// to done.
+    /// For the task fetching events, this is a final state: Once errored, it will not emit any
+    /// further events, and it won't set the state to `done` like it would if the source iterator
+    /// had completed normally.
+    /// 
+    /// This exists as a separate state to ensure a subsequent call to `next()` can throw. Once
+    /// the error was observed there, this state transitions to `done`.
     case failure(any Error)
     case done
     

--- a/Tests/PowerSyncTests/Utils/MergeItemSequence.swift
+++ b/Tests/PowerSyncTests/Utils/MergeItemSequence.swift
@@ -46,6 +46,15 @@ struct MergeItemSequenceTest {
         await #expect(throws: PowerSyncError.self) { try await items.next() }
     }
 
+    @Test func reportsErrorsToSlowListener() async throws {
+        let items = generateMerged().makeAsyncIterator()
+        await source.fail(PowerSyncError.operationFailed(message: "error for test"))
+        for _ in 0...100 {
+            await Task.yield()
+        }
+        await #expect(throws: PowerSyncError.self) { try await items.next() }
+    }
+
     @Test func forwardsClose() async throws {
         let items = generateMerged().makeAsyncIterator()
         await source.send(())


### PR DESCRIPTION
An error state in `MergeItemSequence` should be final, as it can only happen in a `catch` block after the task broke out of its loop. Currently, a `defer` block above the do/catch would transition the state to `.done` shortly after reporting the error, dropping the intermediate error state.

Instead of representing events as results, this adds a dedicated error state that transitions to `.done` when observed, removing the need for the broken `defer`.

AI use: Changes are manual, issue was originally found with Codex after a CI failure on https://github.com/powersync-ja/powersync-swift/pull/153. Claude found a few more potential issues around a cancelled call to `next()` potentially dropping errors, but this should make the test more reliable and in SDK uses we don't actually let errors flow into `MergeItemSequence`.