### PR TITLE
Update core extension

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9db274c1572fc7c0b025b8efb52d26fab5678f8b6a74357649956bff8e897d6c",
+  "originHash" : "89819e01bd6f8fca5a5d180a96cbf3ee5ed9f510168019ece84172dbb9f65ae6",
   "pins" : [
     {
       "identity" : "csqlite",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/powersync-ja/powersync-sqlite-core-swift.git",
       "state" : {
-        "revision" : "ce92ff4decc13767d4ab62e999d9cfea0dc13be0",
-        "version" : "0.5.1"
+        "revision" : "dba41dd6d408b5e221d364dc7032ade14c90d023",
+        "version" : "0.5.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ if let corePath = localCoreExtension {
     conditionalDependencies.append(
         .package(
             url: "https://github.com/powersync-ja/powersync-sqlite-core-swift.git",
-            exact: "0.5.1",
+            exact: "0.5.2",
         ))
 }
 

--- a/Sources/PowerSync/Protocol/PowerSyncDatabaseProtocol.swift
+++ b/Sources/PowerSync/Protocol/PowerSyncDatabaseProtocol.swift
@@ -172,7 +172,7 @@ public struct ConnectOptions: Sendable {
     )
     public init(
         crudThrottle: TimeInterval = 1,
-        retryDelay: TimeInterval = 5,
+        retryDelay: TimeInterval = Self.defaultRetryDelay,
         params: JsonParam = [:],
         newClientImplementation: Bool = true,
         clientConfiguration: SyncClientConfiguration? = nil,
@@ -190,6 +190,8 @@ public struct ConnectOptions: Sendable {
         self.checkpointMode = checkpointMode
     }
 
+    @usableFromInline
+    static let defaultRetryDelay: TimeInterval = 5
 }
 
 /// A PowerSync managed database.

--- a/Tests/PowerSyncTests/SyncTests.swift
+++ b/Tests/PowerSyncTests/SyncTests.swift
@@ -526,7 +526,7 @@ class InMemorySyncIntegrationTests {
             handleSyncLines: { _ in channel },
             checkpointRequestHook: checkpointRequests.handler()
         )
-        let retryDelay: TimeInterval = 1
+        let retryDelay: TimeInterval = 2
         // Scheduling jitter means the observed interval can land just under the configured delay.
         let retryDelayTolerance = retryDelay * 0.9
 

--- a/Tests/PowerSyncTests/SyncTests.swift
+++ b/Tests/PowerSyncTests/SyncTests.swift
@@ -526,7 +526,7 @@ class InMemorySyncIntegrationTests {
             handleSyncLines: { _ in channel },
             checkpointRequestHook: checkpointRequests.handler()
         )
-        let retryDelay: TimeInterval = 0.2
+        let retryDelay: TimeInterval = 1
         // Scheduling jitter means the observed interval can land just under the configured delay.
         let retryDelayTolerance = retryDelay * 0.9
 
@@ -538,7 +538,7 @@ class InMemorySyncIntegrationTests {
             await waitForStatus(db.currentStatus) { $0.connected }
 
             _ = try await db.requestCheckpoint()
-            try await sleepForSeconds(seconds: 0.03)
+            try await sleepForSeconds(seconds: 0.5)
             _ = try await db.requestCheckpoint()
 
             // The second request advances the current sequence to 3. Its first retry should
@@ -606,7 +606,7 @@ class InMemorySyncIntegrationTests {
             try await sleepForSeconds(seconds: 0.05)
             let start = Date()
             try await db.disconnect()
-            #expect(Date().timeIntervalSince(start) < 1)
+            #expect(Date().timeIntervalSince(start) < ConnectOptions.defaultRetryDelay)
         }
     }
 
@@ -2576,13 +2576,13 @@ func waitForStatus(_ status: SyncStatus, predicate: @Sendable (borrowing SyncSta
     let _ = await status.asFlow().first(where: predicate)
 }
 
-func waitUntil(attempts: Int = 100, _ predicate: @escaping @Sendable () -> Bool) async throws {
+func waitUntil(attempts: Int = 100, delay: TimeInterval = 0.05, _ predicate: @escaping @Sendable () -> Bool) async throws {
     for _ in 0..<attempts {
         if predicate() {
             return
         }
 
-        try await sleepForSeconds(seconds: 0.05)
+        try await sleepForSeconds(seconds: delay)
     }
 
     try #require(predicate())

--- a/Tests/PowerSyncTests/SyncTests.swift
+++ b/Tests/PowerSyncTests/SyncTests.swift
@@ -2576,13 +2576,13 @@ func waitForStatus(_ status: SyncStatus, predicate: @Sendable (borrowing SyncSta
     let _ = await status.asFlow().first(where: predicate)
 }
 
-func waitUntil(attempts: Int = 100, delay: TimeInterval = 0.05, _ predicate: @escaping @Sendable () -> Bool) async throws {
+func waitUntil(attempts: Int = 100, _ predicate: @escaping @Sendable () -> Bool) async throws {
     for _ in 0..<attempts {
         if predicate() {
             return
         }
 
-        try await sleepForSeconds(seconds: delay)
+        try await sleepForSeconds(seconds: 0.05)
     }
 
     try #require(predicate())


### PR DESCRIPTION
This updates the core extension to 0.5.2, fixing a memory leak when some functions like `powersync_control('target_checkpoint_request_id')` are called on a read-only connection. This is not an issue for the Swift SDK which only calls that in write transactions, but it's still good to stay up-to-date.

This also attempts to fix a few tests that regularly broke CI:

- `disconnectCancelsDefaultCheckpointRequestRetryDelay()` compared the delay to 1 second, which a slow CI runner can exceed. Increase to compare against the actual limit of 5 seconds.
- `checkpointRequestRetryWaitsAgainAfterNewRequest` used a short retry delay of .2 seconds, which also breaks in slow CI runners. Increase to 2s.