### PR TITLE
Apply subscription changes made while the sync stream is being established

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,8 @@
 
 ## Unreleased
 
-* Fix sync stream subscriptions changed while a connection was being established (after
-  `connect()` returned and before the first `/sync/stream` response arrived) taking effect only
-  on the next keep-alive line from the service, typically 20 seconds later. The change
-  notification was dispatched before the sync iteration started listening for local events, so
-  it was dropped and the core extension never learned about it until its periodic check.
+* Fix sync stream subscriptions changed while the connection was still being established only
+  taking effect on the next keep-alive line from the service, typically 20 seconds later.
 
 ## 1.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+* Fix sync stream subscriptions changed while a connection was being established (after
+  `connect()` returned and before the first `/sync/stream` response arrived) taking effect only
+  on the next keep-alive line from the service, typically 20 seconds later. The change
+  notification was dispatched before the sync iteration started listening for local events, so
+  it was dropped and the core extension never learned about it until its periodic check.
+
 ## 1.16.1
 
 * Fix a re-query storm on databases opened at an absolute path (App Group container). The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.16.2
 
 * Fix sync stream subscriptions changed while the connection was still being established only
   taking effect on the next keep-alive line from the service, typically 20 seconds later.

--- a/Sources/PowerSync/CurrentVersion.swift
+++ b/Sources/PowerSync/CurrentVersion.swift
@@ -1,2 +1,2 @@
 // The current version of the PowerSync Swift SDK. This should be updated to the latest version in `CHANGELOG.md` when a new version is released.
-let libraryVersion = "1.16.1"
+let libraryVersion = "1.16.2"

--- a/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
+++ b/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
@@ -514,13 +514,10 @@ private struct ActiveSyncIteration: Sendable {
             signals.markPendingCheckpointRequestsRequiringAffirmation()
         }
 
-        // Listen for local events BEFORE the watchers below start dispatching them. The stream
-        // buffers whatever is dispatched until the control loop consumes it, so a subscription
-        // change or a completed upload that lands while the request is still being established
-        // takes effect as soon as the response arrives. Subscribing only after `fetchSyncLines`
-        // returned left those events without a listener (`BroadcastStream.dispatch` drops them),
-        // and the core extension then only noticed the change on the next keep-alive line,
-        // typically 20 seconds later.
+        // Subscribe to local events before the watchers below start dispatching them: `BroadcastStream`
+        // only delivers to listeners that already exist, and the subscription buffers everything until
+        // the control loop drains it once the sync stream is established. Otherwise a subscription
+        // change made while the request is in flight is only picked up on the next keep-alive line.
         let pendingLocalEvents = localEvents.subscribe()
 
         // Notify the core extension for changed Sync Stream subscriptions, as we might have to reconnect.

--- a/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
+++ b/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
@@ -514,10 +514,6 @@ private struct ActiveSyncIteration: Sendable {
             signals.markPendingCheckpointRequestsRequiringAffirmation()
         }
 
-        // Subscribe to local events before the watchers below start dispatching them: `BroadcastStream`
-        // only delivers to listeners that already exist, and the subscription buffers everything until
-        // the control loop drains it once the sync stream is established. Otherwise a subscription
-        // change made while the request is in flight is only picked up on the next keep-alive line.
         let pendingLocalEvents = localEvents.subscribe()
 
         // Notify the core extension for changed Sync Stream subscriptions, as we might have to reconnect.

--- a/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
+++ b/Sources/PowerSync/Implementation/sync/StreamingSyncClient.swift
@@ -514,6 +514,15 @@ private struct ActiveSyncIteration: Sendable {
             signals.markPendingCheckpointRequestsRequiringAffirmation()
         }
 
