### PR TITLE
Fix MergeItemSequence shutdown deadlock

### DIFF
--- a/Sources/PowerSync/Implementation/AsyncConnectionPool.swift
+++ b/Sources/PowerSync/Implementation/AsyncConnectionPool.swift
@@ -338,9 +338,14 @@ final class AsyncConnectionPool: SQLiteConnectionPoolProtocol {
         // Only stop update notifications after the async close, since that can be cancelled.
         try await self.opener.close()
         updateLog?.signal.stop()
-        updateLogReader.withLock { reader in
-            reader?.cancel()
+        let reader = updateLogReader.withLock { reader in
+            let task = reader
             reader = nil
+            return task
+        }
+        reader?.cancel()
+        if let reader {
+            await reader.value
         }
     }
 

--- a/Sources/PowerSync/Utils/MergeItemSequence.swift
+++ b/Sources/PowerSync/Utils/MergeItemSequence.swift
@@ -31,12 +31,15 @@ struct MergeItemSequence<Base: AsyncSequence & Sendable>: AsyncSequence where Ba
             self.pollTask = Task {
                 do {
                     for try await _ in inner {
-                        state.inner.withLock { $0.markHasEvent() }
+                        let resolution = state.inner.withLock { $0.markHasEvent() }
+                        resolution.resume()
                     }
 
-                    state.inner.withLock { $0.transitionToDone() }
+                    let resolution = state.inner.withLock { $0.transitionToDone() }
+                    resolution.resume()
                 } catch {
-                    state.inner.withLock { $0.markFailed(error: error) }
+                    let resolution = state.inner.withLock { $0.markFailed(error: error) }
+                    resolution.resume()
                 }
             }
 
@@ -47,23 +50,37 @@ struct MergeItemSequence<Base: AsyncSequence & Sendable>: AsyncSequence where Ba
             try await withTaskCancellationHandler(
                 operation: {
                     try await withCheckedThrowingContinuation { continuation in
-                        state.inner.withLock { $0.registerListener(continuation) }
+                        let resolution = state.inner.withLock { $0.registerListener(continuation) }
+                        resolution.resume()
                     }
                 },
                 onCancel: {
                     pollTask.cancel()
-                    state.inner.withLock {
-                        if case .waitingForUpstream(let continuation) = $0 {
-                            continuation.resume(returning: nil)
-                        }
-                        $0 = .done
-                    }
+                    let resolution = state.inner.withLock { $0.cancel() }
+                    resolution.resume()
                 }
             )
         }
         
         deinit {
             self.pollTask.cancel()
+        }
+    }
+}
+
+private enum MergeSequenceResolution {
+    case none
+    case success(CheckedContinuation<()?, any Error>, ()?)
+    case failure(CheckedContinuation<()?, any Error>, any Error)
+
+    func resume() {
+        switch self {
+        case .none:
+            break
+        case let .success(continuation, value):
+            continuation.resume(returning: value)
+        case let .failure(continuation, error):
+            continuation.resume(throwing: error)
         }
     }
 }
