### PR TITLE
Prepare 1.16.0 release

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -2,7 +2,7 @@ name: Build and test
 
 on:
   push:
-  workflow_call:
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -13,6 +13,7 @@ jobs:
   build:
     name: Build and test
     runs-on: macos-latest
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,6 +2,7 @@ name: Deploy Docs
 
 on:
   push:
+  pull_request:
 
 permissions: {}
 
@@ -12,6 +13,7 @@ jobs:
   build:
     name: Build
     runs-on: macos-latest
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
     steps:
       - uses: actions/checkout@v7
         with:
@@ -51,7 +53,7 @@ jobs:
 
   # Deployment job
   deploy:
-    if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     environment:
       name: github-pages
       url: ${{ needs.build.outputs.page_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.16.0
 
 * Sync status timestamps (`PriorityStatusEntry.lastSyncedAt`, `SyncSubscriptionDescription.lastSyncedAt`,
   and `SyncSubscriptionDescription.expiresAt`) now have microsecond resolution.

--- a/Sources/PowerSync/CurrentVersion.swift
+++ b/Sources/PowerSync/CurrentVersion.swift
@@ -1,2 +1,2 @@
 // The current version of the PowerSync Swift SDK. This should be updated to the latest version in `CHANGELOG.md` when a new version is released.
-let libraryVersion = "1.15.1"
+let libraryVersion = "1.16.0"


### PR DESCRIPTION
This updates the changelog and current version number to prepare the 1.16.0 release. I've also changed actions definitions to run our suite of checks for community PRs (previously, `build_and_test.yaml` only ran for pushes to this repository).