+        // Listen for local events BEFORE the watchers below start dispatching them. The stream
+        // buffers whatever is dispatched until the control loop consumes it, so a subscription
+        // change or a completed upload that lands while the request is still being established
+        // takes effect as soon as the response arrives. Subscribing only after `fetchSyncLines`
+        // returned left those events without a listener (`BroadcastStream.dispatch` drops them),
+        // and the core extension then only noticed the change on the next keep-alive line,
+        // typically 20 seconds later.
+        let pendingLocalEvents = localEvents.subscribe()
+
         // Notify the core extension for changed Sync Stream subscriptions, as we might have to reconnect.
         let (currentStreams, streamChanges) = syncClient.db.group.syncCoordinator.streams.observeActiveStreams()
         async let _ = watchSyncStreams(changes: streamChanges)
@@ -557,7 +566,7 @@ private struct ActiveSyncIteration: Sendable {
                     controlArgs = AsyncAlgorithms.merge(
                         serviceEvents,
                         checkpointRequestStateValidationEvents(task: checkpointRequestStateSeed),
-                        localEvents.subscribe()
+                        pendingLocalEvents
                     )
                 } catch {
                     let streamError = error

--- a/Tests/PowerSyncTests/SyncTests.swift
+++ b/Tests/PowerSyncTests/SyncTests.swift
@@ -2193,11 +2193,9 @@ class InMemorySyncIntegrationTests {
     }
 
     @Test func subscriptionAddedWhileConnectingReconnects() async throws {
-        // A subscription added after `connect()` returned but before the first `/sync/stream`
-        // response arrived used to be applied only on the next keep-alive line from the service,
-        // typically 20 seconds later: the change was dispatched before the sync iteration was
-        // listening for local events. Nothing here sends a keep-alive, so the reconnect has to
-        // come from the subscription change itself.
+        // Regression test: a subscription added after `connect()` returned but before the first
+        // `/sync/stream` response arrived must trigger a reconnect on its own. Nothing here sends a
+        // keep-alive, so the second request can only come from the subscription change.
         let firstRequestStarted = Signal()
         let releaseFirstResponse = Signal()
         let requests = AsyncMutex<[JsonParam]>([])
@@ -2214,7 +2212,9 @@ class InMemorySyncIntegrationTests {
             return AsyncThrowingChannel<Data, any Error>()
         })
 
-        try await db.connect(connector: TestConnector(), options: ConnectOptions())
+        // A short retry delay keeps the 5 s polling budget below independent of how the reconnect
+        // is scheduled.
+        try await db.connect(connector: TestConnector(), options: ConnectOptions(retryDelay: 0.1))
         await firstRequestStarted.await()
 
         // The first request is in flight and its response has not arrived yet.

--- a/Tests/PowerSyncTests/SyncTests.swift
+++ b/Tests/PowerSyncTests/SyncTests.swift
@@ -2212,9 +2212,7 @@ class InMemorySyncIntegrationTests {
             return AsyncThrowingChannel<Data, any Error>()
         })
 
-        // A short retry delay keeps the 5 s polling budget below independent of how the reconnect
-        // is scheduled.
-        try await db.connect(connector: TestConnector(), options: ConnectOptions(retryDelay: 0.1))
+        try await db.connect(connector: TestConnector(), options: ConnectOptions())
         await firstRequestStarted.await()
 
         // The first request is in flight and its response has not arrived yet.

--- a/Tests/PowerSyncTests/SyncTests.swift
+++ b/Tests/PowerSyncTests/SyncTests.swift
@@ -2192,6 +2192,57 @@ class InMemorySyncIntegrationTests {
         try await db.close()
     }
 
