### PR TITLE
Fix issue with weak let in Sendable AirDatabaseGroup

### DIFF
--- a/Sources/PowerSync/Implementation/ActiveInstanceStore.swift
+++ b/Sources/PowerSync/Implementation/ActiveInstanceStore.swift
@@ -44,9 +44,9 @@ private final class ActiveDatabaseGroupData: Sendable {
 /// Additionally, we want to avoid two databases in the same group having a sync stream open at the same time to avoid
 /// duplicate resources being used. For this reason, each active database group has a single sync coordinator actor
 /// responsible for initializing the sync process for all databases in the group.
-final class ActiveDatabaseGroup: Sendable {
+final class ActiveDatabaseGroup: @unchecked Sendable {
     fileprivate let data: ActiveDatabaseGroupData
-    private weak let collection: DatabaseGroupCollection?
+    private weak var collection: DatabaseGroupCollection?
 
     fileprivate init(data: ActiveDatabaseGroupData, collection: DatabaseGroupCollection) {
         self.data = data

--- a/Sources/PowerSync/Implementation/ActiveInstanceStore.swift
+++ b/Sources/PowerSync/Implementation/ActiveInstanceStore.swift
@@ -45,6 +45,7 @@ private final class ActiveDatabaseGroupData: Sendable {
 /// duplicate resources being used. For this reason, each active database group has a single sync coordinator actor
 /// responsible for initializing the sync process for all databases in the group.
 final class ActiveDatabaseGroup: @unchecked Sendable {
+// unchecked sendable because we need to use weak var (our minimum Swift version is 6.1, weak let was introduced in 6.3).
     fileprivate let data: ActiveDatabaseGroupData
     private weak var collection: DatabaseGroupCollection?
 


### PR DESCRIPTION
Fix: Correct weak var declaration and Sendable conformance in ActiveDatabaseGroup

Summary
This PR fixes two compiler issues in ActiveDatabaseGroup related to weak reference declarations and Sendable conformance.

Changes
weak let → weak var

weak references must be declared as var in Swift, since they are implicitly mutable — the runtime sets them to nil when the referenced object is deallocated. The previous weak let declaration was invalid Swift and would not compile.

Sendable → @unchecked Sendable

The compiler cannot automatically verify Sendable conformance on ActiveDatabaseGroup due to the presence of the weak var reference. Marking the class as @unchecked Sendable resolves the compiler error and is appropriate here given the existing design of the type.

⚠️ Note: @unchecked Sendable shifts thread-safety responsibility to the developer. Concurrent access patterns on ActiveDatabaseGroup should be reviewed to ensure this conformance is genuinely safe.