### PR TITLE
Fix concurrency issues around `close()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
   Backends that process uploads asynchronously can handle checkpoint requests themselves by
   implementing `CustomCheckpointRequestConnector` on their connector.
   These APIs are in alpha and may change in future releases.
+* Fix races around `PowerSyncDatabase.close()` crashing the process.
 
 ## 1.15.1
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "89819e01bd6f8fca5a5d180a96cbf3ee5ed9f510168019ece84172dbb9f65ae6",
+  "originHash" : "fbf9e96a3f709e253cd88e4be1fe05e3acbefdcbf7e4270db958841f93441d04",
   "pins" : [
     {
       "identity" : "csqlite",

--- a/Sources/PowerSync/Implementation/AsyncConnectionPool.swift
+++ b/Sources/PowerSync/Implementation/AsyncConnectionPool.swift
@@ -221,7 +221,6 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
 
     private actor PoolOpener {
         private var pool: NativeConnectionPool? = nil
-        private var isClosed = false
 
         func obtainPool(pool context: AsyncConnectionPool) async throws -> NativeConnectionPool {
             if let pool {
@@ -246,11 +245,6 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
         }
 
         func close() async throws {
-            if isClosed {
-                return
-            }
-
-            isClosed = true
             if let pool {
                 try await pool.close()
             }

--- a/Sources/PowerSync/Implementation/AsyncConnectionPool.swift
+++ b/Sources/PowerSync/Implementation/AsyncConnectionPool.swift
@@ -101,7 +101,7 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
     }
 
     private func configureConnection(connection: borrowing RawSqliteConnection, isWriter: Bool) throws {
-        let context = connection.asLease()
+        let context = try connection.asLease()
         for stmt in initialStatements {
             let _ = try context.execute(sql: stmt, parameters: [])
         }

--- a/Sources/PowerSync/Implementation/PowerSyncDatabaseImpl.swift
+++ b/Sources/PowerSync/Implementation/PowerSyncDatabaseImpl.swift
@@ -245,7 +245,7 @@ private actor DatabaseInitializationAction {
     
     func ensureInitialized(db: PowerSyncDatabaseImpl) async throws {
         if closed {
-            throw PowerSyncError.operationFailed(message: "Attempted to use closed PowerSync database")
+            throw PowerSyncError.databaseClosedError()
         }
         if isInitialized {
             return
@@ -270,8 +270,8 @@ private actor DatabaseInitializationAction {
     
     func close(action: () async throws -> ()) async rethrows {
         if !closed {
-            closed = true
             try await action()
+            closed = true
         }
     }
 }

--- a/Sources/PowerSync/Implementation/PowerSyncDatabaseImpl.swift
+++ b/Sources/PowerSync/Implementation/PowerSyncDatabaseImpl.swift
@@ -269,9 +269,16 @@ private actor DatabaseInitializationAction {
     }
     
     func close(action: () async throws -> ()) async rethrows {
-        if !closed {
+        if closed {
+            return
+        }
+
+        closed = true
+        do {
             try await action()
-            closed = true
+        } catch {
+            closed = false
+            throw error
         }
     }
 }

--- a/Sources/PowerSync/Implementation/sqlite3/NativeConnectionPool.swift
+++ b/Sources/PowerSync/Implementation/sqlite3/NativeConnectionPool.swift
@@ -56,13 +56,13 @@ final class NativeConnectionPool: Sendable {
         // No dedicated readers? Acquire write connection for this then
         let semaphore = readers ?? writer
         let connection = try await semaphore.acquire(count: 1)
-        let lease = connection.acquiredItems[0].asLease()
+        let lease = try connection.acquiredItems[0].asLease()
         return try await onConnection(lease)
     }
 
     func write<T>(onConnection: (NativeConnectionLease) async throws -> T) async throws -> T {
         let connection = try await writer.acquire(count: 1)
-        let lease = connection.acquiredItems[0].asLease()
+        let lease = try connection.acquiredItems[0].asLease()
         defer { dispatchWrites(lease: lease) }
         let result = try await onConnection(lease)
         return result
@@ -70,7 +70,7 @@ final class NativeConnectionPool: Sendable {
     
     func withAllConnections<T>(onConnection: (NativeConnectionLease, [NativeConnectionLease]) async throws -> T) async throws -> T {
         let write = try await writer.acquire(count: 1)
-        let writeLease = write.acquiredItems[0].asLease()
+        let writeLease = try write.acquiredItems[0].asLease()
         defer { dispatchWrites(lease: writeLease) }
 
         let result: T
@@ -80,7 +80,7 @@ final class NativeConnectionPool: Sendable {
             
             let span = acquiredReaders.acquiredItems.span
             for idx in span.indices {
-                readerLeases.append(span[idx].asLease())
+                readerLeases.append(try span[idx].asLease())
             }
             result = try await onConnection(writeLease, readerLeases)
         } else {
@@ -128,8 +128,11 @@ struct RawSqliteConnection: ~Copyable {
         sqlite3_close_v2(connection)
     }
     
-    func asLease() -> NativeConnectionLease {
-        precondition(!closed)
+    func asLease() throws(PowerSyncError) -> NativeConnectionLease {
+        if closed {
+            throw .databaseClosedError()
+        }
+
         return NativeConnectionLease(pointer: self.connection)
     }
 }

--- a/Sources/PowerSync/Protocol/PowerSyncError.swift
+++ b/Sources/PowerSync/Protocol/PowerSyncError.swift
@@ -49,4 +49,8 @@ public enum PowerSyncError: Error, LocalizedError {
             return msg
         }
     }
+
+    internal static func databaseClosedError() -> Self {
+        .operationFailed(message: "Attempted to use closed PowerSync database")
+    }
 }

--- a/Tests/PowerSyncTests/Implementation/ConcurrentOpenTests.swift
+++ b/Tests/PowerSyncTests/Implementation/ConcurrentOpenTests.swift
@@ -12,6 +12,9 @@ import Testing
 /// retry with backoff. Reproduced here in-process with a system-SQLite connection holding
 /// a reserved lock, which is byte-for-byte the same file-level contention two processes
 /// produce.
+/// 
+/// We run these tests without parallelization as they can block threads (while waiting for
+/// a busy lock), which interferes with other concurrent tests.
 @Suite("Concurrent open", .serialized)
 struct ConcurrentOpenTests {
     /// Sendable wrapper for the lock-holding SQLite connection used across tasks.

--- a/Tests/PowerSyncTests/Implementation/ConcurrentOpenTests.swift
+++ b/Tests/PowerSyncTests/Implementation/ConcurrentOpenTests.swift
@@ -12,7 +12,10 @@ import Testing
 /// retry with backoff. Reproduced here in-process with a system-SQLite connection holding
 /// a reserved lock, which is byte-for-byte the same file-level contention two processes
 /// produce.
-@Suite("Concurrent open")
+/// 
+/// We run these tests without parallelism since the retry timeout blocks a platform thread,
+/// affecting concurrency in other tests.
+@Suite("Concurrent open", .serialized, .timeLimit(.minutes(1)))
 struct ConcurrentOpenTests {
     /// Sendable wrapper for the lock-holding SQLite connection used across tasks.
     private final class LockHolder: @unchecked Sendable {
@@ -22,7 +25,6 @@ struct ConcurrentOpenTests {
     }
 
     @available(iOS 16, macOS 13, watchOS 9, tvOS 16, *)
-    @Test(.timeLimit(.minutes(1)))
     func openRetriesWhileAnotherConnectionHoldsTheDatabase() async throws {
         let path = FileManager.default.temporaryDirectory
             .appendingPathComponent("concurrent-open-\(UUID().uuidString).db").path
@@ -57,7 +59,6 @@ struct ConcurrentOpenTests {
     }
 
     @available(iOS 16, macOS 13, watchOS 9, tvOS 16, *)
-    @Test(.timeLimit(.minutes(1)))
     func openStillFailsWhenTheDatabaseNeverFreesUp() async throws {
         let path = FileManager.default.temporaryDirectory
             .appendingPathComponent("concurrent-open-stuck-\(UUID().uuidString).db").path
@@ -85,7 +86,6 @@ struct ConcurrentOpenTests {
     }
 
     @available(iOS 16, macOS 13, watchOS 9, tvOS 16, *)
-    @Test(.timeLimit(.minutes(1)))
     func openRetryIsCancellable() async throws {
         // The async retry awaits between attempts instead of blocking a thread, so a task
         // opening a database that is held by another connection can be cancelled promptly

--- a/Tests/PowerSyncTests/Implementation/ConcurrentOpenTests.swift
+++ b/Tests/PowerSyncTests/Implementation/ConcurrentOpenTests.swift
@@ -12,10 +12,7 @@ import Testing
 /// retry with backoff. Reproduced here in-process with a system-SQLite connection holding
 /// a reserved lock, which is byte-for-byte the same file-level contention two processes
 /// produce.
-/// 
-/// We run these tests without parallelism since the retry timeout blocks a platform thread,
-/// affecting concurrency in other tests.
-@Suite("Concurrent open", .serialized, .timeLimit(.minutes(1)))
+@Suite("Concurrent open", .serialized)
 struct ConcurrentOpenTests {
     /// Sendable wrapper for the lock-holding SQLite connection used across tasks.
     private final class LockHolder: @unchecked Sendable {
@@ -25,6 +22,7 @@ struct ConcurrentOpenTests {
     }
 
     @available(iOS 16, macOS 13, watchOS 9, tvOS 16, *)
+    @Test(.timeLimit(.minutes(1)))
     func openRetriesWhileAnotherConnectionHoldsTheDatabase() async throws {
         let path = FileManager.default.temporaryDirectory
             .appendingPathComponent("concurrent-open-\(UUID().uuidString).db").path
@@ -59,6 +57,7 @@ struct ConcurrentOpenTests {
     }
 
     @available(iOS 16, macOS 13, watchOS 9, tvOS 16, *)
+    @Test(.timeLimit(.minutes(1)))
     func openStillFailsWhenTheDatabaseNeverFreesUp() async throws {
         let path = FileManager.default.temporaryDirectory
             .appendingPathComponent("concurrent-open-stuck-\(UUID().uuidString).db").path
@@ -86,6 +85,7 @@ struct ConcurrentOpenTests {
     }
 
     @available(iOS 16, macOS 13, watchOS 9, tvOS 16, *)
+    @Test(.timeLimit(.minutes(1)))
     func openRetryIsCancellable() async throws {
         // The async retry awaits between attempts instead of blocking a thread, so a task
         // opening a database that is held by another connection can be cancelled promptly

--- a/Tests/PowerSyncTests/Implementation/DatabaseImplementationTests.swift
+++ b/Tests/PowerSyncTests/Implementation/DatabaseImplementationTests.swift
@@ -42,4 +42,24 @@ struct DatabaseImplementationTests {
         try #require(results == [2, 4, 6])
         try await db.close()
     }
+
+    @Test func canCancelClose() async throws {
+        let db = PowerSyncDatabase(
+            schema: Schema(),
+            dbFilename: "cancel-close-test",
+            logger: DefaultLogger()
+        )
+
+        let result = try await db.readLock { reader in
+            // Try to close the database, this can't work because of the busy read connection.
+            let task = Task { try await db.close() };
+            task.cancel();
+            return task
+        }.result
+        #expect(throws: CancellationError.self) { try result.get() }
+
+        // Verify that the database is not in a half-closed state by updating the schema, which runs statements
+        // on all connections.
+        try await db.updateSchema(schema: Schema(Table(name: "users", columns: [.text("name")])))
+    }
 }

--- a/Tests/PowerSyncTests/Implementation/DatabaseImplementationTests.swift
+++ b/Tests/PowerSyncTests/Implementation/DatabaseImplementationTests.swift
@@ -62,4 +62,48 @@ struct DatabaseImplementationTests {
         // on all connections.
         try await db.updateSchema(schema: Schema(Table(name: "users", columns: [.text("name")])))
     }
+
+    @Test func canCloseAfterCancellingClose() async throws {
+        let pool = AsyncConnectionPool(
+            location: .inMemory,
+            logger: DefaultLogger()
+        )
+        let db = OpenedPowerSyncDatabase(
+            schema: Schema(),
+            pool: pool,
+            identifier: "cancel-then-close-test"
+        )
+
+        let (readerAcquired, signalReaderAcquired) = AsyncStream<Void>.makeStream()
+        let releaseReader = DispatchSemaphore(value: 0)
+        let reader = Task {
+            try await db.readLock { _ in
+                signalReaderAcquired.yield()
+                releaseReader.wait()
+            }
+        }
+
+        // Wait until the callback has leased a reader, then initiate close independently.
+        var readerAcquiredIterator = readerAcquired.makeAsyncIterator()
+        _ = await readerAcquiredIterator.next()
+        let cancelledClose = Task { try await db.close() }
+        cancelledClose.cancel()
+        await #expect(throws: CancellationError.self) {
+            try await cancelledClose.value
+        }
+        releaseReader.signal()
+        try await reader.value
+
+        // Retrying close must still reach and close the underlying connection pool.
+        try await db.close()
+
+        // We inspect the pool directly because the database's initialization actor now considers
+        // the database closed and would reject public operations before they reach the pool. A
+        // successful retry closes every RawSqliteConnection, so acquiring a lease must throw. If
+        // this succeeds, PoolOpener kept isClosed = true after the cancelled attempt and treated
+        // the retry as a no-op, leaving the native connections open.
+        await #expect(throws: PowerSyncError.self) {
+            try await pool.read { _ in () }
+        }
+    }
 }

--- a/Tests/PowerSyncTests/Implementation/StatementTests.swift
+++ b/Tests/PowerSyncTests/Implementation/StatementTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct StatementTests {
     @Test func bindValues() throws {
         let connection = try DatabaseLocation.inMemory.openConnection(writer: true)
-        let lease = connection.asLease()
+        let lease = try connection.asLease()
         try lease.withIterator(
             sql: "SELECT ?, ?, ?, ?, ?, ?, typeof(?), typeof(?)",
             parameters: [


### PR DESCRIPTION
This fixes two issues reported in https://github.com/powersync-ja/powersync-swift/issues/172.

### Crashes on race between `close()` and other operations

Emitting a closed SQLite connection as a connection lease crashes the process (as a `precondition`). This is better than the use-after-free it would have been otherwise, but it shouldn't be possible to reach that state. Unfortunately, it can happen when:

1. We call `close()`.
2. Another task runs an operation on the database. Because `close()` did not complete yet, `DatabaseInitializationAction.ensureInitialized()` works and the operation can continue. It waits for a connection, though.
3. The original task closes connections and returns, returning closed connections into the async semaphore.
4. The second task now obtains the closed connection, crashing.

The fix is what we do on most other SDKs too: Check for closed connections _after_ we've obtained their handle from an async semaphore.

### Cancelling `close()`

When a call to `close()` is cancelled before it actually closes connections, it would previously leave the database in a state where everything throws even though connections are still open.

This fixes the issue by only marking the database as closed when connections are actually closed. There's still a race condition here where while a database is being closed, queries would throw but if the throw is cancelled the database keeps working afterwards. I think that should be harmless overall, though.

AI use: Original issue report is likely generated by AI. Changes are manual, with minor revisions after a review with Claude Code.