+    @Test func subscriptionAddedWhileConnectingReconnects() async throws {
+        // A subscription added after `connect()` returned but before the first `/sync/stream`
+        // response arrived used to be applied only on the next keep-alive line from the service,
+        // typically 20 seconds later: the change was dispatched before the sync iteration was
+        // listening for local events. Nothing here sends a keep-alive, so the reconnect has to
+        // come from the subscription change itself.
+        let firstRequestStarted = Signal()
+        let releaseFirstResponse = Signal()
+        let requests = AsyncMutex<[JsonParam]>([])
+        let db = openDatabase(MockHttpSession { request in
+            let body = try StreamingSyncClient.jsonDecoder.decode(JsonParam.self, from: try #require(request.httpBody))
+            let count = await requests.withMutex { requests in
+                requests.append(body)
+                return requests.count
+            }
+            if count == 1 {
+                await firstRequestStarted.complete()
+                await releaseFirstResponse.await()
+            }
+            return AsyncThrowingChannel<Data, any Error>()
+        })
+
+        try await db.connect(connector: TestConnector(), options: ConnectOptions())
+        await firstRequestStarted.await()
+
+        // The first request is in flight and its response has not arrived yet.
+        let subscription = try await db.syncStream(name: "a", params: nil).subscribe()
+        await releaseFirstResponse.complete()
+
+        try await waitUntilAsync { await requests.inner.count == 2 }
+        let allRequests = await requests.inner
+        if case let .object(streams) = allRequests[0]["streams"] {
+            try #require(streams["subscriptions"] == .array([]))
+        } else {
+            Issue.record("Should have streams key in first body")
+        }
+        if case let .object(streams) = allRequests[1]["streams"] {
+            try #require(streams["subscriptions"] == .array([
+                .object([
+                    "stream": .string("a"),
+                    "parameters": .null,
+                    "override_priority": .null,
+                ])
+            ]))
+        } else {
+            Issue.record("Should have streams key in second body")
+        }
+        let _ = consume subscription
+        try await db.close()
+    }
+
     @Test func subscriptionsUpdateWhileOffline() async throws {
         let db = openDatabase(MockHttpSession {
             request in throw PowerSyncError.operationFailed(message: "Unexpected connection", underlyingError: nil)


### PR DESCRIPTION
Fixes #157

## Problem

A sync stream subscription added after `connect()` returned but before the first `/sync/stream` response arrived only took effect on the next keep-alive line from the service, typically 20 seconds later. With `includeDefaultStreams: false` and a fresh database, the common "connect, then subscribe" pattern hits this on every first launch: the first request goes out with no subscriptions at all, the service answers with an empty checkpoint (`buckets: 0`), and nothing is delivered until the keep-alive triggers the periodic subscription check in the core.

This is the same stall @elcode100 describes in #157, and the mechanism @simolus3 pointed at there: the `DidUpdateSubscriptions` notification that should have caused an immediate reconnect never reached the core.

## Cause

In `SyncIteration.run()`, `watchSyncStreams` and `watchCompletedCrudUploads` start before the request goes out, but the merge only subscribed to `localEvents` after `fetchSyncLines` returned. `BroadcastStream.dispatch` drops events that have no listener, so an `updateSubscriptions` raised in that window (a few milliseconds locally, up to the full round trip on a slow link) was lost.

## Fix

Subscribe to `localEvents` before the watchers start. The `AsyncStream` is unbounded, so anything dispatched while the request is in flight is buffered and consumed as soon as the control loop starts; the core then compares the current subscriptions against the in-flight request and reconnects right away, exactly as it already does once connected. No changes to the core extension or the protocol.

## Test

`subscriptionAddedWhileConnectingReconnects` holds the first mock response open, subscribes in that window, and requires a second `/sync/stream` request carrying the subscription without ever sending a keep-alive. It fails on 1.16.1 (times out after 5 s) and passes with the change in about 70 ms. The full package suite passes.

## Verified against a real service

PowerSync service 1.24.0 (self-hosted), iOS app, fresh anonymous account, subscribing four streams right after `connect()`:

- Before: first stream opened with `buckets: 0` and stayed idle for 19.93 s; the service logged `Sync stream complete` right after the keep-alive, then a second stream with `buckets: 16` delivered the data.
- After: first stream still opens with `buckets: 0`, `Sync stream complete` after 70 ms, second stream with `buckets: 16` 300 ms later. First row visible to the app 0.59 s after sign-in instead of 20 s.