@@ -86,45 +103,65 @@ private enum MergeSequenceState {
     case failure(any Error)
     case done
     
-    mutating func registerListener(_ continuation: CheckedContinuation<()?, any Error>) {
+    mutating func registerListener(_ continuation: CheckedContinuation<()?, any Error>) -> MergeSequenceResolution {
         switch self {
         case .idle:
             self = .waitingForUpstream(continuation)
+            return .none
         case .waitingForUpstream(_):
             fatalError("Async throttle sequence has two concurrent listeners?!")
         case .hasPendingEvent:
-            continuation.resume(returning: ())
             self = .idle
+            return .success(continuation, ())
         case .failure(let error):
-            continuation.resume(throwing: error)
             self = .done
+            return .failure(continuation, error)
         case .done:
-            continuation.resume(returning: nil)
+            return .success(continuation, nil)
         }
     }
 
-    mutating func markHasEvent() {
-        if case let .waitingForUpstream(continuation) = self {
-            continuation.resume(returning: ())
+    mutating func markHasEvent() -> MergeSequenceResolution {
+        switch self {
+        case let .waitingForUpstream(continuation):
             self = .idle
-        } else {
+            return .success(continuation, ())
+        case .idle, .hasPendingEvent:
             self = .hasPendingEvent
+            return .none
+        case .failure, .done:
+            return .none
         }
     }
 
-    mutating func markFailed(error: any Error) {
-        if case let .waitingForUpstream(continuation) = self {
-            continuation.resume(throwing: error)
+    mutating func markFailed(error: any Error) -> MergeSequenceResolution {
+        switch self {
+        case let .waitingForUpstream(continuation):
             self = .done
-        } else {
+            return .failure(continuation, error)
+        case .idle, .hasPendingEvent, .failure:
             self = .failure(error)
+            return .none
+        case .done:
+            return .none
         }
     }
 
-    mutating func transitionToDone() {
+    mutating func transitionToDone() -> MergeSequenceResolution {
         if case let .waitingForUpstream(continuation) = self {
-            continuation.resume(returning: nil)
+            self = .done
+            return .success(continuation, nil)
         }
         self = .done
+        return .none
+    }
+
+    mutating func cancel() -> MergeSequenceResolution {
+        if case let .waitingForUpstream(continuation) = self {
+            self = .done
+            return .success(continuation, nil)
+        }
+        self = .done
+        return .none
     }
 }

--- a/Tests/PowerSyncTests/Implementation/AbsolutePathTests.swift
+++ b/Tests/PowerSyncTests/Implementation/AbsolutePathTests.swift
@@ -36,4 +36,36 @@ struct AbsolutePathTests {
 
         try? FileManager.default.removeItem(at: directory)
     }
+
+    @Test func repeatedAbsolutePathCloseStopsUpdateReaders() async throws {
+        let schema = Schema(tables: [
+            Table(name: "items", columns: [.text("name")]),
+        ])
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("powersync-absolute-close-\(UUID().uuidString)")
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            for lane in 0..<4 {
+                group.addTask {
+                    for iteration in 0..<50 {
+                        let path = directory
+                            .appendingPathComponent("\(lane)-\(iteration).db")
+                            .path
+                        let database = PowerSyncDatabase(
+                            schema: schema,
+                            dbFilename: path,
+                            logger: DefaultLogger()
+                        )
+                        _ = try await database.get(sql: "SELECT 1", parameters: nil) { row in
+                            try row.getInt(index: 0)
+                        }
+                        try await database.close(deleteDatabase: true)
+                    }
+                }
+            }
+            try await group.waitForAll()
+        }
+
+        try? FileManager.default.removeItem(at: directory)
+    }
 }

--- a/Tests/PowerSyncTests/Utils/MergeItemSequence.swift
+++ b/Tests/PowerSyncTests/Utils/MergeItemSequence.swift
@@ -73,4 +73,21 @@ struct MergeItemSequenceTest {
 
         try await task.value
     }
+
+    @Test func cancellationCanRaceWithUpstreamFinish() async throws {
+        for _ in 0..<1_000 {
+            let source = AsyncThrowingChannel<(), any Error>()
+            let items = MergeItemSequence(inner: source).makeAsyncIterator()
+            let next = Task { try await items.next() }
+
+            await Task.yield()
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask { source.finish() }
+                group.addTask { next.cancel() }
+            }
+
+            _ = try? await next.value
+            try? await items.pollTask.value
+        }
+    }
 }


### PR DESCRIPTION
Summary

- Transfer MergeItemSequence continuation ownership while holding the state mutex, then resume only after unlocking.
- Keep the terminal state sticky across cancellation and upstream completion races.
- Cancel and await the detached cross-process update-log reader after a successful native pool close.

The 1.16.1 implementation can deadlock when close cancels the update-log reader while its poll task finishes and resumes the same waiting task under the mutex. This was reproduced as a hung absolute-path PowerSync database close.

Tests

- 1,000 cancellation-versus-upstream-finish races.
- 200 concurrent absolute-path open and close cycles.
- Full package suite: 112 tests passed.